### PR TITLE
TRADE-21: remove list columns.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ rsconnect/
 .DS_Store
 /doc/
 /Meta/
+
+# Claude Code local state (worktrees from parallel subagents, etc.)
+.claude/

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
 * Fixed `KucoinLending$get_loan_market()` — KuCoin now requires authentication for `/api/v3/project/list`. Removed erroneous `auth = FALSE`.
 * Removed usage of `%||%` operator which was not defined or imported; replaced with explicit `if (is.null(...))` checks.
 * Fixed `URLencode()` in request signing to coerce query values to character before encoding, preventing errors on numeric parameters.
+* `KucoinMarginTrading$repay()` now coerces the response `timestamp` to `POSIXct` instead of leaving it as a raw millisecond `numeric`, matching the rest of the package's timestamp behaviour.
+* `KucoinMarginData$get_margin_config()` now returns a schema-stable zero-row `data.table` when `currencyList` is empty or `data` is `NULL`, rather than indexing into an empty row.
 
 ## IMPROVEMENTS
 
@@ -54,6 +56,7 @@
     - `KucoinLending$get_purchase_orders()` / `get_redeem_orders()`: `status` is **required** in the query list.
     - `KucoinLending$get_loan_market()`: now documented as authenticated.
 * Corrected `wrap_list_fields` / `as_dt_row` documentation to accurately describe `length >= 1` wrapping behavior.
+* Expanded `@return` blocks across `KucoinMarginData`, `KucoinMarginTrading`, and `KucoinLending`: every public method now spells out its columns and their R types, the per-method row entity, and how the empty case is shaped — matching the binance/alpaca data-shape vignette.
 * Updated `kucoin_btc_usdt_4h_ohlcv` dataset documentation to reflect 18,351 rows through March 2026.
 * Two new vignettes: "Margin Trading" and "Futures Trading".
 * Updated ROADMAP to v4.0.0 with Futures classes added to completed items.
@@ -66,6 +69,7 @@
 * New mocked test suites: `test-KucoinMarginTrading.R`, `test-KucoinMarginData.R`, `test-KucoinLending.R`, `test-KucoinFuturesMarketData.R`, `test-KucoinFuturesTrading.R`, `test-KucoinFuturesAccount.R`, `test-bug-hunt.R`, `test-fetch-all.R`.
 * All live tests use `Sys.sleep(0.5)` rate limiting between calls.
 * Write tests use only the `/orders/test` dry-run endpoint — no real orders placed.
+* Added data-shape regression tests on `KucoinMarginData`, `KucoinMarginTrading`, and `KucoinLending`: each public method asserts there are no list columns, the column types match the documented `@return` block, and the empty-response path yields a zero-row `data.table` rather than a stub row.
 
 ## DATA
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
     - `datetime_applied` → `apply_time` (`KucoinLending`)
     - `datetime` → `time` (ticker, trade history, orderbook, 24hr stats)
 * **Kline parameter renamed**: `freq` → `timeframe` in `kucoin_backfill_klines()` and related functions.
+* **`KucoinMarketData$get_klines()` default window changed**: with `from = NULL`/`to = NULL` the method now returns the most recent candles for the requested timeframe rather than the previous "last 24 hours" window. Pass explicit `from`/`to` to restore deterministic ranges.
 * **`KucoinDeposit$get_deposit_addresses()`**: `currency` is now a required argument (removed `NULL` default) to match KuCoin API requirement.
 
 ## BUG FIXES

--- a/R/KucoinAccount.R
+++ b/R/KucoinAccount.R
@@ -570,7 +570,10 @@ KucoinAccount <- R6::R6Class(
         endpoint = "/api/v3/margin/accounts",
         query = query,
         .parser = function(data) {
-          accounts <- data$accounts %||% data
+          accounts <- data
+          if (!is.null(data$accounts)) {
+            accounts <- data$accounts
+          }
           if (is.null(accounts) || length(accounts) == 0) {
             return(data.table::data.table()[])
           }
@@ -682,7 +685,10 @@ KucoinAccount <- R6::R6Class(
         endpoint = "/api/v3/isolated/accounts",
         query = query,
         .parser = function(data) {
-          assets <- data$assets %||% data
+          assets <- data
+          if (!is.null(data$assets)) {
+            assets <- data$assets
+          }
           if (is.null(assets) || length(assets) == 0) {
             return(data.table::data.table()[])
           }
@@ -965,7 +971,10 @@ KucoinAccount <- R6::R6Class(
           endAt = endAt
         ),
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }

--- a/R/KucoinAccount.R
+++ b/R/KucoinAccount.R
@@ -130,7 +130,7 @@ KucoinAccount <- R6::R6Class(
     #' }
     #' ```
     #'
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row and columns:
     #' - `level` (integer): VIP tier.
     #' - `sub_quantity` (integer): Total sub-accounts.
     #' - `max_default_sub_quantity` (integer): Max default sub-accounts.
@@ -208,13 +208,15 @@ KucoinAccount <- R6::R6Class(
     #' }
     #' ```
     #'
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row and columns:
     #' - `remark` (character): Key label.
     #' - `api_key` (character): API key ID.
     #' - `api_version` (integer): Key version.
     #' - `permission` (character): Comma-separated permissions e.g. `"General,Spot"`.
-    #' - `ip_whitelist` (character): Allowed IPs.
-    #' - `created_at` (numeric): Epoch ms.
+    #'   Already a single string from KuCoin (not a JSON array); recover the
+    #'   vector with `strsplit(dt$permission[1], ",", fixed = TRUE)[[1]]`.
+    #' - `ip_whitelist` (character): Allowed IPs (comma-separated string).
+    #' - `created_at` (POSIXct): Key creation datetime (coerced from epoch milliseconds).
     #' - `uid` (numeric): User ID.
     #' - `is_master` (logical): TRUE if master account key.
     #'
@@ -229,7 +231,11 @@ KucoinAccount <- R6::R6Class(
     get_apikey_info = function() {
       return(private$.request(
         endpoint = "/api/v1/user/api-key",
-        .parser = as_dt_row
+        .parser = function(data) {
+          dt <- as_dt_row(data)
+          coerce_cols(dt, "created_at", ms_to_datetime)
+          return(dt[])
+        }
       ))
     },
 
@@ -543,17 +549,25 @@ KucoinAccount <- R6::R6Class(
     #'   - `quoteCurrency` (character): Quote currency for valuation e.g. `"USDT"`, `"BTC"`.
     #'   - `queryType` (character): Query type e.g. `"MARGIN"`, `"MARGIN_V2"`.
     #'
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
-    #' - `currency` (character): Currency code.
-    #' - `total` (character): Total balance.
-    #' - `available` (character): Available balance.
-    #' - `hold` (character): Amount on hold.
-    #' - `liability` (character): Total liability.
-    #' - `liability_principal` (character): Liability principal.
-    #' - `liability_interest` (character): Liability interest.
-    #' - `max_borrow_size` (character): Maximum borrowable amount.
-    #' - `borrow_enabled` (logical): Whether borrowing is enabled.
-    #' - `transfer_in_enabled` (logical): Whether transfer-in is enabled.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with
+    #'   one row per currency (Treatment B). The account-level summary fields
+    #'   (`total_asset_of_quote_currency`, `total_liability_of_quote_currency`, `debt_ratio`,
+    #'   `status`) are replicated on every row so the caller never needs a sibling method.
+    #'   Columns (subset; the exact set depends on the KuCoin payload):
+    #'   - `currency` (character): Currency code (e.g. `"USDT"`, `"BTC"`).
+    #'   - `total` (character): Total balance.
+    #'   - `available` (character): Available balance.
+    #'   - `hold` (character): Amount on hold.
+    #'   - `liability` (character): Total liability.
+    #'   - `liability_principal` (character): Liability principal.
+    #'   - `liability_interest` (character): Liability interest.
+    #'   - `max_borrow_size` (character): Maximum borrowable amount.
+    #'   - `borrow_enabled` (logical): Whether borrowing is enabled.
+    #'   - `transfer_in_enabled` (logical): Whether transfer-in is enabled.
+    #'   - `total_asset_of_quote_currency` (character): Account-level total asset (repeated).
+    #'   - `total_liability_of_quote_currency` (character): Account-level total liability (repeated).
+    #'   - `debt_ratio` (character): Account-level debt ratio (repeated).
+    #'   - `status` (character): Account-level status (repeated).
     #'
     #'   Returns an empty `data.table` if no margin accounts exist.
     #'
@@ -570,14 +584,33 @@ KucoinAccount <- R6::R6Class(
         endpoint = "/api/v3/margin/accounts",
         query = query,
         .parser = function(data) {
-          accounts <- data
+          accounts <- NULL
           if (!is.null(data$accounts)) {
             accounts <- data$accounts
           }
-          if (is.null(accounts) || length(accounts) == 0) {
+          if (is.null(accounts) || length(accounts) == 0L) {
             return(data.table::data.table()[])
           }
-          return(data.table::rbindlist(lapply(accounts, as_dt_row), fill = TRUE)[])
+
+          child_dt <- as_dt_list(accounts)
+          if (nrow(child_dt) == 0L) {
+            return(data.table::data.table()[])
+          }
+
+          # Account-level summary fields replicated on each per-currency row
+          # (Treatment B with replicated parent). The spec prefers replication
+          # over Treatment D here because the parent fields are small scalars
+          # and the caller would otherwise need to refetch the same endpoint.
+          parent <- data
+          parent$accounts <- NULL
+          parent_dt <- as_dt_row(parent)
+          if (nrow(parent_dt) > 0L) {
+            parent_dt <- parent_dt[rep(1L, nrow(child_dt))]
+            dt <- cbind(child_dt, parent_dt)
+          } else {
+            dt <- child_dt
+          }
+          return(dt[])
         }
       ))
     },
@@ -665,12 +698,40 @@ KucoinAccount <- R6::R6Class(
     #'   - `quoteCurrency` (character): Quote currency for valuation e.g. `"USDT"`.
     #'   - `queryType` (character): Query type e.g. `"ISOLATED"`, `"ISOLATED_V2"`.
     #'
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
-    #'   Columns are flattened from the nested response and may include:
-    #'   `symbol` (character), `status` (character), `debt_ratio` (character),
-    #'   and nested `base_asset.*` and `quote_asset.*` fields (currency, total, available, hold,
-    #'   liability, liability_principal, liability_interest, max_borrow_size). Returns an empty `data.table`
-    #'   if no isolated margin accounts exist.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with
+    #'   one row per isolated-margin pair (Treatment B) and the nested `baseAsset` / `quoteAsset`
+    #'   objects flattened wide-prefix (Treatment C). The account-level fields
+    #'   `total_asset_of_quote_currency`, `total_liability_of_quote_currency`, and `timestamp`
+    #'   are replicated on every row.
+    #'   Columns:
+    #'   - `symbol` (character): Isolated pair symbol (e.g. `"BTC-USDT"`).
+    #'   - `status` (character): Account status (e.g. `"EFFECTIVE"`).
+    #'   - `debt_ratio` (character): Liability-to-asset ratio.
+    #'   - `base_asset_currency` (character): Base asset code.
+    #'   - `base_asset_borrow_enabled` (logical): Whether borrowing the base asset is allowed.
+    #'   - `base_asset_transfer_in_enabled` (logical): Whether transferring the base asset in is allowed.
+    #'   - `base_asset_liability` (character): Total base-asset liability.
+    #'   - `base_asset_liability_principal` (character): Base-asset liability principal.
+    #'   - `base_asset_liability_interest` (character): Base-asset liability interest.
+    #'   - `base_asset_total` (character): Base-asset total balance.
+    #'   - `base_asset_available` (character): Base-asset available balance.
+    #'   - `base_asset_hold` (character): Base-asset amount on hold.
+    #'   - `base_asset_max_borrow_size` (character): Base-asset maximum borrowable.
+    #'   - `quote_asset_currency` (character): Quote asset code.
+    #'   - `quote_asset_borrow_enabled` (logical): Whether borrowing the quote asset is allowed.
+    #'   - `quote_asset_transfer_in_enabled` (logical): Whether transferring the quote asset in is allowed.
+    #'   - `quote_asset_liability` (character): Total quote-asset liability.
+    #'   - `quote_asset_liability_principal` (character): Quote-asset liability principal.
+    #'   - `quote_asset_liability_interest` (character): Quote-asset liability interest.
+    #'   - `quote_asset_total` (character): Quote-asset total balance.
+    #'   - `quote_asset_available` (character): Quote-asset available balance.
+    #'   - `quote_asset_hold` (character): Quote-asset amount on hold.
+    #'   - `quote_asset_max_borrow_size` (character): Quote-asset maximum borrowable.
+    #'   - `total_asset_of_quote_currency` (character): Account-level total asset (repeated).
+    #'   - `total_liability_of_quote_currency` (character): Account-level total liability (repeated).
+    #'   - `timestamp` (POSIXct): Snapshot timestamp (repeated).
+    #'
+    #'   Returns an empty `data.table` if no isolated-margin pairs exist.
     #'
     #' @examples
     #' \dontrun{
@@ -685,14 +746,80 @@ KucoinAccount <- R6::R6Class(
         endpoint = "/api/v3/isolated/accounts",
         query = query,
         .parser = function(data) {
-          assets <- data
+          assets <- NULL
           if (!is.null(data$assets)) {
             assets <- data$assets
           }
-          if (is.null(assets) || length(assets) == 0) {
+          if (is.null(assets) || length(assets) == 0L) {
             return(data.table::data.table()[])
           }
-          return(data.table::rbindlist(lapply(assets, as_dt_row), fill = TRUE)[])
+
+          # Flatten each asset: nested baseAsset/quoteAsset objects -> wide-prefix
+          # (Treatment C). The result is a single flat record per pair so the
+          # outer `as_dt_list` doesn't have to deal with list columns.
+          flat_assets <- lapply(assets, function(a) {
+            for (nested in c("baseAsset", "quoteAsset")) {
+              obj <- a[[nested]]
+              prefix <- to_snake_case(nested)
+              if (!is.null(obj) && is.list(obj) && length(obj) > 0L) {
+                for (nm in names(obj)) {
+                  a[[paste0(prefix, "_", nm)]] <- obj[[nm]]
+                }
+              }
+              a[[nested]] <- NULL
+            }
+            return(a)
+          })
+
+          child_dt <- as_dt_list(flat_assets)
+          if (nrow(child_dt) == 0L) {
+            return(data.table::data.table()[])
+          }
+
+          # Account-level summary fields replicated on each row (Treatment B
+          # with replicated parent). Caller doesn't need a sibling method —
+          # the parent summary is small enough to inline.
+          parent <- data
+          parent$assets <- NULL
+          parent_dt <- as_dt_row(parent)
+          if (nrow(parent_dt) > 0L) {
+            coerce_cols(parent_dt, "timestamp", ms_to_datetime)
+            parent_dt <- parent_dt[rep(1L, nrow(child_dt))]
+            dt <- cbind(child_dt, parent_dt)
+          } else {
+            dt <- child_dt
+          }
+
+          expected <- c(
+            "symbol",
+            "status",
+            "debt_ratio",
+            "base_asset_currency",
+            "base_asset_borrow_enabled",
+            "base_asset_transfer_in_enabled",
+            "base_asset_liability",
+            "base_asset_liability_principal",
+            "base_asset_liability_interest",
+            "base_asset_total",
+            "base_asset_available",
+            "base_asset_hold",
+            "base_asset_max_borrow_size",
+            "quote_asset_currency",
+            "quote_asset_borrow_enabled",
+            "quote_asset_transfer_in_enabled",
+            "quote_asset_liability",
+            "quote_asset_liability_principal",
+            "quote_asset_liability_interest",
+            "quote_asset_total",
+            "quote_asset_available",
+            "quote_asset_hold",
+            "quote_asset_max_borrow_size",
+            "total_asset_of_quote_currency",
+            "total_liability_of_quote_currency",
+            "timestamp"
+          )
+          data.table::setcolorder(dt, intersect(expected, names(dt)))
+          return(dt[])
         }
       ))
     },

--- a/R/KucoinAccount.R
+++ b/R/KucoinAccount.R
@@ -212,9 +212,7 @@ KucoinAccount <- R6::R6Class(
     #' - `remark` (character): Key label.
     #' - `api_key` (character): API key ID.
     #' - `api_version` (integer): Key version.
-    #' - `permission` (character): Comma-separated permissions e.g. `"General,Spot"`.
-    #'   Already a single string from KuCoin (not a JSON array); recover the
-    #'   vector with `strsplit(dt$permission[1], ",", fixed = TRUE)[[1]]`.
+    #' - `permission` (character): Comma-separated permissions e.g. `"General,Spot"` (already a single string from KuCoin, not a JSON array; recover the vector with `strsplit(dt$permission[1], ",", fixed = TRUE)[[1]]`).
     #' - `ip_whitelist` (character): Allowed IPs (comma-separated string).
     #' - `created_at` (POSIXct): Key creation datetime (coerced from epoch milliseconds).
     #' - `uid` (numeric): User ID.

--- a/R/KucoinDeposit.R
+++ b/R/KucoinDeposit.R
@@ -114,7 +114,7 @@ KucoinDeposit <- R6::R6Class(
     #'   include `"main"` (funding account) and `"trade"` (trading account). Required by the KuCoin API.
     #' @param amount Character or NULL; deposit amount. Required for some invoice-based
     #'   deposit addresses (e.g., Lightning Network).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row and columns:
     #'   - `address` (character): The generated deposit address.
     #'   - `memo` (character): Memo/tag for the address (empty string if not applicable).
     #'   - `chain` (character): Blockchain network name.
@@ -246,7 +246,7 @@ KucoinDeposit <- R6::R6Class(
     #'   to generate invoice-based addresses (e.g., Lightning Network).
     #' @param chain Character or NULL; blockchain network identifier (e.g., `"ERC20"`,
     #'   `"TRC20"`, `"btc"`). When NULL, returns addresses for all chains.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row per address and columns:
     #'   - `address` (character): The deposit address string.
     #'   - `memo` (character): Memo/tag for the address (empty string if not applicable).
     #'   - `chain` (character): Blockchain network name.
@@ -391,7 +391,7 @@ KucoinDeposit <- R6::R6Class(
     #'   Used to filter deposits created on or before this time.
     #' @param page_size Integer; number of results per page (default 50, max 100).
     #' @param max_pages Numeric; maximum number of pages to fetch (default `Inf` for all pages).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row per deposit and columns:
     #'   - `currency` (character): Deposited currency code.
     #'   - `chain` (character): Blockchain network used for the deposit.
     #'   - `status` (character): Deposit status (`"PROCESSING"`, `"SUCCESS"`, `"FAILURE"`).
@@ -401,9 +401,9 @@ KucoinDeposit <- R6::R6Class(
     #'   - `amount` (character): Deposit amount.
     #'   - `fee` (character): Deposit fee charged.
     #'   - `wallet_tx_id` (character): On-chain transaction hash.
-    #'   - `updated_at` (numeric): Last update timestamp in milliseconds.
-    #'   - `remark` (character): Optional remark.
     #'   - `created_at` (POSIXct): Creation datetime (coerced from epoch milliseconds).
+    #'   - `updated_at` (POSIXct): Last update datetime (coerced from epoch milliseconds).
+    #'   - `remark` (character): Optional remark.
     #'
     #'   Returns an empty `data.table` if no deposits match the filters.
     #'
@@ -451,9 +451,7 @@ KucoinDeposit <- R6::R6Class(
           if (nrow(dt) == 0L) {
             return(dt[])
           }
-          if ("created_at" %in% names(dt)) {
-            dt[, created_at := ms_to_datetime(created_at)]
-          }
+          coerce_cols(dt, c("created_at", "updated_at"), ms_to_datetime)
           data.table::setcolorder(
             dt,
             intersect(

--- a/R/KucoinFuturesAccount.R
+++ b/R/KucoinFuturesAccount.R
@@ -109,7 +109,8 @@ KucoinFuturesAccount <- R6::R6Class(
     #'
     #' @param currency Character; settlement currency (e.g., `"USDT"`).
     #'   Default `"USDT"`.
-    #' @return A single-row `data.table` with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `account_equity` (numeric): Total account equity.
     #'   - `unrealised_pnl` (numeric): Unrealised profit and loss.
     #'   - `margin_balance` (numeric): Margin balance (equity + unrealised PNL).
@@ -123,7 +124,7 @@ KucoinFuturesAccount <- R6::R6Class(
         endpoint = "/api/v1/account-overview",
         query = list(currency = currency),
         .parser = function(data) {
-          return(as_dt_row(data))
+          return(as_dt_row(data)[])
         }
       ))
     },
@@ -194,21 +195,35 @@ KucoinFuturesAccount <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol (e.g., `"XBTUSDTM"`).
-    #' @return A `data.table` with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `id` (character): Position identifier.
     #'   - `symbol` (character): Contract symbol.
+    #'   - `auto_deposit` (logical): Auto-deposit margin flag.
     #'   - `real_leverage` (numeric): Effective leverage.
     #'   - `cross_mode` (logical): Whether cross margin mode is active.
+    #'   - `delev_percentage` (numeric): Auto-deleveraging percentage.
     #'   - `current_qty` (integer): Current position size in contracts.
     #'   - `current_cost` (character): Cost of the current position.
+    #'   - `current_comm` (character): Current commission paid.
+    #'   - `unrealised_cost` (character): Unrealised cost.
+    #'   - `realised_gross_cost` (character): Realised gross cost.
+    #'   - `realised_cost` (character): Realised cost.
     #'   - `is_open` (logical): Whether the position is open.
     #'   - `mark_price` (numeric): Current mark price.
     #'   - `mark_value` (character): Mark value of the position.
+    #'   - `pos_cost` (character): Position cost.
+    #'   - `pos_init` (character): Initial margin.
+    #'   - `pos_comm` (character): Position commission.
     #'   - `pos_margin` (character): Position margin.
-    #'   - `unrealised_pnl` (numeric): Unrealised profit and loss.
+    #'   - `unrealised_pnl` (character): Unrealised profit and loss.
+    #'   - `unrealised_pnl_pcnt` (numeric): Unrealised PnL as a percentage.
     #'   - `avg_entry_price` (character): Average entry price.
     #'   - `liquidation_price` (character): Estimated liquidation price.
+    #'   - `bankrupt_price` (character): Bankruptcy price.
+    #'   - `settle_currency` (character): Settlement currency.
     #'   - `margin_mode` (character): `"ISOLATED"` or `"CROSS"`.
+    #'   - `position_side` (character): `"BOTH"`, `"LONG"`, or `"SHORT"`.
     #'   - `opening_timestamp` (POSIXct): Position opened time (coerced from milliseconds).
     #'   - `current_timestamp` (POSIXct): Current server time (coerced from milliseconds).
     get_position = function(symbol) {
@@ -217,13 +232,8 @@ KucoinFuturesAccount <- R6::R6Class(
         query = list(symbol = symbol),
         .parser = function(data) {
           dt <- as_dt_row(data)
-          if (nrow(dt) > 0 && "opening_timestamp" %in% names(dt)) {
-            dt[, opening_timestamp := ms_to_datetime(opening_timestamp)]
-          }
-          if (nrow(dt) > 0 && "current_timestamp" %in% names(dt)) {
-            dt[, current_timestamp := ms_to_datetime(current_timestamp)]
-          }
-          return(dt)
+          coerce_cols(dt, c("opening_timestamp", "current_timestamp"), ms_to_datetime)
+          return(dt[])
         }
       ))
     },
@@ -302,20 +312,21 @@ KucoinFuturesAccount <- R6::R6Class(
     #' ```
     #'
     #' @param currency Character or NULL; filter by settlement currency.
-    #' @return A `data.table`; same columns as `get_position()`.
+    #' @return A `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per open position; same columns as
+    #'   `get_position()`. Returns an empty `data.table` when there are no
+    #'   open positions.
     get_positions = function(currency = NULL) {
       return(private$.request(
         endpoint = "/api/v1/positions",
         query = list(currency = currency),
         .parser = function(data) {
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
+          }
           dt <- as_dt_list(data)
-          if (nrow(dt) > 0 && "opening_timestamp" %in% names(dt)) {
-            dt[, opening_timestamp := ms_to_datetime(opening_timestamp)]
-          }
-          if (nrow(dt) > 0 && "current_timestamp" %in% names(dt)) {
-            dt[, current_timestamp := ms_to_datetime(current_timestamp)]
-          }
-          return(dt)
+          coerce_cols(dt, c("opening_timestamp", "current_timestamp"), ms_to_datetime)
+          return(dt[])
         }
       ))
     },
@@ -385,13 +396,25 @@ KucoinFuturesAccount <- R6::R6Class(
     #'
     #' @param query Named list; query parameters. Optional: `symbol`,
     #'   `from`, `to`, `limit`, `pageId`.
-    #' @return A `data.table` with columns:
+    #' @return A `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per closed position record. Returns an
+    #'   empty `data.table` when no history records match. Columns:
+    #'   - `close_id` (character): Close-event identifier.
+    #'   - `position_id` (character): Position identifier.
+    #'   - `uid` (integer): Numeric user ID.
+    #'   - `user_id` (character): String user ID.
     #'   - `symbol` (character): Contract symbol.
     #'   - `settle_currency` (character): Settlement currency.
-    #'   - `realised_gross_pnl` (character): Gross realised PNL.
-    #'   - `realised_pnl` (character): Net realised PNL (after fees).
-    #'   - `leverage` (integer): Leverage used.
+    #'   - `leverage` (character): Leverage used.
     #'   - `type` (character): Close type (e.g., `"Close"`).
+    #'   - `pnl` (character): Realised PnL.
+    #'   - `realised_gross_cost` (character): Gross realised cost.
+    #'   - `withdraw_pnl` (character): Withdrawn PnL.
+    #'   - `trade_fee` (character): Trading fee.
+    #'   - `funding_fee` (character): Funding fee.
+    #'   - `open_price` (character): Average open price.
+    #'   - `close_price` (character): Average close price.
+    #'   - `margin_mode` (character): `"ISOLATED"` or `"CROSS"`.
     #'   - `open_time` (POSIXct): Position opened time (coerced from milliseconds).
     #'   - `close_time` (POSIXct): Position closed time (coerced from milliseconds).
     get_positions_history = function(query = list()) {
@@ -400,17 +423,15 @@ KucoinFuturesAccount <- R6::R6Class(
         query = query,
         .parser = function(data) {
           items <- data
-          if (!is.null(data$items)) {
+          if (is.list(data) && !is.null(data$items)) {
             items <- data$items
           }
+          if (is.null(items) || length(items) == 0L) {
+            return(data.table::data.table()[])
+          }
           dt <- as_dt_list(items)
-          if (nrow(dt) > 0 && "open_time" %in% names(dt)) {
-            dt[, open_time := ms_to_datetime(open_time)]
-          }
-          if (nrow(dt) > 0 && "close_time" %in% names(dt)) {
-            dt[, close_time := ms_to_datetime(close_time)]
-          }
-          return(dt)
+          coerce_cols(dt, c("open_time", "close_time"), ms_to_datetime)
+          return(dt[])
         }
       ))
     },
@@ -454,7 +475,8 @@ KucoinFuturesAccount <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol.
-    #' @return A single-row `data.table` with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `margin_mode` (character): `"ISOLATED"` or `"CROSS"`.
     get_margin_mode = function(symbol) {
@@ -462,7 +484,7 @@ KucoinFuturesAccount <- R6::R6Class(
         endpoint = "/api/v1/marginMode",
         query = list(symbol = symbol),
         .parser = function(data) {
-          return(as_dt_row(data))
+          return(as_dt_row(data)[])
         }
       ))
     },
@@ -517,7 +539,8 @@ KucoinFuturesAccount <- R6::R6Class(
     #'
     #' @param symbol Character; futures symbol.
     #' @param marginMode Character; `"ISOLATED"` or `"CROSS"`.
-    #' @return A single-row `data.table` with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `margin_mode` (character): Updated margin mode.
     set_margin_mode = function(symbol, marginMode) {
@@ -526,7 +549,7 @@ KucoinFuturesAccount <- R6::R6Class(
         method = "POST",
         body = list(symbol = symbol, marginMode = marginMode),
         .parser = function(data) {
-          return(as_dt_row(data))
+          return(as_dt_row(data)[])
         }
       ))
     },
@@ -570,7 +593,8 @@ KucoinFuturesAccount <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol.
-    #' @return A single-row `data.table` with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `leverage` (character): Current leverage multiplier.
     get_cross_margin_leverage = function(symbol) {
@@ -578,7 +602,7 @@ KucoinFuturesAccount <- R6::R6Class(
         endpoint = "/api/v1/crossMarginLeverage",
         query = list(symbol = symbol),
         .parser = function(data) {
-          return(as_dt_row(data))
+          return(as_dt_row(data)[])
         }
       ))
     },
@@ -633,7 +657,8 @@ KucoinFuturesAccount <- R6::R6Class(
     #'
     #' @param symbol Character; futures symbol.
     #' @param leverage Integer; leverage multiplier.
-    #' @return A single-row `data.table` with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `leverage` (character): Updated leverage multiplier.
     set_cross_margin_leverage = function(symbol, leverage) {
@@ -642,7 +667,7 @@ KucoinFuturesAccount <- R6::R6Class(
         method = "POST",
         body = list(symbol = symbol, leverage = leverage),
         .parser = function(data) {
-          return(as_dt_row(data))
+          return(as_dt_row(data)[])
         }
       ))
     },
@@ -689,7 +714,8 @@ KucoinFuturesAccount <- R6::R6Class(
     #' @param symbol Character; futures symbol.
     #' @param price Character; order price.
     #' @param leverage Integer; leverage multiplier.
-    #' @return A single-row `data.table` with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `max_buy_open_size` (integer): Maximum buy contracts.
     #'   - `max_sell_open_size` (integer): Maximum sell contracts.
@@ -698,7 +724,7 @@ KucoinFuturesAccount <- R6::R6Class(
         endpoint = "/api/v1/maxOpenSize",
         query = list(symbol = symbol, price = price, leverage = leverage),
         .parser = function(data) {
-          return(as_dt_row(data))
+          return(as_dt_row(data)[])
         }
       ))
     },
@@ -739,13 +765,27 @@ KucoinFuturesAccount <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol.
-    #' @return A single-row `data.table` with the maximum withdrawable margin amount.
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
+    #'   - `max_withdraw_margin` (character): Maximum amount of isolated
+    #'     margin that can be withdrawn from the position. Returned by
+    #'     KuCoin as a fixed-precision string so the caller controls
+    #'     numeric coercion.
     get_max_withdraw_margin = function(symbol) {
       return(private$.request(
         endpoint = "/api/v1/maxWithdrawMargin",
         query = list(symbol = symbol),
         .parser = function(data) {
-          return(as_dt_row(data))
+          # KuCoin returns a scalar string here (e.g. "21.1234") rather than
+          # a named object. Wrap it explicitly so the caller gets a
+          # one-row, one-column data.table with a meaningful name rather
+          # than the default `v1` `as_dt_row()` would assign.
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
+          }
+          return(data.table::data.table(
+            max_withdraw_margin = as.character(data)
+          )[])
         }
       ))
     },
@@ -804,7 +844,8 @@ KucoinFuturesAccount <- R6::R6Class(
     #' @param symbol Character; futures symbol.
     #' @param margin Numeric; amount of margin to add.
     #' @param bizNo Character; unique business ID for idempotency.
-    #' @return A single-row `data.table` with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `id` (character): Margin operation ID.
     #'   - `symbol` (character): Contract symbol.
     #'   - `margin` (character): Amount deposited.
@@ -815,7 +856,7 @@ KucoinFuturesAccount <- R6::R6Class(
         method = "POST",
         body = list(symbol = symbol, margin = margin, bizNo = bizNo),
         .parser = function(data) {
-          return(as_dt_row(data))
+          return(as_dt_row(data)[])
         }
       ))
     },
@@ -872,7 +913,8 @@ KucoinFuturesAccount <- R6::R6Class(
     #'
     #' @param symbol Character; futures symbol.
     #' @param withdrawAmount Numeric; amount of margin to withdraw.
-    #' @return A single-row `data.table` with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `id` (character): Margin operation ID.
     #'   - `symbol` (character): Contract symbol.
     #'   - `margin` (character): Amount withdrawn.
@@ -883,7 +925,7 @@ KucoinFuturesAccount <- R6::R6Class(
         method = "POST",
         body = list(symbol = symbol, withdrawAmount = withdrawAmount),
         .parser = function(data) {
-          return(as_dt_row(data))
+          return(as_dt_row(data)[])
         }
       ))
     },
@@ -952,7 +994,9 @@ KucoinFuturesAccount <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol.
-    #' @return A `data.table` with columns:
+    #' @return A `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per risk-limit tier. Returns an empty
+    #'   `data.table` when KuCoin returns no tiers. Columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `level` (integer): Risk limit tier level.
     #'   - `max_risk_limit` (integer): Maximum position value for this tier.
@@ -964,7 +1008,10 @@ KucoinFuturesAccount <- R6::R6Class(
       return(private$.request(
         endpoint = paste0("/api/v1/contracts/risk-limit/", symbol),
         .parser = function(data) {
-          return(as_dt_list(data))
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
+          }
+          return(as_dt_list(data)[])
         }
       ))
     },
@@ -1034,7 +1081,9 @@ KucoinFuturesAccount <- R6::R6Class(
     #' @param symbol Character; futures symbol.
     #' @param query Named list; additional query parameters. Optional:
     #'   `startAt`, `endAt`, `reverse`, `offset`, `forward`, `maxCount`.
-    #' @return A `data.table` with columns:
+    #' @return A `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per funding settlement. Returns an
+    #'   empty `data.table` when no records are returned. Columns:
     #'   - `id` (integer): Record identifier.
     #'   - `symbol` (character): Contract symbol.
     #'   - `time_point` (POSIXct): Funding settlement time (coerced from milliseconds).
@@ -1051,14 +1100,15 @@ KucoinFuturesAccount <- R6::R6Class(
         query = query,
         .parser = function(data) {
           items <- data
-          if (!is.null(data$dataList)) {
+          if (is.list(data) && !is.null(data$dataList)) {
             items <- data$dataList
           }
-          dt <- as_dt_list(items)
-          if (nrow(dt) > 0 && "time_point" %in% names(dt)) {
-            dt[, time_point := ms_to_datetime(time_point)]
+          if (is.null(items) || length(items) == 0L) {
+            return(data.table::data.table()[])
           }
-          return(dt)
+          dt <- as_dt_list(items)
+          coerce_cols(dt, "time_point", ms_to_datetime)
+          return(dt[])
         }
       ))
     }

--- a/R/KucoinFuturesAccount.R
+++ b/R/KucoinFuturesAccount.R
@@ -399,7 +399,10 @@ KucoinFuturesAccount <- R6::R6Class(
         endpoint = "/api/v1/history-positions",
         query = query,
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           dt <- as_dt_list(items)
           if (nrow(dt) > 0 && "open_time" %in% names(dt)) {
             dt[, open_time := ms_to_datetime(open_time)]
@@ -1047,7 +1050,10 @@ KucoinFuturesAccount <- R6::R6Class(
         endpoint = "/api/v1/funding-history",
         query = query,
         .parser = function(data) {
-          items <- data$dataList %||% data
+          items <- data
+          if (!is.null(data$dataList)) {
+            items <- data$dataList
+          }
           dt <- as_dt_list(items)
           if (nrow(dt) > 0 && "time_point" %in% names(dt)) {
             dt[, time_point := ms_to_datetime(time_point)]

--- a/R/KucoinFuturesMarketData.R
+++ b/R/KucoinFuturesMarketData.R
@@ -541,6 +541,8 @@ KucoinFuturesMarketData <- R6::R6Class(
     #'   - `ts` (POSIXct): Snapshot timestamp (coerced from nanoseconds).
     #'   - `sequence` (character): Sequence number for change detection.
     #'   - `side` (character): `"bid"` or `"ask"`.
+    #'   - `level` (integer): 1-indexed depth from top-of-book within the side
+    #'     (`level == 1` is best bid / best ask).
     #'   - `price` (numeric): Price level.
     #'   - `size` (numeric): Size at this price level.
     #'
@@ -548,7 +550,7 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' \dontrun{
     #' futures_market <- KucoinFuturesMarketData$new()
     #' ob <- futures_market$get_part_orderbook("XBTUSDTM", size = 20)
-    #' print(ob[side == "bid"][1:5])
+    #' print(ob[side == "bid"][order(level)][1:5])
     #' }
     get_part_orderbook = function(symbol, size = 20) {
       size <- match.arg(as.character(size), c("20", "100"))
@@ -623,6 +625,8 @@ KucoinFuturesMarketData <- R6::R6Class(
     #'   - `ts` (POSIXct): Snapshot timestamp (coerced from nanoseconds).
     #'   - `sequence` (character): Sequence number for change detection.
     #'   - `side` (character): `"bid"` or `"ask"`.
+    #'   - `level` (integer): 1-indexed depth from top-of-book within the side
+    #'     (`level == 1` is best bid / best ask).
     #'   - `price` (numeric): Price level.
     #'   - `size` (numeric): Size at this price level.
     #'
@@ -1260,12 +1264,17 @@ parse_futures_orderbook <- function(data) {
     if (is.null(entries) || length(entries) == 0) {
       return(data.table::data.table(
         side = character(),
+        level = integer(),
         price = numeric(),
         size = numeric()
       )[])
     }
+    # KuCoin returns best price first; `level = 1` is the top of the
+    # book for the given side. Matches `parse_orderbook` (spot) and the
+    # cross-package long-format convention.
     return(data.table::data.table(
       side = side_label,
+      level = seq_along(entries),
       price = vapply(entries, function(e) as.numeric(e[[1]]), numeric(1)),
       size = vapply(entries, function(e) as.numeric(e[[2]]), numeric(1))
     )[])
@@ -1280,7 +1289,7 @@ parse_futures_orderbook <- function(data) {
   if (!is.null(data$symbol)) {
     result[, symbol := data$symbol]
   }
-  data.table::setcolorder(result, c("ts", "sequence", "side", "price", "size"))
+  data.table::setcolorder(result, c("ts", "sequence", "side", "level", "price", "size"))
 
   return(result[])
 }

--- a/R/KucoinFuturesMarketData.R
+++ b/R/KucoinFuturesMarketData.R
@@ -163,7 +163,9 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol (e.g., `"XBTUSDTM"`).
-    #' @return A single-row `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with the contract specification
+    #'   flattened to one row per symbol. Key columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `root_symbol` (character): Root symbol (e.g., `"USDT"`).
     #'   - `type` (character): Contract type (e.g., `"FFWCSX"` for perpetual).
@@ -180,8 +182,17 @@ KucoinFuturesMarketData <- R6::R6Class(
     #'   - `taker_fee_rate` (numeric): Taker fee rate.
     #'   - `status` (character): Contract status (e.g., `"Open"`).
     #'   - `mark_price` (numeric): Current mark price.
+    #'   - `index_price` (numeric): Underlying index price.
     #'   - `last_trade_price` (numeric): Last traded price.
     #'   - `funding_fee_rate` (numeric): Current funding fee rate.
+    #'   - `predicted_funding_fee_rate` (numeric): Predicted next funding fee rate.
+    #'   - `open_interest` (character): Current open interest.
+    #'   - `turnover_of24h` (numeric): 24h turnover in settlement currency.
+    #'   - `volume_of24h` (numeric): 24h trading volume.
+    #'   - `low_price` (numeric): 24h low price.
+    #'   - `high_price` (numeric): 24h high price.
+    #'   - `price_chg_pct` (numeric): 24h price change percentage.
+    #'   - `price_chg` (numeric): 24h price change.
     #'
     #' @examples
     #' \dontrun{
@@ -194,6 +205,9 @@ KucoinFuturesMarketData <- R6::R6Class(
         endpoint = paste0("/api/v1/contracts/", symbol),
         auth = FALSE,
         .parser = function(data) {
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
+          }
           return(as_dt_row(data)[])
         }
       ))
@@ -275,7 +289,10 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' }
     #' ```
     #'
-    #' @return A `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row per contract; same columns as `get_contract()`.
+    #' @return A `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per active contract; columns match
+    #'   `get_contract()`. Returns an empty `data.table` if no active
+    #'   contracts are returned.
     #'
     #' @examples
     #' \dontrun{
@@ -288,6 +305,9 @@ KucoinFuturesMarketData <- R6::R6Class(
         endpoint = "/api/v1/contracts/active",
         auth = FALSE,
         .parser = function(data) {
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
+          }
           return(as_dt_list(data)[])
         }
       ))
@@ -341,11 +361,13 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol (e.g., `"XBTUSDTM"`).
-    #' @return A single-row `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `sequence` (integer): Sequence number.
     #'   - `symbol` (character): Contract symbol.
     #'   - `side` (character): Side of the last trade (`"buy"` or `"sell"`).
     #'   - `size` (integer): Size of the last trade.
+    #'   - `trade_id` (character): Identifier of the last trade.
     #'   - `price` (character): Last trade price.
     #'   - `best_bid_size` (integer): Quantity at best bid.
     #'   - `best_bid_price` (character): Best bid price.
@@ -365,10 +387,11 @@ KucoinFuturesMarketData <- R6::R6Class(
         query = list(symbol = symbol),
         auth = FALSE,
         .parser = function(data) {
-          dt <- as_dt_row(data)
-          if (nrow(dt) > 0 && "ts" %in% names(dt)) {
-            dt[, ts := ns_to_datetime(ts)]
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
           }
+          dt <- as_dt_row(data)
+          coerce_cols(dt, "ts", ns_to_datetime)
           return(dt[])
         }
       ))
@@ -434,7 +457,10 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' }
     #' ```
     #'
-    #' @return A `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row per contract; same columns as `get_ticker()`.
+    #' @return A `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per contract; columns match
+    #'   `get_ticker()`. Returns an empty `data.table` if no tickers are
+    #'   returned.
     #'
     #' @examples
     #' \dontrun{
@@ -447,10 +473,11 @@ KucoinFuturesMarketData <- R6::R6Class(
         endpoint = "/api/v1/allTickers",
         auth = FALSE,
         .parser = function(data) {
-          dt <- as_dt_list(data)
-          if (nrow(dt) > 0 && "ts" %in% names(dt)) {
-            dt[, ts := ns_to_datetime(ts)]
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
           }
+          dt <- as_dt_list(data)
+          coerce_cols(dt, "ts", ns_to_datetime)
           return(dt[])
         }
       ))
@@ -673,7 +700,9 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol (e.g., `"XBTUSDTM"`).
-    #' @return A `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return A `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per trade. Returns an empty
+    #'   `data.table` when KuCoin reports no recent trades. Columns:
     #'   - `sequence` (integer): Trade sequence number.
     #'   - `trade_id` (character): Unique trade identifier.
     #'   - `taker_order_id` (character): Taker's order ID.
@@ -695,10 +724,11 @@ KucoinFuturesMarketData <- R6::R6Class(
         query = list(symbol = symbol),
         auth = FALSE,
         .parser = function(data) {
-          dt <- as_dt_list(data)
-          if (nrow(dt) > 0 && "ts" %in% names(dt)) {
-            dt[, ts := ns_to_datetime(ts)]
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
           }
+          dt <- as_dt_list(data)
+          coerce_cols(dt, "ts", ns_to_datetime)
           return(dt[])
         }
       ))
@@ -887,7 +917,8 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol (e.g., `"XBTUSDTM"`).
-    #' @return A single-row `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `granularity` (integer): Price granularity in milliseconds.
     #'   - `time_point` (POSIXct): Timestamp (coerced from milliseconds).
@@ -905,10 +936,11 @@ KucoinFuturesMarketData <- R6::R6Class(
         endpoint = paste0("/api/v1/mark-price/", symbol, "/current"),
         auth = FALSE,
         .parser = function(data) {
-          dt <- as_dt_row(data)
-          if (nrow(dt) > 0 && "time_point" %in% names(dt)) {
-            dt[, time_point := ms_to_datetime(time_point)]
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
           }
+          dt <- as_dt_row(data)
+          coerce_cols(dt, "time_point", ms_to_datetime)
           return(dt[])
         }
       ))
@@ -958,7 +990,8 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' ```
     #'
     #' @param symbol Character; futures symbol (e.g., `"XBTUSDTM"`).
-    #' @return A single-row `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `granularity` (integer): Funding interval in milliseconds.
     #'   - `time_point` (POSIXct): Current rate timestamp (coerced from milliseconds).
@@ -977,13 +1010,11 @@ KucoinFuturesMarketData <- R6::R6Class(
         endpoint = paste0("/api/v1/funding-rate/", symbol, "/current"),
         auth = FALSE,
         .parser = function(data) {
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
+          }
           dt <- as_dt_row(data)
-          if (nrow(dt) > 0 && "time_point" %in% names(dt)) {
-            dt[, time_point := ms_to_datetime(time_point)]
-          }
-          if (nrow(dt) > 0 && "funding_time" %in% names(dt)) {
-            dt[, funding_time := ms_to_datetime(funding_time)]
-          }
+          coerce_cols(dt, c("time_point", "funding_time"), ms_to_datetime)
           return(dt[])
         }
       ))
@@ -1047,7 +1078,9 @@ KucoinFuturesMarketData <- R6::R6Class(
     #'   If numeric, assumed to be milliseconds.
     #' @param to POSIXct or numeric; end time. If POSIXct, converted to milliseconds.
     #'   If numeric, assumed to be milliseconds.
-    #' @return A `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return A `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per funding settlement. Returns an
+    #'   empty `data.table` when no records cover the time range. Columns:
     #'   - `symbol` (character): Contract symbol.
     #'   - `funding_rate` (numeric): Funding rate for the period.
     #'   - `timepoint` (POSIXct): Settlement timestamp (coerced from milliseconds).
@@ -1075,10 +1108,11 @@ KucoinFuturesMarketData <- R6::R6Class(
         query = list(symbol = symbol, from = from, to = to),
         auth = FALSE,
         .parser = function(data) {
-          dt <- as_dt_list(data)
-          if (nrow(dt) > 0 && "timepoint" %in% names(dt)) {
-            dt[, timepoint := ms_to_datetime(timepoint)]
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
           }
+          dt <- as_dt_list(data)
+          coerce_cols(dt, "timepoint", ms_to_datetime)
           return(dt[])
         }
       ))
@@ -1120,7 +1154,8 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' }
     #' ```
     #'
-    #' @return A single-row `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `server_time` (POSIXct): Server timestamp (coerced from milliseconds).
     #'
     #' @examples
@@ -1134,6 +1169,9 @@ KucoinFuturesMarketData <- R6::R6Class(
         endpoint = "/api/v1/timestamp",
         auth = FALSE,
         .parser = function(data) {
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
+          }
           return(data.table::data.table(server_time = ms_to_datetime(data))[])
         }
       ))
@@ -1178,7 +1216,8 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' }
     #' ```
     #'
-    #' @return A single-row `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return A single-row `data.table` (or `promise<data.table>` if
+    #'   constructed with `async = TRUE`) with columns:
     #'   - `status` (character): Service status (e.g., `"open"`, `"close"`).
     #'   - `msg` (character): Status message (empty when operational).
     #'
@@ -1193,6 +1232,9 @@ KucoinFuturesMarketData <- R6::R6Class(
         endpoint = "/api/v1/status",
         auth = FALSE,
         .parser = function(data) {
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
+          }
           return(as_dt_row(data)[])
         }
       ))

--- a/R/KucoinFuturesTrading.R
+++ b/R/KucoinFuturesTrading.R
@@ -585,25 +585,35 @@ KucoinFuturesTrading <- R6::R6Class(
     #' ```
     #'
     #' @param orderId Character; the system order ID to cancel.
-    #' @return A single-row `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
-    #'   - `cancelled_order_ids` (list): Vector of cancelled order IDs.
+    #' @return `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per cancelled order, and column:
+    #'   - `cancelled_order_id` (character): Cancelled order ID. Empty
+    #'     `data.table` (zero rows) if no orders matched.
     #'
     #' @examples
     #' \dontrun{
     #' ft <- KucoinFuturesTrading$new()
     #' result <- ft$cancel_order_by_id("234125150956625920")
-    #' print(result$cancelled_order_ids)
+    #' print(result$cancelled_order_id)
     #' }
     cancel_order_by_id = function(orderId) {
       return(private$.request(
         endpoint = paste0("/api/v1/orders/", orderId),
         method = "DELETE",
         .parser = function(data) {
-          ids <- data$cancelledOrderIds
-          data$cancelledOrderIds <- NULL
+          ids <- NULL
+          if (!is.null(data)) {
+            ids <- data$cancelledOrderIds
+            data$cancelledOrderIds <- NULL
+          }
+          if (is.null(ids) || length(ids) == 0) {
+            return(data.table::data.table()[])
+          }
           dt <- as_dt_row(data)
-          if (!is.null(ids) && length(ids) > 0) {
-            id_vals <- unlist(ids)
+          id_vals <- as.character(unlist(ids, use.names = FALSE))
+          if (nrow(dt) == 0L) {
+            dt <- data.table::data.table(cancelled_order_id = id_vals)
+          } else {
             dt <- dt[rep(1L, length(id_vals))]
             dt[, cancelled_order_id := id_vals]
           }
@@ -726,8 +736,10 @@ KucoinFuturesTrading <- R6::R6Class(
     #'
     #' @param symbol Character or NULL; filter by futures symbol. When NULL,
     #'   cancels all open orders across all symbols.
-    #' @return A single-row `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
-    #'   - `cancelled_order_ids` (list): Vector of cancelled order IDs.
+    #' @return `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per cancelled order, and column:
+    #'   - `cancelled_order_id` (character): Cancelled order ID. Empty
+    #'     `data.table` (zero rows) if no orders matched.
     #'
     #' @examples
     #' \dontrun{
@@ -735,7 +747,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #'
     #' # Cancel all open orders for XBTUSDTM
     #' result <- ft$cancel_all(symbol = "XBTUSDTM")
-    #' print(result$cancelled_order_ids)
+    #' print(result$cancelled_order_id)
     #'
     #' # Cancel all open orders across all symbols
     #' result <- ft$cancel_all()
@@ -746,11 +758,19 @@ KucoinFuturesTrading <- R6::R6Class(
         method = "DELETE",
         query = list(symbol = symbol),
         .parser = function(data) {
-          ids <- data$cancelledOrderIds
-          data$cancelledOrderIds <- NULL
+          ids <- NULL
+          if (!is.null(data)) {
+            ids <- data$cancelledOrderIds
+            data$cancelledOrderIds <- NULL
+          }
+          if (is.null(ids) || length(ids) == 0) {
+            return(data.table::data.table()[])
+          }
           dt <- as_dt_row(data)
-          if (!is.null(ids) && length(ids) > 0) {
-            id_vals <- unlist(ids)
+          id_vals <- as.character(unlist(ids, use.names = FALSE))
+          if (nrow(dt) == 0L) {
+            dt <- data.table::data.table(cancelled_order_id = id_vals)
+          } else {
             dt <- dt[rep(1L, length(id_vals))]
             dt[, cancelled_order_id := id_vals]
           }
@@ -807,8 +827,10 @@ KucoinFuturesTrading <- R6::R6Class(
     #'
     #' @param symbol Character or NULL; filter by futures symbol. When NULL,
     #'   cancels all untriggered stop orders across all symbols.
-    #' @return A single-row `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
-    #'   - `cancelled_order_ids` (list): Vector of cancelled order IDs.
+    #' @return `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per cancelled order, and column:
+    #'   - `cancelled_order_id` (character): Cancelled order ID. Empty
+    #'     `data.table` (zero rows) if no orders matched.
     #'
     #' @examples
     #' \dontrun{
@@ -816,7 +838,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #'
     #' # Cancel all stop orders for XBTUSDTM
     #' result <- ft$cancel_all_stop_orders(symbol = "XBTUSDTM")
-    #' print(result$cancelled_order_ids)
+    #' print(result$cancelled_order_id)
     #'
     #' # Cancel all stop orders across all symbols
     #' result <- ft$cancel_all_stop_orders()
@@ -827,11 +849,19 @@ KucoinFuturesTrading <- R6::R6Class(
         method = "DELETE",
         query = list(symbol = symbol),
         .parser = function(data) {
-          ids <- data$cancelledOrderIds
-          data$cancelledOrderIds <- NULL
+          ids <- NULL
+          if (!is.null(data)) {
+            ids <- data$cancelledOrderIds
+            data$cancelledOrderIds <- NULL
+          }
+          if (is.null(ids) || length(ids) == 0) {
+            return(data.table::data.table()[])
+          }
           dt <- as_dt_row(data)
-          if (!is.null(ids) && length(ids) > 0) {
-            id_vals <- unlist(ids)
+          id_vals <- as.character(unlist(ids, use.names = FALSE))
+          if (nrow(dt) == 0L) {
+            dt <- data.table::data.table(cancelled_order_id = id_vals)
+          } else {
             dt <- dt[rep(1L, length(id_vals))]
             dt[, cancelled_order_id := id_vals]
           }

--- a/R/KucoinFuturesTrading.R
+++ b/R/KucoinFuturesTrading.R
@@ -599,7 +599,15 @@ KucoinFuturesTrading <- R6::R6Class(
         endpoint = paste0("/api/v1/orders/", orderId),
         method = "DELETE",
         .parser = function(data) {
-          return(as_dt_row(data))
+          ids <- data$cancelledOrderIds
+          data$cancelledOrderIds <- NULL
+          dt <- as_dt_row(data)
+          if (!is.null(ids) && length(ids) > 0) {
+            id_vals <- unlist(ids)
+            dt <- dt[rep(1L, length(id_vals))]
+            dt[, cancelled_order_id := id_vals]
+          }
+          return(dt[])
         }
       ))
     },
@@ -738,7 +746,15 @@ KucoinFuturesTrading <- R6::R6Class(
         method = "DELETE",
         query = list(symbol = symbol),
         .parser = function(data) {
-          return(as_dt_row(data))
+          ids <- data$cancelledOrderIds
+          data$cancelledOrderIds <- NULL
+          dt <- as_dt_row(data)
+          if (!is.null(ids) && length(ids) > 0) {
+            id_vals <- unlist(ids)
+            dt <- dt[rep(1L, length(id_vals))]
+            dt[, cancelled_order_id := id_vals]
+          }
+          return(dt[])
         }
       ))
     },
@@ -811,7 +827,15 @@ KucoinFuturesTrading <- R6::R6Class(
         method = "DELETE",
         query = list(symbol = symbol),
         .parser = function(data) {
-          return(as_dt_row(data))
+          ids <- data$cancelledOrderIds
+          data$cancelledOrderIds <- NULL
+          dt <- as_dt_row(data)
+          if (!is.null(ids) && length(ids) > 0) {
+            id_vals <- unlist(ids)
+            dt <- dt[rep(1L, length(id_vals))]
+            dt[, cancelled_order_id := id_vals]
+          }
+          return(dt[])
         }
       ))
     },

--- a/R/KucoinLending.R
+++ b/R/KucoinLending.R
@@ -439,7 +439,10 @@ KucoinLending <- R6::R6Class(
         endpoint = "/api/v3/purchase/orders",
         query = query,
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }
@@ -619,7 +622,10 @@ KucoinLending <- R6::R6Class(
         endpoint = "/api/v3/redeem/orders",
         query = query,
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }

--- a/R/KucoinLending.R
+++ b/R/KucoinLending.R
@@ -106,7 +106,21 @@ KucoinLending <- R6::R6Class(
     #'
     #' @param query Named list; optional filter. Supported keys:
     #'   - `currency` (character): Filter by currency (e.g., `"USDT"`).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with lending currency info.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per lending currency** and columns:
+    #'   - `currency` (character): Currency code (e.g. `"USDT"`).
+    #'   - `purchase_enable` (logical): Whether new purchases are accepted.
+    #'   - `redeem_enable` (logical): Whether redemptions are accepted.
+    #'   - `increment` (character): Smallest purchase-size step.
+    #'   - `min_purchase_size` (character): Minimum purchase amount.
+    #'   - `max_purchase_size` (character): Maximum purchase amount.
+    #'   - `interest_increment` (character): Smallest interest-rate step.
+    #'   - `min_interest_rate` (character): Minimum permitted interest rate.
+    #'   - `market_interest_rate` (character): Current market rate.
+    #'   - `max_interest_rate` (character): Maximum permitted interest rate.
+    #'   - `auto_purchase_enable` (logical): Whether auto-purchase is available.
+    #'
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{
@@ -166,9 +180,12 @@ KucoinLending <- R6::R6Class(
     #' ```
     #'
     #' @param currency Character; the currency to query (e.g., `"USDT"`).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per observation** and columns:
     #'   - `time` (character): Timestamp string (YYYYMMDDHHmm format).
     #'   - `market_interest_rate` (character): Market interest rate at that time.
+    #'
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{
@@ -426,7 +443,18 @@ KucoinLending <- R6::R6Class(
     #'   - `purchaseOrderNo` (character): Specific order number.
     #'   - `currentPage` (integer): Page number.
     #'   - `pageSize` (integer): Items per page.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with purchase order records.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per purchase order** and columns:
+    #'   - `currency` (character): Lent currency.
+    #'   - `purchase_order_no` (character): Purchase order number.
+    #'   - `purchase_size` (character): Amount lent.
+    #'   - `match_size` (character): Amount that has been matched.
+    #'   - `interest_rate` (character): Rate of the lending order.
+    #'   - `income_size` (character): Accrued income so far.
+    #'   - `apply_time` (POSIXct): Order creation time (millisecond epoch coerced).
+    #'   - `status` (character): Order status (e.g. `"DONE"`).
+    #'
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{
@@ -609,7 +637,17 @@ KucoinLending <- R6::R6Class(
     #'   - `redeemOrderNo` (character): Specific redemption order number.
     #'   - `currentPage` (integer): Page number.
     #'   - `pageSize` (integer): Items per page.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with redeem order records.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per redemption order** and columns:
+    #'   - `currency` (character): Redeemed currency.
+    #'   - `purchase_order_no` (character): Source purchase order.
+    #'   - `redeem_order_no` (character): Redemption order number.
+    #'   - `redeem_size` (character): Requested redeem amount.
+    #'   - `receipt_size` (character): Amount actually received.
+    #'   - `apply_time` (POSIXct): Order creation time (millisecond epoch coerced).
+    #'   - `status` (character): Order status (e.g. `"DONE"`).
+    #'
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinMarginData.R
+++ b/R/KucoinMarginData.R
@@ -106,7 +106,27 @@ KucoinMarginData <- R6::R6Class(
     #'
     #' @param query Named list; optional. Supported keys:
     #'   - `symbol` (character): Filter by specific symbol (e.g., `"BTC-USDT"`).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with margin symbol details.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per cross-margin symbol** and the following columns
+    #'   (subset shown — KuCoin may add fields):
+    #'   - `symbol` (character): Trading pair identifier (e.g. `"BTC-USDT"`).
+    #'   - `name` (character): Display name.
+    #'   - `enable_trading` (logical): Whether trading is enabled.
+    #'   - `market` (character): Market category (e.g. `"USDS"`).
+    #'   - `base_currency` (character): Base asset code.
+    #'   - `quote_currency` (character): Quote asset code.
+    #'   - `base_increment` (character): Minimum base-quantity step.
+    #'   - `base_min_size` (character): Minimum order base quantity.
+    #'   - `base_max_size` (character): Maximum order base quantity.
+    #'   - `quote_increment` (character): Minimum quote-quantity step.
+    #'   - `quote_min_size` (character): Minimum order quote quantity.
+    #'   - `quote_max_size` (character): Maximum order quote quantity.
+    #'   - `price_increment` (character): Minimum price step.
+    #'   - `fee_currency` (character): Currency charged for trading fees.
+    #'   - `price_limit_rate` (character): Maximum allowed price deviation.
+    #'   - `min_funds` (character): Minimum order notional.
+    #'
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{
@@ -180,7 +200,21 @@ KucoinMarginData <- R6::R6Class(
     #' }
     #' ```
     #'
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with isolated margin symbol details.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per isolated-margin pair** and columns:
+    #'   - `symbol` (character): Trading pair identifier.
+    #'   - `symbol_name` (character): Display name.
+    #'   - `base_currency` (character): Base asset code.
+    #'   - `quote_currency` (character): Quote asset code.
+    #'   - `max_leverage` (integer): Maximum leverage available.
+    #'   - `fl_debt_ratio` (character): Forced-liquidation debt ratio.
+    #'   - `trade_enable` (logical): Whether trading is enabled.
+    #'   - `base_borrow_enable` (logical): Base-currency borrow allowed.
+    #'   - `quote_borrow_enable` (logical): Quote-currency borrow allowed.
+    #'   - `base_transfer_in_enable` (logical): Base-currency transfer-in allowed.
+    #'   - `quote_transfer_in_enable` (logical): Quote-currency transfer-in allowed.
+    #'
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{
@@ -240,12 +274,16 @@ KucoinMarginData <- R6::R6Class(
     #' }
     #' ```
     #'
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row
-    #'   per supported currency, containing:
-    #' - `currency` (character): Supported margin currency (e.g., `"BTC"`, `"ETH"`).
-    #' - `max_leverage` (numeric): Maximum leverage.
-    #' - `warning_debt_ratio` (character): Warning debt ratio.
-    #' - `liq_debt_ratio` (character): Liquidation debt ratio.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per supported currency** (the `currencyList` array is
+    #'   exploded so each currency gets its own row with the config-level fields
+    #'   replicated). Columns:
+    #'   - `currency` (character): Supported margin currency (e.g. `"BTC"`).
+    #'   - `max_leverage` (integer): Maximum leverage.
+    #'   - `warning_debt_ratio` (character): Warning debt ratio.
+    #'   - `liq_debt_ratio` (character): Liquidation debt ratio.
+    #'
+    #'   Empty `currencyList` yields a zero-row `data.table` with this schema.
     #'
     #' @examples
     #' \dontrun{
@@ -259,9 +297,21 @@ KucoinMarginData <- R6::R6Class(
         endpoint = "/api/v1/margin/config",
         auth = FALSE,
         .parser = function(data) {
+          if (is.null(data) || length(data) == 0L) {
+            return(data.table::data.table()[])
+          }
+          # Treatment B: explode `currencyList` (array of plain strings) so
+          # each supported currency gets its own row with the config-level
+          # fields replicated.
           currencies <- as.character(unlist(data$currencyList))
           data$currencyList <- NULL
           dt <- as_dt_row(data)
+          if (length(currencies) == 0L) {
+            # Schema-stable zero-row table with the same column set.
+            dt[, currency := character()]
+            data.table::setcolorder(dt, c("currency", setdiff(names(dt), "currency")))
+            return(dt[0L][])
+          }
           dt <- dt[rep(1L, length(currencies))]
           dt[, currency := currencies]
           data.table::setcolorder(dt, c("currency", setdiff(names(dt), "currency")))
@@ -316,8 +366,16 @@ KucoinMarginData <- R6::R6Class(
     #'
     #' @param query Named list; optional. Supported keys:
     #'   - `currencyList` (character): Comma-separated currencies (e.g., `"BTC,ETH"`).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row per currency per tier.
-    #'   Columns: `currency`, `lower_limit`, `upper_limit`, `collateral_ratio`.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per (currency, tier) pair**. The nested
+    #'   `currencyList`/`items` arrays are cross-joined to a flat long table.
+    #'   Columns:
+    #'   - `currency` (character): Currency code.
+    #'   - `lower_limit` (character): Lower bound of the collateral range.
+    #'   - `upper_limit` (character): Upper bound of the collateral range.
+    #'   - `collateral_ratio` (character): Ratio applied in that range.
+    #'
+    #'   Empty response yields a zero-row `data.table` with this schema.
     #'
     #' @examples
     #' \dontrun{
@@ -410,7 +468,22 @@ KucoinMarginData <- R6::R6Class(
     #' @param query Named list; optional additional filters. Supported keys:
     #'   - `currency` (character): Currency filter (cross margin).
     #'   - `symbol` (character): Symbol filter (isolated margin only).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with risk limit details.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per currency** (cross) or **one row per (symbol, currency)
+    #'   pair** (isolated). Common columns:
+    #'   - `currency` (character): Currency code.
+    #'   - `borrow_max_amount` (character): Maximum borrowable amount.
+    #'   - `buy_max_amount` (character): Maximum buyable amount.
+    #'   - `hold_max_amount` (character): Maximum hold amount.
+    #'   - `borrow_coefficient` (character): Coefficient applied to borrows.
+    #'   - `margin_coefficient` (character): Coefficient applied to margin.
+    #'   - `precision` (integer): Decimal precision.
+    #'   - `borrow_min_amount` (character): Minimum borrowable amount.
+    #'   - `borrow_min_unit` (character): Minimum borrow step.
+    #'   - `borrow_enabled` (logical): Whether borrowing is currently enabled.
+    #'
+    #'   For isolated margin an extra `symbol` (character) column is present.
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinMarginData.R
+++ b/R/KucoinMarginData.R
@@ -297,8 +297,16 @@ KucoinMarginData <- R6::R6Class(
         endpoint = "/api/v1/margin/config",
         auth = FALSE,
         .parser = function(data) {
+          # Schema-stable empty `data.table` — same columns as a populated
+          # response, just zero rows. Documented in NEWS as the contract.
+          empty_dt <- data.table::data.table(
+            currency = character(),
+            max_leverage = integer(),
+            warning_debt_ratio = character(),
+            liq_debt_ratio = character()
+          )
           if (is.null(data) || length(data) == 0L) {
-            return(data.table::data.table()[])
+            return(empty_dt[])
           }
           # Treatment B: explode `currencyList` (array of plain strings) so
           # each supported currency gets its own row with the config-level
@@ -307,10 +315,7 @@ KucoinMarginData <- R6::R6Class(
           data$currencyList <- NULL
           dt <- as_dt_row(data)
           if (length(currencies) == 0L) {
-            # Schema-stable zero-row table with the same column set.
-            dt[, currency := character()]
-            data.table::setcolorder(dt, c("currency", setdiff(names(dt), "currency")))
-            return(dt[0L][])
+            return(empty_dt[])
           }
           dt <- dt[rep(1L, length(currencies))]
           dt[, currency := currencies]

--- a/R/KucoinMarginData.R
+++ b/R/KucoinMarginData.R
@@ -121,7 +121,10 @@ KucoinMarginData <- R6::R6Class(
         auth = FALSE,
         .parser = function(data) {
           # API wraps response in {timestamp, items} envelope
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }
@@ -345,9 +348,9 @@ KucoinMarginData <- R6::R6Class(
               for (cur in currencies) {
                 rows[[length(rows) + 1L]] <- data.table::data.table(
                   currency = cur,
-                  lower_limit = as.character(item$lowerLimit %||% NA),
-                  upper_limit = as.character(item$upperLimit %||% NA),
-                  collateral_ratio = as.character(item$collateralRatio %||% NA)
+                  lower_limit = as.character(if (is.null(item$lowerLimit)) NA else item$lowerLimit),
+                  upper_limit = as.character(if (is.null(item$upperLimit)) NA else item$upperLimit),
+                  collateral_ratio = as.character(if (is.null(item$collateralRatio)) NA else item$collateralRatio)
                 )
               }
             }

--- a/R/KucoinMarginTrading.R
+++ b/R/KucoinMarginTrading.R
@@ -790,7 +790,9 @@ KucoinMarginTrading <- R6::R6Class(
     #'
     #' @param currency Character; the currency to repay (e.g., `"USDT"`, `"BTC"`).
     #' @param size Numeric; the amount to repay.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with a single row and columns:
+    #'   - `timestamp` (POSIXct): Server-side acceptance time of the repay.
     #'   - `order_no` (character): Repayment order number.
     #'   - `actual_size` (character): Amount actually repaid.
     #'
@@ -817,7 +819,11 @@ KucoinMarginTrading <- R6::R6Class(
         endpoint = "/api/v3/margin/repay",
         method = "POST",
         body = body,
-        .parser = as_dt_row
+        .parser = function(data) {
+          dt <- as_dt_row(data)
+          coerce_cols(dt, "timestamp", ms_to_datetime)
+          return(dt[])
+        }
       ))
     },
 
@@ -880,7 +886,17 @@ KucoinMarginTrading <- R6::R6Class(
     #'   - `endTime` (integer): End timestamp in milliseconds.
     #'   - `currentPage` (integer): Page number.
     #'   - `pageSize` (integer): Items per page.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with borrow records.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per borrow record** and columns:
+    #'   - `order_no` (character): Borrow order number.
+    #'   - `symbol` (character): Trading pair (NA on cross-margin records).
+    #'   - `currency` (character): Borrowed currency.
+    #'   - `size` (character): Requested borrow amount.
+    #'   - `actual_size` (character): Amount actually borrowed.
+    #'   - `status` (character): Lifecycle status (e.g. `"DONE"`).
+    #'   - `created_time` (POSIXct): Borrow timestamp (millisecond epoch coerced).
+    #'
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{
@@ -958,7 +974,17 @@ KucoinMarginTrading <- R6::R6Class(
     #' ```
     #'
     #' @param query Named list; optional filter parameters. Same keys as `get_borrow_history()`.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with repay records.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per repay record** and columns:
+    #'   - `order_no` (character): Repay order number.
+    #'   - `symbol` (character): Trading pair (NA on cross-margin records).
+    #'   - `currency` (character): Repaid currency.
+    #'   - `size` (character): Requested repay amount.
+    #'   - `actual_size` (character): Amount actually repaid.
+    #'   - `status` (character): Lifecycle status.
+    #'   - `created_time` (POSIXct): Repay timestamp (millisecond epoch coerced).
+    #'
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{
@@ -1040,7 +1066,14 @@ KucoinMarginTrading <- R6::R6Class(
     #'   - `endTime` (integer): End timestamp in milliseconds.
     #'   - `currentPage` (integer): Page number.
     #'   - `pageSize` (integer): Items per page.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with interest records.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with **one row per interest record** and columns:
+    #'   - `currency` (character): Currency on which interest accrued.
+    #'   - `day_ratio` (character): Daily rate applied.
+    #'   - `interest_amount` (character): Interest charged in the period.
+    #'   - `created_time` (POSIXct): Accrual timestamp (millisecond epoch coerced).
+    #'
+    #'   Empty response yields an empty `data.table`.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinMarginTrading.R
+++ b/R/KucoinMarginTrading.R
@@ -893,7 +893,10 @@ KucoinMarginTrading <- R6::R6Class(
         endpoint = "/api/v3/margin/borrow",
         query = query,
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }
@@ -968,7 +971,10 @@ KucoinMarginTrading <- R6::R6Class(
         endpoint = "/api/v3/margin/repay",
         query = query,
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }
@@ -1047,7 +1053,10 @@ KucoinMarginTrading <- R6::R6Class(
         endpoint = "/api/v3/margin/interest",
         query = query,
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }
@@ -1122,7 +1131,10 @@ KucoinMarginTrading <- R6::R6Class(
         endpoint = "/api/v3/margin/borrowRate",
         query = query,
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }

--- a/R/KucoinMarketData.R
+++ b/R/KucoinMarketData.R
@@ -138,11 +138,16 @@ KucoinMarketData <- R6::R6Class(
     #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
     #'   - `ann_id` (integer): Announcement identifier.
     #'   - `ann_title` (character): Announcement title.
-    #'   - `ann_type` (character): Category tag for the announcement.
-    #'     KuCoin returns `annType` as an array; the parser explodes to
-    #'     long format so an announcement tagged with N types appears in
-    #'     N rows with the other columns replicated. `NA_character_` if
-    #'     KuCoin returned no tags for an announcement.
+    #'   - `ann_type` (character): `;`-separated category tags for the
+    #'     announcement. KuCoin returns `annType` as an array; the parser
+    #'     collapses it to a single character column via the shared
+    #'     `collapse_string_array_fields()` helper (Treatment A —
+    #'     matches the cross-package convention used by alpaca/binance
+    #'     for plain-string arrays). Filter with
+    #'     `grepl("latest-announcements", ann_type, fixed = TRUE)`;
+    #'     recover the vector via
+    #'     `strsplit(ann_type, ";", fixed = TRUE)[[1]]`. `NA_character_`
+    #'     if KuCoin returned no tags.
     #'   - `ann_desc` (character): Short description text.
     #'   - `c_time` (POSIXct): Creation datetime (coerced from epoch milliseconds).
     #'   - `language` (character): Language code.
@@ -172,42 +177,20 @@ KucoinMarketData <- R6::R6Class(
           if (length(pages) == 0) {
             return(data.table::data.table()[])
           }
-          # Extract annType arrays before flattening to avoid list-columns
-          ann_types_list <- list()
-          idx <- 0L
-          for (page in pages) {
-            for (item in page) {
-              idx <- idx + 1L
-              types <- item[["annType"]]
-              if (is.null(types) || length(types) == 0) {
-                ann_types_list[[idx]] <- NA_character_
-              } else {
-                ann_types_list[[idx]] <- as.character(unlist(types))
-              }
-              item[["annType"]] <- NULL
-            }
-          }
-          # Remove annType from items before flatten_pages
+          # Treatment A: `annType` is an array of plain strings (e.g.
+          # `c("latest-announcements", "new-listings")`). Collapse to a
+          # single `;`-separated character column via the shared helper
+          # so we keep one row per announcement (no list-column, no row
+          # multiplication). Matches the cross-package convention used
+          # by `alpaca`/`binance` for `permissions`, `order_types`, etc.
           pages_clean <- lapply(pages, function(page) {
-            lapply(page, function(item) {
-              item[["annType"]] <- NULL
-              return(item)
-            })
+            lapply(page, collapse_string_array_fields, "annType")
           })
           dt <- flatten_pages(pages_clean)
           if (nrow(dt) == 0) {
             return(dt[])
           }
-          if ("c_time" %in% names(dt)) {
-            dt[, c_time := ms_to_datetime(c_time)]
-          }
-          # Expand ann_type to long format: one row per type tag
-          dt[, .ann_idx := .I]
-          types_dt <- data.table::rbindlist(lapply(seq_along(ann_types_list), function(i) {
-            data.table::data.table(.ann_idx = i, ann_type = ann_types_list[[i]])
-          }))
-          dt <- dt[types_dt, on = ".ann_idx"]
-          dt[, .ann_idx := NULL]
+          coerce_cols(dt, "c_time", ms_to_datetime)
           return(dt[])
         },
         page_size = page_size,

--- a/R/KucoinMarketData.R
+++ b/R/KucoinMarketData.R
@@ -165,10 +165,45 @@ KucoinMarketData <- R6::R6Class(
         query = query,
         auth = FALSE,
         .parser = function(pages) {
-          dt <- flatten_pages(pages)
-          if (nrow(dt) > 0 && "c_time" %in% names(dt)) {
+          if (length(pages) == 0) {
+            return(data.table::data.table()[])
+          }
+          # Extract annType arrays before flattening to avoid list-columns
+          ann_types_list <- list()
+          idx <- 0L
+          for (page in pages) {
+            for (item in page) {
+              idx <- idx + 1L
+              types <- item[["annType"]]
+              if (is.null(types) || length(types) == 0) {
+                ann_types_list[[idx]] <- NA_character_
+              } else {
+                ann_types_list[[idx]] <- as.character(unlist(types))
+              }
+              item[["annType"]] <- NULL
+            }
+          }
+          # Remove annType from items before flatten_pages
+          pages_clean <- lapply(pages, function(page) {
+            lapply(page, function(item) {
+              item[["annType"]] <- NULL
+              return(item)
+            })
+          })
+          dt <- flatten_pages(pages_clean)
+          if (nrow(dt) == 0) {
+            return(dt[])
+          }
+          if ("c_time" %in% names(dt)) {
             dt[, c_time := ms_to_datetime(c_time)]
           }
+          # Expand ann_type to long format: one row per type tag
+          dt[, .ann_idx := .I]
+          types_dt <- data.table::rbindlist(lapply(seq_along(ann_types_list), function(i) {
+            data.table::data.table(.ann_idx = i, ann_type = ann_types_list[[i]])
+          }))
+          dt <- dt[types_dt, on = ".ann_idx"]
+          dt[, .ann_idx := NULL]
           return(dt[])
         },
         page_size = page_size,

--- a/R/KucoinMarketData.R
+++ b/R/KucoinMarketData.R
@@ -1275,8 +1275,9 @@ KucoinMarketData <- R6::R6Class(
     #'   `"1min"`, `"3min"`, `"5min"`, `"15min"`, `"30min"`,
     #'   `"1hour"`, `"2hour"`, `"4hour"`, `"6hour"`, `"8hour"`, `"12hour"`,
     #'   `"1day"`, `"1week"`, `"1month"`. Default `"15min"`.
-    #' @param from POSIXct; start time (default 24 hours ago).
-    #' @param to POSIXct; end time (default now).
+    #' @param from POSIXct or NULL; start time. When both `from` and `to` are
+    #'   `NULL`, the API returns up to 1500 most recent candles.
+    #' @param to POSIXct or NULL; end time.
     #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
     #'   - `datetime` (POSIXct): Candle open datetime.
     #'   - `open` (numeric): Opening price.
@@ -1290,7 +1291,7 @@ KucoinMarketData <- R6::R6Class(
     #' \dontrun{
     #' market <- KucoinMarketData$new()
     #'
-    #' # Last 24 hours of 15-minute candles
+    #' # Most recent candles (up to 1500)
     #' klines <- market$get_klines("BTC-USDT")
     #' print(head(klines))
     #'
@@ -1306,8 +1307,8 @@ KucoinMarketData <- R6::R6Class(
     get_klines = function(
       symbol,
       timeframe = "15min",
-      from = lubridate::now() - lubridate::dhours(24),
-      to = lubridate::now()
+      from = NULL,
+      to = NULL
     ) {
       return(kucoin_fetch_klines(
         symbol = symbol,

--- a/R/KucoinMarketData.R
+++ b/R/KucoinMarketData.R
@@ -922,7 +922,7 @@ KucoinMarketData <- R6::R6Class(
     #' 1. **Validation**: Ensures `size` is 20 or 100.
     #' 2. **Request**: GET with size embedded in endpoint path.
     #' 3. **Parsing**: Calls `parse_orderbook()` to convert nested bid/ask arrays
-    #'    into a long-format `data.table` with `side`, `price`, and `size` columns.
+    #'    into a long-format `data.table` with `side`, `level`, `price`, and `size` columns.
     #'
     #' ### API Endpoint
     #' `GET https://api.kucoin.com/api/v1/market/orderbook/level2_{20|100}`
@@ -962,6 +962,8 @@ KucoinMarketData <- R6::R6Class(
     #'   - `time` (POSIXct): Server timestamp (coerced from epoch milliseconds).
     #'   - `sequence` (character): Order book sequence number.
     #'   - `side` (character): `"bid"` or `"ask"`.
+    #'   - `level` (integer): 1-indexed depth from top-of-book within the side
+    #'     (`level == 1` is best bid / best ask).
     #'   - `price` (numeric): Price level.
     #'   - `size` (numeric): Size at that price.
     #'
@@ -969,9 +971,9 @@ KucoinMarketData <- R6::R6Class(
     #' \dontrun{
     #' market <- KucoinMarketData$new()
     #' ob <- market$get_part_orderbook("BTC-USDT", size = 20)
-    #' bids <- ob[side == "bid"]
-    #' asks <- ob[side == "ask"]
-    #' print(paste("Best bid:", bids$price[1], "Best ask:", asks$price[1]))
+    #' best_bid <- ob[side == "bid" & level == 1L]
+    #' best_ask <- ob[side == "ask" & level == 1L]
+    #' print(paste("Best bid:", best_bid$price, "Best ask:", best_ask$price))
     #' }
     get_part_orderbook = function(symbol, size = 20) {
       if (!size %in% c(20, 100)) {
@@ -1038,6 +1040,8 @@ KucoinMarketData <- R6::R6Class(
     #'   - `time` (POSIXct): Server timestamp (coerced from epoch milliseconds).
     #'   - `sequence` (character): Order book sequence number.
     #'   - `side` (character): `"bid"` or `"ask"`.
+    #'   - `level` (integer): 1-indexed depth from top-of-book within the side
+    #'     (`level == 1` is best bid / best ask).
     #'   - `price` (numeric): Price level.
     #'   - `size` (numeric): Size at that price.
     #'

--- a/R/KucoinMarketData.R
+++ b/R/KucoinMarketData.R
@@ -138,7 +138,11 @@ KucoinMarketData <- R6::R6Class(
     #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
     #'   - `ann_id` (integer): Announcement identifier.
     #'   - `ann_title` (character): Announcement title.
-    #'   - `ann_type` (list): Category tags as character vector.
+    #'   - `ann_type` (character): Category tag for the announcement.
+    #'     KuCoin returns `annType` as an array; the parser explodes to
+    #'     long format so an announcement tagged with N types appears in
+    #'     N rows with the other columns replicated. `NA_character_` if
+    #'     KuCoin returned no tags for an announcement.
     #'   - `ann_desc` (character): Short description text.
     #'   - `c_time` (POSIXct): Creation datetime (coerced from epoch milliseconds).
     #'   - `language` (character): Language code.

--- a/R/KucoinOcoOrders.R
+++ b/R/KucoinOcoOrders.R
@@ -740,10 +740,11 @@ KucoinOcoOrders <- R6::R6Class(
     #' \dontrun{
     #' oco <- KucoinOcoOrders$new()
     #'
-    #' # Get full OCO order details with sub-orders
+    #' # Get full OCO order details with sub-orders. The `orders` array
+    #' # is exploded to long format, so each sub-order is its own row
+    #' # with `sub_order_*` columns alongside the parent OCO fields.
     #' details <- oco$get_order_detail_by_id("674c40d38b4b2f00073deef3")
-    #' print(details$status)
-    #' print(details$orders)
+    #' details[, .(order_id, status, sub_order_id, sub_order_side, sub_order_price)]
     #' }
     get_order_detail_by_id = function(orderId) {
       return(private$.request(

--- a/R/KucoinOcoOrders.R
+++ b/R/KucoinOcoOrders.R
@@ -254,9 +254,11 @@ KucoinOcoOrders <- R6::R6Class(
     #'
     #' @param orderId Character; the KuCoin-assigned OCO order ID to cancel
     #'   (e.g., `"674c40d38b4b2f00073deef3"`).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
-    #'   - `cancelled_order_ids` (list): List of cancelled order IDs including the
-    #'     parent OCO and its sub-orders.
+    #' @return `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per cancelled order, and column:
+    #'   - `cancelled_order_id` (character): Cancelled order ID (the parent
+    #'     OCO and each of its sub-orders appear as separate rows). Empty
+    #'     `data.table` if nothing matched.
     #'
     #' @examples
     #' \dontrun{
@@ -264,18 +266,26 @@ KucoinOcoOrders <- R6::R6Class(
     #'
     #' # Cancel a specific OCO order
     #' result <- oco$cancel_order_by_id("674c40d38b4b2f00073deef3")
-    #' print(result$cancelled_order_ids)
+    #' print(result$cancelled_order_id)
     #' }
     cancel_order_by_id = function(orderId) {
       return(private$.request(
         endpoint = paste0("/api/v3/oco/order/", orderId),
         method = "DELETE",
         .parser = function(data) {
-          ids <- data$cancelledOrderIds
-          data$cancelledOrderIds <- NULL
+          ids <- NULL
+          if (!is.null(data)) {
+            ids <- data$cancelledOrderIds
+            data$cancelledOrderIds <- NULL
+          }
+          if (is.null(ids) || length(ids) == 0) {
+            return(data.table::data.table()[])
+          }
           dt <- as_dt_row(data)
-          if (!is.null(ids) && length(ids) > 0) {
-            id_vals <- unlist(ids)
+          id_vals <- as.character(unlist(ids, use.names = FALSE))
+          if (nrow(dt) == 0L) {
+            dt <- data.table::data.table(cancelled_order_id = id_vals)
+          } else {
             dt <- dt[rep(1L, length(id_vals))]
             dt[, cancelled_order_id := id_vals]
           }
@@ -335,9 +345,11 @@ KucoinOcoOrders <- R6::R6Class(
     #'
     #' @param clientOid Character; the client-assigned order ID used when placing
     #'   the OCO order (e.g., `"my-bot-oco-001"`).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
-    #'   - `cancelled_order_ids` (list): List of cancelled order IDs including the
-    #'     parent OCO and its sub-orders.
+    #' @return `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per cancelled order, and column:
+    #'   - `cancelled_order_id` (character): Cancelled order ID (the parent
+    #'     OCO and each of its sub-orders appear as separate rows). Empty
+    #'     `data.table` if nothing matched.
     #'
     #' @examples
     #' \dontrun{
@@ -345,18 +357,26 @@ KucoinOcoOrders <- R6::R6Class(
     #'
     #' # Cancel by client-assigned ID
     #' result <- oco$cancel_order_by_client_oid("my-bot-oco-001")
-    #' print(result$cancelled_order_ids)
+    #' print(result$cancelled_order_id)
     #' }
     cancel_order_by_client_oid = function(clientOid) {
       return(private$.request(
         endpoint = paste0("/api/v3/oco/client-order/", clientOid),
         method = "DELETE",
         .parser = function(data) {
-          ids <- data$cancelledOrderIds
-          data$cancelledOrderIds <- NULL
+          ids <- NULL
+          if (!is.null(data)) {
+            ids <- data$cancelledOrderIds
+            data$cancelledOrderIds <- NULL
+          }
+          if (is.null(ids) || length(ids) == 0) {
+            return(data.table::data.table()[])
+          }
           dt <- as_dt_row(data)
-          if (!is.null(ids) && length(ids) > 0) {
-            id_vals <- unlist(ids)
+          id_vals <- as.character(unlist(ids, use.names = FALSE))
+          if (nrow(dt) == 0L) {
+            dt <- data.table::data.table(cancelled_order_id = id_vals)
+          } else {
             dt <- dt[rep(1L, length(id_vals))]
             dt[, cancelled_order_id := id_vals]
           }
@@ -420,8 +440,10 @@ KucoinOcoOrders <- R6::R6Class(
     #'   - `symbol` (character): Optional. Trading pair to filter by (e.g., `"BTC-USDT"`).
     #'   - `orderIds` (character): Optional. Comma-separated order IDs to cancel specifically.
     #'   If empty, all active OCO orders are cancelled.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
-    #'   - `cancelled_order_ids` (list): List of all cancelled order IDs.
+    #' @return `data.table` (or `promise<data.table>` if constructed with
+    #'   `async = TRUE`) with one row per cancelled order, and column:
+    #'   - `cancelled_order_id` (character): Cancelled order ID. Empty
+    #'     `data.table` if no active OCO orders matched the filter.
     #'
     #' @examples
     #' \dontrun{
@@ -429,7 +451,7 @@ KucoinOcoOrders <- R6::R6Class(
     #'
     #' # Cancel all OCO orders for BTC-USDT
     #' result <- oco$cancel_all(query = list(symbol = "BTC-USDT"))
-    #' print(result$cancelled_order_ids)
+    #' print(result$cancelled_order_id)
     #'
     #' # Cancel all OCO orders (no filter)
     #' result <- oco$cancel_all()
@@ -440,11 +462,19 @@ KucoinOcoOrders <- R6::R6Class(
         method = "DELETE",
         query = query,
         .parser = function(data) {
-          ids <- data$cancelledOrderIds
-          data$cancelledOrderIds <- NULL
+          ids <- NULL
+          if (!is.null(data)) {
+            ids <- data$cancelledOrderIds
+            data$cancelledOrderIds <- NULL
+          }
+          if (is.null(ids) || length(ids) == 0) {
+            return(data.table::data.table()[])
+          }
           dt <- as_dt_row(data)
-          if (!is.null(ids) && length(ids) > 0) {
-            id_vals <- unlist(ids)
+          id_vals <- as.character(unlist(ids, use.names = FALSE))
+          if (nrow(dt) == 0L) {
+            dt <- data.table::data.table(cancelled_order_id = id_vals)
+          } else {
             dt <- dt[rep(1L, length(id_vals))]
             dt[, cancelled_order_id := id_vals]
           }
@@ -693,8 +723,18 @@ KucoinOcoOrders <- R6::R6Class(
     #'   - `client_oid` (character): Client-assigned order identifier.
     #'   - `order_time` (POSIXct): Order creation datetime (coerced from epoch milliseconds).
     #'   - `status` (character): Overall OCO order status.
-    #'   - `orders` (list): List of sub-order details, each containing `id`, `symbol`,
-    #'     `side`, `price`, `size`, `status`, and optionally `stop_price`.
+    #'
+    #'   The nested `orders` array (one entry per sub-order — typically the
+    #'   limit leg + the stop-limit leg) is exploded to long format: the
+    #'   parent OCO row is replicated once per sub-order, and each sub-order's
+    #'   fields are added with a `sub_order_` prefix. Typical sub-order columns:
+    #'   - `sub_order_id` (character)
+    #'   - `sub_order_symbol` (character)
+    #'   - `sub_order_side` (character)
+    #'   - `sub_order_price` (character)
+    #'   - `sub_order_size` (character)
+    #'   - `sub_order_status` (character)
+    #'   - `sub_order_stop_price` (character; only present on the stop leg)
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinOcoOrders.R
+++ b/R/KucoinOcoOrders.R
@@ -270,7 +270,17 @@ KucoinOcoOrders <- R6::R6Class(
       return(private$.request(
         endpoint = paste0("/api/v3/oco/order/", orderId),
         method = "DELETE",
-        .parser = as_dt_row
+        .parser = function(data) {
+          ids <- data$cancelledOrderIds
+          data$cancelledOrderIds <- NULL
+          dt <- as_dt_row(data)
+          if (!is.null(ids) && length(ids) > 0) {
+            id_vals <- unlist(ids)
+            dt <- dt[rep(1L, length(id_vals))]
+            dt[, cancelled_order_id := id_vals]
+          }
+          return(dt[])
+        }
       ))
     },
 
@@ -341,7 +351,17 @@ KucoinOcoOrders <- R6::R6Class(
       return(private$.request(
         endpoint = paste0("/api/v3/oco/client-order/", clientOid),
         method = "DELETE",
-        .parser = as_dt_row
+        .parser = function(data) {
+          ids <- data$cancelledOrderIds
+          data$cancelledOrderIds <- NULL
+          dt <- as_dt_row(data)
+          if (!is.null(ids) && length(ids) > 0) {
+            id_vals <- unlist(ids)
+            dt <- dt[rep(1L, length(id_vals))]
+            dt[, cancelled_order_id := id_vals]
+          }
+          return(dt[])
+        }
       ))
     },
 
@@ -419,7 +439,17 @@ KucoinOcoOrders <- R6::R6Class(
         endpoint = "/api/v3/oco/orders",
         method = "DELETE",
         query = query,
-        .parser = as_dt_row
+        .parser = function(data) {
+          ids <- data$cancelledOrderIds
+          data$cancelledOrderIds <- NULL
+          dt <- as_dt_row(data)
+          if (!is.null(ids) && length(ids) > 0) {
+            id_vals <- unlist(ids)
+            dt <- dt[rep(1L, length(id_vals))]
+            dt[, cancelled_order_id := id_vals]
+          }
+          return(dt[])
+        }
       ))
     },
 
@@ -679,11 +709,22 @@ KucoinOcoOrders <- R6::R6Class(
       return(private$.request(
         endpoint = paste0("/api/v3/oco/order/details/", orderId),
         .parser = function(data) {
+          orders <- data$orders
+          data$orders <- NULL
           dt <- as_dt_row(data)
           if ("order_time" %in% names(dt)) {
             dt[, order_time := ms_to_datetime(order_time)]
           }
-          expected <- c("order_id", "symbol", "client_oid", "order_time", "status", "orders")
+          # Expand orders to long format: one row per sub-order
+          if (!is.null(orders) && length(orders) > 0) {
+            orders_dt <- as_dt_list(orders)
+            order_names <- names(orders_dt)
+            new_names <- paste0("sub_order_", order_names)
+            data.table::setnames(orders_dt, order_names, new_names)
+            dt <- dt[rep(1L, nrow(orders_dt))]
+            dt <- cbind(dt, orders_dt)
+          }
+          expected <- c("order_id", "symbol", "client_oid", "order_time", "status")
           data.table::setcolorder(dt, intersect(expected, names(dt)))
           return(dt[])
         }

--- a/R/KucoinOcoOrders.R
+++ b/R/KucoinOcoOrders.R
@@ -837,7 +837,10 @@ KucoinOcoOrders <- R6::R6Class(
         endpoint = "/api/v3/oco/orders",
         query = query,
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }

--- a/R/KucoinStopOrders.R
+++ b/R/KucoinStopOrders.R
@@ -366,8 +366,11 @@ KucoinStopOrders <- R6::R6Class(
     #' ```
     #'
     #' @param orderId Character; the KuCoin-assigned stop order ID to cancel.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with column:
-    #'   - `cancelled_order_ids` (character): Vector of cancelled stop order IDs.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with one row per cancelled stop order (Treatment B — long format):
+    #'   - `cancelled_order_id` (character): KuCoin order ID of a cancelled stop order.
+    #'   Returns an empty `data.table` if no stop orders matched (per the
+    #'   "empty response -> empty data.table" cross-package convention).
     #'
     #' @examples
     #' \dontrun{
@@ -375,13 +378,32 @@ KucoinStopOrders <- R6::R6Class(
     #'
     #' # Cancel a specific stop order
     #' result <- stop$cancel_order_by_id("vs8hoo8q2ceshiue003b67c0")
-    #' print(result$cancelled_order_ids)
+    #' print(result$cancelled_order_id)
     #' }
     cancel_order_by_id = function(orderId) {
       return(private$.request(
         endpoint = paste0("/api/v1/stop-order/", orderId),
         method = "DELETE",
-        .parser = as_dt_row
+        .parser = function(data) {
+          ids <- NULL
+          if (!is.null(data)) {
+            ids <- data$cancelledOrderIds
+            data$cancelledOrderIds <- NULL
+          }
+          if (is.null(ids) || length(ids) == 0) {
+            return(data.table::data.table()[])
+          }
+          dt <- as_dt_row(data)
+          id_vals <- as.character(unlist(ids, use.names = FALSE))
+          if (nrow(dt) == 0L) {
+            dt <- data.table::data.table(cancelled_order_id = id_vals)
+          } else {
+            dt <- dt[rep(1L, length(id_vals))]
+            dt[, cancelled_order_id := id_vals]
+          }
+          data.table::setcolorder(dt, intersect("cancelled_order_id", names(dt)))
+          return(dt[])
+        }
       ))
     },
 
@@ -432,7 +454,8 @@ KucoinStopOrders <- R6::R6Class(
     #' @param clientOid Character; the client-assigned order ID used when placing the stop order.
     #' @param symbol Character; trading pair symbol (e.g., `"BTC-USDT"`). Required to
     #'   disambiguate client OIDs across different trading pairs.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with a single row:
     #'   - `cancelled_order_id` (character): The KuCoin order ID of the cancelled stop order.
     #'   - `client_oid` (character): The client-assigned order ID that was cancelled.
     #'
@@ -449,7 +472,14 @@ KucoinStopOrders <- R6::R6Class(
         endpoint = "/api/v1/stop-order/cancelOrderByClientOid",
         method = "DELETE",
         query = list(clientOid = clientOid, symbol = symbol),
-        .parser = as_dt_row
+        .parser = function(data) {
+          dt <- as_dt_row(data)
+          data.table::setcolorder(
+            dt,
+            intersect(c("cancelled_order_id", "client_oid"), names(dt))
+          )
+          return(dt[])
+        }
       ))
     },
 
@@ -505,8 +535,11 @@ KucoinStopOrders <- R6::R6Class(
     #'   - `symbol` (character): Trading pair to filter by (e.g., `"BTC-USDT"`).
     #'   - `tradeType` (character): Trade type, typically `"TRADE"` for spot.
     #'   - `orderIds` (character): Comma-separated list of specific stop order IDs to cancel.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with column:
-    #'   - `cancelled_order_ids` (character): Vector of cancelled stop order IDs.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with one row per cancelled stop order (Treatment B — long format):
+    #'   - `cancelled_order_id` (character): KuCoin order ID of a cancelled stop order.
+    #'   Returns an empty `data.table` if no stop orders matched the filters
+    #'   (per the "empty response -> empty data.table" cross-package convention).
     #'
     #' @examples
     #' \dontrun{
@@ -514,18 +547,37 @@ KucoinStopOrders <- R6::R6Class(
     #'
     #' # Cancel all stop orders for BTC-USDT
     #' result <- stop$cancel_all(query = list(symbol = "BTC-USDT"))
-    #' print(result$cancelled_order_ids)
+    #' print(result$cancelled_order_id)
     #'
     #' # Cancel all stop orders (no filter)
     #' result <- stop$cancel_all()
-    #' print(result$cancelled_order_ids)
+    #' print(result$cancelled_order_id)
     #' }
     cancel_all = function(query = list()) {
       return(private$.request(
         endpoint = "/api/v1/stop-order/cancel",
         method = "DELETE",
         query = query,
-        .parser = as_dt_row
+        .parser = function(data) {
+          ids <- NULL
+          if (!is.null(data)) {
+            ids <- data$cancelledOrderIds
+            data$cancelledOrderIds <- NULL
+          }
+          if (is.null(ids) || length(ids) == 0) {
+            return(data.table::data.table()[])
+          }
+          dt <- as_dt_row(data)
+          id_vals <- as.character(unlist(ids, use.names = FALSE))
+          if (nrow(dt) == 0L) {
+            dt <- data.table::data.table(cancelled_order_id = id_vals)
+          } else {
+            dt <- dt[rep(1L, length(id_vals))]
+            dt[, cancelled_order_id := id_vals]
+          }
+          data.table::setcolorder(dt, intersect("cancelled_order_id", names(dt)))
+          return(dt[])
+        }
       ))
     },
 
@@ -597,7 +649,8 @@ KucoinStopOrders <- R6::R6Class(
     #' ```
     #'
     #' @param orderId Character; the KuCoin-assigned stop order ID to retrieve.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row containing order details. Key columns include:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with a single row containing order details (no list columns). Key columns include:
     #'   - `id` (character): Stop order identifier.
     #'   - `symbol` (character): Trading pair (e.g., `"BTC-USDT"`).
     #'   - `type` (character): Order type (`"limit"` or `"market"`).
@@ -607,6 +660,9 @@ KucoinStopOrders <- R6::R6Class(
     #'   - `stop_price` (character): Trigger price for the stop order.
     #'   - `stop` (character): Stop direction (`"loss"` or `"entry"`).
     #'   - `created_at` (POSIXct): Creation datetime (coerced from epoch milliseconds).
+    #'   - `order_time` (POSIXct): Order placement datetime (coerced from epoch nanoseconds).
+    #'   - `stop_trigger_time` (POSIXct): Trigger datetime if triggered (coerced from
+    #'     epoch milliseconds), `NA` if not yet triggered.
     #'
     #' @examples
     #' \dontrun{
@@ -622,13 +678,24 @@ KucoinStopOrders <- R6::R6Class(
         endpoint = paste0("/api/v1/stop-order/", orderId),
         .parser = function(data) {
           dt <- as_dt_row(data)
-          if ("created_at" %in% names(dt)) {
-            dt[, created_at := ms_to_datetime(created_at)]
-          }
+          coerce_cols(dt, c("created_at", "stop_trigger_time"), ms_to_datetime)
+          coerce_cols(dt, "order_time", ns_to_datetime)
           data.table::setcolorder(
             dt,
             intersect(
-              c("id", "symbol", "type", "side", "price", "size", "stop_price", "stop", "created_at"),
+              c(
+                "id",
+                "symbol",
+                "type",
+                "side",
+                "price",
+                "size",
+                "stop_price",
+                "stop",
+                "created_at",
+                "order_time",
+                "stop_trigger_time"
+              ),
               names(dt)
             )
           )
@@ -710,7 +777,8 @@ KucoinStopOrders <- R6::R6Class(
     #' @param clientOid Character; the client-assigned order ID to search for.
     #' @param symbol Character; trading pair symbol (e.g., `"BTC-USDT"`). Required to
     #'   scope the search to a specific trading pair.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one or more rows of order details. Key columns include:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with one row per matching stop order (no list columns). Key columns include:
     #'   - `id` (character): Stop order identifier.
     #'   - `symbol` (character): Trading pair (e.g., `"BTC-USDT"`).
     #'   - `type` (character): Order type (`"limit"` or `"market"`).
@@ -720,6 +788,10 @@ KucoinStopOrders <- R6::R6Class(
     #'   - `stop_price` (character): Trigger price for the stop order.
     #'   - `client_oid` (character): The client-assigned order ID.
     #'   - `created_at` (POSIXct): Creation datetime (coerced from epoch milliseconds).
+    #'   - `order_time` (POSIXct): Order placement datetime (coerced from epoch nanoseconds).
+    #'   - `stop_trigger_time` (POSIXct): Trigger datetime if triggered (coerced from
+    #'     epoch milliseconds), `NA` if not yet triggered.
+    #'   Returns an empty `data.table` if no stop orders match.
     #'
     #' @examples
     #' \dontrun{
@@ -735,18 +807,33 @@ KucoinStopOrders <- R6::R6Class(
         endpoint = "/api/v1/stop-order/queryOrderByClientOid",
         query = list(clientOid = clientOid, symbol = symbol),
         .parser = function(data) {
+          if (is.null(data) || length(data) == 0) {
+            return(data.table::data.table()[])
+          }
+          dt <- data.table::data.table()
           if (is.list(data) && !is.null(data[[1]]) && is.list(data[[1]])) {
             dt <- data.table::rbindlist(lapply(data, as_dt_row), fill = TRUE)
           } else {
             dt <- as_dt_row(data)
           }
-          if ("created_at" %in% names(dt)) {
-            dt[, created_at := ms_to_datetime(created_at)]
-          }
+          coerce_cols(dt, c("created_at", "stop_trigger_time"), ms_to_datetime)
+          coerce_cols(dt, "order_time", ns_to_datetime)
           data.table::setcolorder(
             dt,
             intersect(
-              c("id", "symbol", "type", "side", "price", "size", "stop_price", "client_oid", "created_at"),
+              c(
+                "id",
+                "symbol",
+                "type",
+                "side",
+                "price",
+                "size",
+                "stop_price",
+                "client_oid",
+                "created_at",
+                "order_time",
+                "stop_trigger_time"
+              ),
               names(dt)
             )
           )
@@ -841,8 +928,9 @@ KucoinStopOrders <- R6::R6Class(
     #'   - `pageSize` (integer): Number of results per page (default 50, max 100).
     #'   - `tradeType` (character): Trade type, typically `"TRADE"` for spot.
     #'   - `orderIds` (character): Comma-separated list of specific stop order IDs.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with zero or more rows. Returns an empty `data.table` if no
-    #'   stop orders match the query. Key columns include:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`)
+    #'   with one row per stop order (no list columns). Returns an empty `data.table`
+    #'   if no stop orders match the query. Key columns include:
     #'   - `id` (character): Stop order identifier.
     #'   - `symbol` (character): Trading pair (e.g., `"BTC-USDT"`).
     #'   - `type` (character): Order type (`"limit"` or `"market"`).
@@ -853,6 +941,9 @@ KucoinStopOrders <- R6::R6Class(
     #'   - `stop` (character): Stop direction (`"loss"` or `"entry"`).
     #'   - `time_in_force` (character): Time-in-force policy.
     #'   - `created_at` (POSIXct): Creation datetime (coerced from epoch milliseconds).
+    #'   - `order_time` (POSIXct): Order placement datetime (coerced from epoch nanoseconds).
+    #'   - `stop_trigger_time` (POSIXct): Trigger datetime if triggered (coerced from
+    #'     epoch milliseconds), `NA` if not yet triggered.
     #'
     #' @examples
     #' \dontrun{
@@ -889,9 +980,8 @@ KucoinStopOrders <- R6::R6Class(
             return(data.table::data.table()[])
           }
           dt <- data.table::rbindlist(lapply(items, as_dt_row), fill = TRUE)
-          if ("created_at" %in% names(dt)) {
-            dt[, created_at := ms_to_datetime(created_at)]
-          }
+          coerce_cols(dt, c("created_at", "stop_trigger_time"), ms_to_datetime)
+          coerce_cols(dt, "order_time", ns_to_datetime)
           data.table::setcolorder(
             dt,
             intersect(
@@ -905,7 +995,9 @@ KucoinStopOrders <- R6::R6Class(
                 "stop_price",
                 "stop",
                 "time_in_force",
-                "created_at"
+                "created_at",
+                "order_time",
+                "stop_trigger_time"
               ),
               names(dt)
             )

--- a/R/KucoinStopOrders.R
+++ b/R/KucoinStopOrders.R
@@ -881,7 +881,10 @@ KucoinStopOrders <- R6::R6Class(
         endpoint = "/api/v1/stop-order",
         query = query,
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }

--- a/R/KucoinSubAccount.R
+++ b/R/KucoinSubAccount.R
@@ -431,7 +431,13 @@ KucoinSubAccount <- R6::R6Class(
               lapply(accounts, as_dt_row),
               fill = TRUE
             )
-            acct_dt[, account_type := to_snake_case(field_name)]
+            # Map raw response field names back to semantic labels
+            # (`mainAccounts` -> `"main"`, `tradeAccounts` -> `"trade"`,
+            # `marginAccounts` -> `"margin"`, future-proofed for any
+            # other `<x>Accounts` shape). This keeps the documented
+            # filter idiom `balances[account_type == "trade"]` working
+            # across schema additions.
+            acct_dt[, account_type := sub("_?accounts?$", "", to_snake_case(field_name))]
             acct_dt[, sub_user_id := sub_id]
             acct_dt[, sub_name := sub_name]
             rows[[length(rows) + 1L]] <- acct_dt
@@ -613,7 +619,13 @@ KucoinSubAccount <- R6::R6Class(
                   lapply(accounts, as_dt_row),
                   fill = TRUE
                 )
-                acct_dt[, account_type := to_snake_case(field_name)]
+                # Map raw response field names back to semantic labels
+                # (`mainAccounts` -> `"main"`, `tradeAccounts` -> `"trade"`,
+                # `marginAccounts` -> `"margin"`, future-proofed for any
+                # other `<x>Accounts` shape). This keeps the documented
+                # filter idiom `balances[account_type == "trade"]` working
+                # across schema additions.
+                acct_dt[, account_type := sub("_?accounts?$", "", to_snake_case(field_name))]
                 acct_dt[, sub_user_id := sub_id]
                 acct_dt[, sub_name := sub_name]
                 all_rows[[length(all_rows) + 1L]] <- acct_dt

--- a/R/KucoinSubAccount.R
+++ b/R/KucoinSubAccount.R
@@ -412,22 +412,28 @@ KucoinSubAccount <- R6::R6Class(
         endpoint = paste0("/api/v1/sub-accounts/", subUserId),
         query = list(includeBaseAmount = tolower(as.character(includeBaseAmount))),
         .parser = function(data) {
-          account_types <- c("mainAccounts", "tradeAccounts", "marginAccounts")
-          type_labels <- c("main", "trade", "margin")
           rows <- list()
+          sub_id <- as.character(data$subUserId)
+          sub_name <- as.character(data$subName)
 
-          for (i in seq_along(account_types)) {
-            accounts <- data[[account_types[i]]]
-            if (is.null(accounts) || length(accounts) == 0L) {
+          # Dynamically detect account type arrays by checking for currency/balance fields
+          for (field_name in names(data)) {
+            accounts <- data[[field_name]]
+            if (!is.list(accounts) || length(accounts) == 0L) {
               next
             }
+            first <- accounts[[1]]
+            if (!is.list(first) || !all(c("currency", "balance") %in% names(first))) {
+              next
+            }
+
             acct_dt <- data.table::rbindlist(
               lapply(accounts, as_dt_row),
               fill = TRUE
             )
-            acct_dt[, account_type := type_labels[i]]
-            acct_dt[, sub_user_id := as.character(data$subUserId)]
-            acct_dt[, sub_name := as.character(data$subName)]
+            acct_dt[, account_type := to_snake_case(field_name)]
+            acct_dt[, sub_user_id := sub_id]
+            acct_dt[, sub_name := sub_name]
             rows[[length(rows) + 1L]] <- acct_dt
           }
 
@@ -436,18 +442,8 @@ KucoinSubAccount <- R6::R6Class(
           }
 
           dt <- data.table::rbindlist(rows, fill = TRUE)
-          data.table::setcolorder(
-            dt,
-            c(
-              "sub_user_id",
-              "sub_name",
-              "account_type",
-              "currency",
-              "balance",
-              "available",
-              "holds"
-            )
-          )
+          expected <- c("sub_user_id", "sub_name", "account_type", "currency", "balance", "available", "holds")
+          data.table::setcolorder(dt, intersect(expected, names(dt)))
           return(dt[])
         }
       ))
@@ -595,27 +591,31 @@ KucoinSubAccount <- R6::R6Class(
             return(data.table::data.table()[])
           }
 
-          account_types <- c("mainAccounts", "tradeAccounts", "marginAccounts")
-          type_labels <- c("main", "trade", "margin")
           all_rows <- list()
 
           for (page in pages) {
             for (item in page) {
-              sub_id <- item$subUserId
-              sub_name <- item$subName
+              sub_id <- as.character(item$subUserId)
+              sub_name <- as.character(item$subName)
 
-              for (i in seq_along(account_types)) {
-                accounts <- item[[account_types[i]]]
-                if (is.null(accounts) || length(accounts) == 0L) {
+              # Dynamically detect account type arrays
+              for (field_name in names(item)) {
+                accounts <- item[[field_name]]
+                if (!is.list(accounts) || length(accounts) == 0L) {
                   next
                 }
+                first <- accounts[[1]]
+                if (!is.list(first) || !all(c("currency", "balance") %in% names(first))) {
+                  next
+                }
+
                 acct_dt <- data.table::rbindlist(
                   lapply(accounts, as_dt_row),
                   fill = TRUE
                 )
-                acct_dt[, account_type := type_labels[i]]
-                acct_dt[, sub_user_id := as.character(sub_id)]
-                acct_dt[, sub_name := as.character(sub_name)]
+                acct_dt[, account_type := to_snake_case(field_name)]
+                acct_dt[, sub_user_id := sub_id]
+                acct_dt[, sub_name := sub_name]
                 all_rows[[length(all_rows) + 1L]] <- acct_dt
               }
             }
@@ -626,18 +626,8 @@ KucoinSubAccount <- R6::R6Class(
           }
 
           dt <- data.table::rbindlist(all_rows, fill = TRUE)
-          data.table::setcolorder(
-            dt,
-            c(
-              "sub_user_id",
-              "sub_name",
-              "account_type",
-              "currency",
-              "balance",
-              "available",
-              "holds"
-            )
-          )
+          expected <- c("sub_user_id", "sub_name", "account_type", "currency", "balance", "available", "holds")
+          data.table::setcolorder(dt, intersect(expected, names(dt)))
           return(dt[])
         }
       ))

--- a/R/KucoinTrading.R
+++ b/R/KucoinTrading.R
@@ -573,7 +573,9 @@ KucoinTrading <- R6::R6Class(
         method = "DELETE",
         query = list(symbol = symbol),
         .parser = function(data) {
-          return(data.table::data.table(order_id = as.character(data$orderId %||% orderId))[])
+          return(data.table::data.table(
+            order_id = as.character(if (is.null(data$orderId)) orderId else data$orderId)
+          )[])
         }
       ))
     },
@@ -636,7 +638,9 @@ KucoinTrading <- R6::R6Class(
         method = "DELETE",
         query = list(symbol = symbol),
         .parser = function(data) {
-          return(data.table::data.table(client_oid = as.character(data$clientOid %||% clientOid))[])
+          return(data.table::data.table(
+            client_oid = as.character(if (is.null(data$clientOid)) clientOid else data$clientOid)
+          )[])
         }
       ))
     },
@@ -829,8 +833,16 @@ KucoinTrading <- R6::R6Class(
             }
             return(data.table::data.table(symbol = data, status = "succeed")[])
           }
-          succeed <- as.character(unlist(data$succeedSymbols %||% list()))
-          failed <- as.character(unlist(data$failedSymbols %||% list()))
+          succeed_raw <- list()
+          if (!is.null(data$succeedSymbols)) {
+            succeed_raw <- data$succeedSymbols
+          }
+          failed_raw <- list()
+          if (!is.null(data$failedSymbols)) {
+            failed_raw <- data$failedSymbols
+          }
+          succeed <- as.character(unlist(succeed_raw))
+          failed <- as.character(unlist(failed_raw))
           if (length(succeed) == 0 && length(failed) == 0) {
             return(data.table::data.table(symbol = character(), status = character())[])
           }
@@ -1177,7 +1189,10 @@ KucoinTrading <- R6::R6Class(
           endAt = endAt
         ),
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }
@@ -1268,7 +1283,10 @@ KucoinTrading <- R6::R6Class(
       return(private$.request(
         endpoint = "/api/v1/hf/orders/active/symbols",
         .parser = function(data) {
-          symbols <- data$symbols %||% data
+          symbols <- data
+          if (!is.null(data$symbols)) {
+            symbols <- data$symbols
+          }
           if (is.null(symbols) || length(symbols) == 0) {
             return(data.table::data.table(symbols = character())[])
           }
@@ -1506,7 +1524,10 @@ KucoinTrading <- R6::R6Class(
           lastId = lastId
         ),
         .parser = function(data) {
-          items <- data$items %||% data
+          items <- data
+          if (!is.null(data$items)) {
+            items <- data$items
+          }
           if (is.null(items) || length(items) == 0) {
             return(data.table::data.table()[])
           }

--- a/R/KucoinTrading.R
+++ b/R/KucoinTrading.R
@@ -912,7 +912,7 @@ KucoinTrading <- R6::R6Class(
     #' ```
     #'
     #' @param orderId Character; the KuCoin order ID.
-    #' @param symbol Character; trading pair (e.g., `"BTC-USDT"`).
+    #' @param symbol Character (optional); trading pair (e.g., `"BTC-USDT"`). Defaults to `NULL`.
     #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with full order details
     #'   including `created_at` and `last_updated_at` (POSIXct) if timestamps are present.
     #'
@@ -922,17 +922,17 @@ KucoinTrading <- R6::R6Class(
     #' order <- trading$get_order_by_id("671124f9365ccb00073debd4", "BTC-USDT")
     #' print(order)
     #' }
-    get_order_by_id = function(orderId, symbol) {
+    get_order_by_id = function(orderId, symbol = NULL) {
       if (!is.character(orderId) || !nzchar(orderId)) {
         rlang::abort("Parameter 'orderId' must be a non-empty string.")
       }
-      if (!verify_symbol(symbol)) {
+      if (!is.null(symbol) && !verify_symbol(symbol)) {
         rlang::abort("Parameter 'symbol' must be a valid ticker.")
       }
 
       return(private$.request(
         endpoint = paste0("/api/v1/hf/orders/", orderId),
-        query = list(symbol = symbol),
+        query = if (!is.null(symbol)) list(symbol = symbol) else list(),
         .parser = function(data) {
           dt <- as_dt_row(data)
           if ("created_at" %in% names(dt)) {

--- a/R/KucoinTransfer.R
+++ b/R/KucoinTransfer.R
@@ -135,7 +135,7 @@ KucoinTransfer <- R6::R6Class(
     #' @param fromAccountTag Character or NULL; symbol for ISOLATED/ISOLATED_V2 source accounts (e.g., `"BTC-USDT"`).
     #' @param toUserId Character or NULL; destination user ID (required for `"PARENT_TO_SUB"` transfers).
     #' @param toAccountTag Character or NULL; symbol for ISOLATED/ISOLATED_V2 destination accounts (e.g., `"BTC-USDT"`).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row and columns:
     #'   - `order_id` (character): The transfer order identifier.
     #'
     #' @examples
@@ -292,7 +292,7 @@ KucoinTransfer <- R6::R6Class(
     #'   `"ISOLATED"`, `"MARGIN_V2"`, `"ISOLATED_V2"`.
     #' @param tag Character or NULL; trading pair symbol required for `"ISOLATED"`
     #'   account type (e.g., `"BTC-USDT"`).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row and columns:
     #'   - `currency` (character): Currency code.
     #'   - `balance` (character): Total funds in the account.
     #'   - `available` (character): Funds available to withdraw or trade.
@@ -330,11 +330,11 @@ KucoinTransfer <- R6::R6Class(
         .parser = function(data) {
           dt <- as_dt_row(data)
           if (nrow(dt) == 0L) {
-            return(dt)
+            return(dt[])
           }
           expected <- c("currency", "balance", "available", "holds", "transferable")
           data.table::setcolorder(dt, intersect(expected, names(dt)))
-          return(dt)
+          return(dt[])
         }
       ))
     }

--- a/R/KucoinWithdrawal.R
+++ b/R/KucoinWithdrawal.R
@@ -125,7 +125,7 @@ KucoinWithdrawal <- R6::R6Class(
     #' @param isInner Logical or NULL; if `TRUE`, this is an internal KuCoin transfer (no on-chain fee).
     #' @param remark Character or NULL; optional remark for the withdrawal.
     #' @param feeDeductType Character or NULL; fee deduction type: `"INTERNAL"` or `"EXTERNAL"`.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row and columns:
     #'   - `withdrawal_id` (character): The unique withdrawal identifier.
     #'
     #' @examples
@@ -258,8 +258,9 @@ KucoinWithdrawal <- R6::R6Class(
     #' ```
     #'
     #' @param withdrawalId Character; the unique withdrawal ID to cancel.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
-    #'   - `withdrawal_id` (character): The cancelled withdrawal ID.
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row and columns:
+    #'   - `withdrawal_id` (character): The cancelled withdrawal ID (echoed from the input
+    #'     since KuCoin returns `null` data on a successful cancel).
     #'
     #' @examples
     #' \dontrun{
@@ -347,7 +348,7 @@ KucoinWithdrawal <- R6::R6Class(
     #' @param currency Character; currency code (e.g., `"BTC"`, `"USDT"`).
     #' @param chain Character or NULL; blockchain network identifier (e.g., `"eth"`, `"trx"`).
     #'   When NULL, returns quotas for the default chain.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row and columns:
     #'   - `currency` (character): Currency code.
     #'   - `limit_btc_amount` (character): Daily withdrawal limit in BTC equivalent.
     #'   - `used_btc_amount` (character): BTC equivalent already withdrawn today.
@@ -485,7 +486,7 @@ KucoinWithdrawal <- R6::R6Class(
     #' @param endAt Integer or NULL; end timestamp in milliseconds (inclusive).
     #' @param page_size Integer; number of results per page (default 50, max 500).
     #' @param max_pages Numeric; maximum number of pages to fetch (default `Inf` for all pages).
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row per withdrawal and columns:
     #'   - `currency` (character): Withdrawn currency code.
     #'   - `chain` (character): Blockchain network used.
     #'   - `status` (character): Withdrawal status.
@@ -495,10 +496,10 @@ KucoinWithdrawal <- R6::R6Class(
     #'   - `amount` (character): Withdrawal amount.
     #'   - `fee` (character): Withdrawal fee charged.
     #'   - `wallet_tx_id` (character): On-chain transaction hash.
-    #'   - `updated_at` (numeric): Last update timestamp in milliseconds.
+    #'   - `created_at` (POSIXct): Creation datetime (coerced from epoch milliseconds).
+    #'   - `updated_at` (POSIXct): Last update datetime (coerced from epoch milliseconds).
     #'   - `remark` (character): Optional remark.
     #'   - `arrears` (logical): Whether the withdrawal is in arrears.
-    #'   - `created_at` (POSIXct): Creation datetime (coerced from epoch milliseconds).
     #'
     #'   Returns an empty `data.table` if no withdrawals match the filters.
     #'
@@ -548,9 +549,7 @@ KucoinWithdrawal <- R6::R6Class(
           if (nrow(dt) == 0L) {
             return(dt[])
           }
-          if ("created_at" %in% names(dt)) {
-            dt[, created_at := ms_to_datetime(created_at)]
-          }
+          coerce_cols(dt, c("created_at", "updated_at"), ms_to_datetime)
           data.table::setcolorder(
             dt,
             intersect(
@@ -636,7 +635,7 @@ KucoinWithdrawal <- R6::R6Class(
     #' ```
     #'
     #' @param withdrawalId Character; the unique withdrawal ID.
-    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with columns:
+    #' @return `data.table` (or `promise<data.table>` if constructed with `async = TRUE`) with one row and columns:
     #'   - `id` (character): Withdrawal ID.
     #'   - `currency` (character): Currency code.
     #'   - `chain_id` (character): Chain identifier (e.g., `"trx"`, `"eth"`).

--- a/R/helpers_parse.R
+++ b/R/helpers_parse.R
@@ -84,9 +84,15 @@ as_dt_list <- function(items) {
 #' @keywords internal
 #' @noRd
 ms_to_datetime <- function(ms) {
-  if (is.null(ms) || all(is.na(ms))) {
+  if (is.null(ms)) {
     return(lubridate::NA_POSIXct_)
   }
+  # Don't short-circuit on `all(is.na(ms))` — returning the length-1
+  # `NA_POSIXct_` from there would get recycled by `data.table::set()`
+  # into the existing column's storage type rather than replacing the
+  # column with a POSIXct one. Always return a vector matching input
+  # length so columns documented as POSIXct actually land as POSIXct,
+  # even when every upstream value is missing. Matches binance/alpaca.
   return(lubridate::as_datetime(as.numeric(ms) / 1000))
 }
 
@@ -99,10 +105,107 @@ ms_to_datetime <- function(ms) {
 #' @keywords internal
 #' @noRd
 ns_to_datetime <- function(ns) {
-  if (is.null(ns) || all(is.na(ns))) {
+  if (is.null(ns)) {
     return(lubridate::NA_POSIXct_)
   }
+  # Same all-NA shape contract as `ms_to_datetime`.
   return(lubridate::as_datetime(as.numeric(ns) / 1e9))
+}
+
+#' Collapse a Plain-String Array Field on a Single Record
+#'
+#' Walks the named list `x` and replaces any named field whose value is a
+#' length >= 1 list of plain character strings (or atomic character vector)
+#' with a single semicolon-separated character scalar. Used to apply
+#' Treatment A (`;`-collapse for arrays of plain strings) so we get one row
+#' per entity instead of a list column or an exploded long row count.
+#'
+#' Ported from the same-named helper in binance/alpaca. Separator is `;`
+#' rather than `,` because semicolons are far less likely to appear inside
+#' any of the joined values themselves. Recover with
+#' `strsplit(x, ";", fixed = TRUE)[[1]]`.
+#'
+#' NA-safe: scalar `NA_character_` input is preserved as `NA_character_`;
+#' mixed vectors like `c("real", NA)` filter NAs before joining (without
+#' this, `paste(c("real", NA), collapse = ";")` would produce the literal
+#' string `"real;NA"`); all-NA vectors round-trip to `NA_character_`.
+#'
+#' If any individual value contains a literal `;`, emits a once-per-session
+#' warning so we catch silent corruption.
+#'
+#' @param x A named list representing a single API record.
+#' @param fields Character vector; names of fields to collapse.
+#' @return The same named list with the matching fields collapsed in place.
+#'
+#' @keywords internal
+#' @noRd
+collapse_string_array_fields <- function(x, fields) {
+  for (nm in fields) {
+    val <- x[[nm]]
+    if (is.null(val) || length(val) == 0L) {
+      x[[nm]] <- NA_character_
+      next
+    }
+    if (is.list(val)) {
+      val <- unlist(val, use.names = FALSE)
+    }
+    if (is.atomic(val) && length(val) >= 1L) {
+      val_chr <- as.character(val)
+      val_chr <- val_chr[!is.na(val_chr)]
+      if (length(val_chr) == 0L) {
+        x[[nm]] <- NA_character_
+        next
+      }
+      if (any(grepl(";", val_chr, fixed = TRUE), na.rm = TRUE)) {
+        rlang::warn(
+          paste0(
+            "Field `",
+            nm,
+            "` contains a literal `;` which collides with the ",
+            "collapse separator. Joining anyway; downstream code that splits ",
+            "on `;` will see corrupted values. Please report this so we can ",
+            "switch the separator for this field."
+          ),
+          .frequency = "once",
+          .frequency_id = paste0("collapse_sep_collision_", nm)
+        )
+      }
+      x[[nm]] <- paste(val_chr, collapse = ";")
+    }
+  }
+  return(x)
+}
+
+#' Apply a Function to Selected Columns of a data.table by Reference
+#'
+#' Walks `cols`; for each that exists in `dt`, replaces it in place with the
+#' result of `fn(dt[[col]])`. Columns that are not in `dt` are silently
+#' skipped — useful for endpoints whose payload sometimes omits optional
+#' fields. A zero-row `dt` short-circuits.
+#'
+#' Replaces the repeated boilerplate of
+#' `if (nrow(dt) > 0 && "X" %in% names(dt)) { dt[, X := fn(X)] }`
+#' with `coerce_cols(dt, "X", fn)`. Modifies `dt` by reference via
+#' `data.table::set()`. Same shape and contract as the same-named helper
+#' in binance/alpaca.
+#'
+#' @param dt A [data.table::data.table].
+#' @param cols Character; candidate column names to convert.
+#' @param fn Function; takes a column vector, returns the coerced vector.
+#' @return `dt`, modified by reference and returned invisibly.
+#'
+#' @keywords internal
+#' @noRd
+coerce_cols <- function(dt, cols, fn) {
+  if (nrow(dt) == 0L) {
+    return(invisible(dt))
+  }
+  for (col in cols) {
+    if (col %in% names(dt)) {
+      data.table::set(dt, j = col, value = fn(dt[[col]]))
+    }
+  }
+  return(invisible(dt))
 }
 
 #' Process Orderbook Data into a data.table

--- a/R/helpers_parse.R
+++ b/R/helpers_parse.R
@@ -211,12 +211,15 @@ coerce_cols <- function(dt, cols, fn) {
 #' Process Orderbook Data into a data.table
 #'
 #' Transforms the bids/asks arrays from a KuCoin orderbook response into a
-#' tidy [data.table::data.table] with `side`, `price`, and `size` columns.
+#' tidy [data.table::data.table]. KuCoin returns best price first, so the
+#' `level` column captures the 1-indexed depth from top-of-book (1 = best
+#' bid / best ask); the position would otherwise be lost after any sort or
+#' filter. Matches the cross-package long-format convention.
 #'
 #' @param data List; the parsed KuCoin orderbook response data containing
 #'   `bids`, `asks`, `time`, and `sequence` fields.
 #' @return A [data.table::data.table] with columns: `time`, `sequence`,
-#'   `side`, `price`, `size`.
+#'   `side`, `level`, `price`, `size`.
 #'
 #' @keywords internal
 #' @noRd
@@ -225,13 +228,19 @@ parse_orderbook <- function(data) {
     if (is.null(entries) || length(entries) == 0) {
       return(data.table::data.table(
         side = character(),
+        level = integer(),
         price = numeric(),
         size = numeric()
       )[])
     }
-    # Each entry is a list of two strings: [price, quantity].
+    # Each entry is a list of two strings: [price, quantity]. KuCoin
+    # returns best price first, so the 1-indexed position is depth from
+    # top-of-book (`level = 1` is the best bid / best ask). Matches the
+    # cross-package long-format convention (alpaca / binance both add a
+    # position-index column where the source order is meaningful).
     return(data.table::data.table(
       side = side_label,
+      level = seq_along(entries),
       price = as.numeric(vapply(entries, `[[`, character(1), 1L)),
       size = as.numeric(vapply(entries, `[[`, character(1), 2L))
     )[])
@@ -243,7 +252,7 @@ parse_orderbook <- function(data) {
 
   result[, time := ms_to_datetime(data$time)]
   result[, sequence := as.character(data$sequence)]
-  data.table::setcolorder(result, c("time", "sequence", "side", "price", "size"))
+  data.table::setcolorder(result, c("time", "sequence", "side", "level", "price", "size"))
 
   return(result[])
 }

--- a/R/helpers_request.R
+++ b/R/helpers_request.R
@@ -43,7 +43,7 @@ fetch_server_time_ms <- function(base_url) {
       "Failed to fetch server time: KuCoin API error ",
       parsed$code,
       ": ",
-      parsed$msg %||% "No message."
+      if (is.null(parsed$msg)) "No message." else parsed$msg
     ))
   }
   return(as.numeric(parsed$data))
@@ -241,7 +241,7 @@ parse_kucoin_response <- function(resp) {
       "KuCoin API error ",
       parsed$code,
       ": ",
-      parsed$msg %||% "No error message provided."
+      if (is.null(parsed$msg)) "No error message provided." else parsed$msg
     ))
   }
 
@@ -316,8 +316,14 @@ kucoin_paginate <- function(
           accumulator[[length(accumulator) + 1L]] <<- page_items
         }
 
-        current <- data$currentPage %||% page
-        total <- data$totalPage %||% 1L
+        current <- page
+        if (!is.null(data$currentPage)) {
+          current <- data$currentPage
+        }
+        total <- 1L
+        if (!is.null(data$totalPage)) {
+          total <- data$totalPage
+        }
 
         if (page < total && page < max_pages) {
           return(fetch_page(page + 1L))

--- a/R/helpers_request.R
+++ b/R/helpers_request.R
@@ -316,10 +316,6 @@ kucoin_paginate <- function(
           accumulator[[length(accumulator) + 1L]] <<- page_items
         }
 
-        current <- page
-        if (!is.null(data$currentPage)) {
-          current <- data$currentPage
-        }
         total <- 1L
         if (!is.null(data$totalPage)) {
           total <- data$totalPage

--- a/R/impl_klines.R
+++ b/R/impl_klines.R
@@ -36,8 +36,8 @@ kucoin_timeframe_map <- list(
 kucoin_fetch_klines <- function(
   symbol,
   timeframe = "15min",
-  from = lubridate::now("UTC") - lubridate::dhours(24),
-  to = lubridate::now("UTC"),
+  from = NULL,
+  to = NULL,
   .req_fn,
   is_async = FALSE
 ) {
@@ -49,6 +49,33 @@ kucoin_fetch_klines <- function(
       paste(names(kucoin_timeframe_map), collapse = ", ")
     ))
   }
+
+  # When no time range specified, make a single request without startAt/endAt.
+  # The KuCoin API returns up to 1500 most recent candles.
+  if (is.null(from) && is.null(to)) {
+    fetch_no_range <- function() {
+      return(.req_fn(
+        endpoint = "/api/v1/market/candles",
+        method = "GET",
+        query = list(type = timeframe, symbol = symbol),
+        auth = FALSE,
+        .parser = parse_klines
+      ))
+    }
+    if (is_async) {
+      return(fetch_no_range()$then(function(dt) {
+        if (nrow(dt) > 0L) data.table::setorder(dt, datetime)
+        return(dt[])
+      }))
+    }
+    dt <- fetch_no_range()
+    if (nrow(dt) > 0L) data.table::setorder(dt, datetime)
+    return(dt[])
+  }
+
+  # Fill in whichever bound is missing
+  if (is.null(to)) to <- lubridate::now("UTC")
+  if (is.null(from)) from <- lubridate::now("UTC") - lubridate::dhours(24)
 
   timeframe_seconds <- kucoin_timeframe_map[[timeframe]]
   from_s <- as.integer(as.numeric(from))

--- a/R/impl_klines.R
+++ b/R/impl_klines.R
@@ -64,18 +64,26 @@ kucoin_fetch_klines <- function(
     }
     if (is_async) {
       return(fetch_no_range()$then(function(dt) {
-        if (nrow(dt) > 0L) data.table::setorder(dt, datetime)
+        if (nrow(dt) > 0L) {
+          data.table::setorder(dt, datetime)
+        }
         return(dt[])
       }))
     }
     dt <- fetch_no_range()
-    if (nrow(dt) > 0L) data.table::setorder(dt, datetime)
+    if (nrow(dt) > 0L) {
+      data.table::setorder(dt, datetime)
+    }
     return(dt[])
   }
 
   # Fill in whichever bound is missing
-  if (is.null(to)) to <- lubridate::now("UTC")
-  if (is.null(from)) from <- lubridate::now("UTC") - lubridate::dhours(24)
+  if (is.null(to)) {
+    to <- lubridate::now("UTC")
+  }
+  if (is.null(from)) {
+    from <- lubridate::now("UTC") - lubridate::dhours(24)
+  }
 
   timeframe_seconds <- kucoin_timeframe_map[[timeframe]]
   from_s <- as.integer(as.numeric(from))

--- a/man/KucoinAccount.Rd
+++ b/man/KucoinAccount.Rd
@@ -430,9 +430,7 @@ Verified: 2026-02-01
 \item \code{remark} (character): Key label.
 \item \code{api_key} (character): API key ID.
 \item \code{api_version} (integer): Key version.
-\item \code{permission} (character): Comma-separated permissions e.g. \code{"General,Spot"}.
-Already a single string from KuCoin (not a JSON array); recover the
-vector with \code{strsplit(dt$permission[1], ",", fixed = TRUE)[[1]]}.
+\item \code{permission} (character): Comma-separated permissions e.g. \code{"General,Spot"} (already a single string from KuCoin, not a JSON array; recover the vector with \code{strsplit(dt$permission[1], ",", fixed = TRUE)[[1]]}).
 \item \code{ip_whitelist} (character): Allowed IPs (comma-separated string).
 \item \code{created_at} (POSIXct): Key creation datetime (coerced from epoch milliseconds).
 \item \code{uid} (numeric): User ID.

--- a/man/KucoinAccount.Rd
+++ b/man/KucoinAccount.Rd
@@ -327,7 +327,7 @@ Verified: 2026-02-01
 }
 
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row and columns:
 \itemize{
 \item \code{level} (integer): VIP tier.
 \item \code{sub_quantity} (integer): Total sub-accounts.
@@ -425,14 +425,16 @@ Verified: 2026-02-01
 }
 
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row and columns:
 \itemize{
 \item \code{remark} (character): Key label.
 \item \code{api_key} (character): API key ID.
 \item \code{api_version} (integer): Key version.
 \item \code{permission} (character): Comma-separated permissions e.g. \code{"General,Spot"}.
-\item \code{ip_whitelist} (character): Allowed IPs.
-\item \code{created_at} (numeric): Epoch ms.
+Already a single string from KuCoin (not a JSON array); recover the
+vector with \code{strsplit(dt$permission[1], ",", fixed = TRUE)[[1]]}.
+\item \code{ip_whitelist} (character): Allowed IPs (comma-separated string).
+\item \code{created_at} (POSIXct): Key creation datetime (coerced from epoch milliseconds).
 \item \code{uid} (numeric): User ID.
 \item \code{is_master} (logical): TRUE if master account key.
 }
@@ -854,9 +856,13 @@ Verified: 2026-02-01
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with
+one row per currency (Treatment B). The account-level summary fields
+(\code{total_asset_of_quote_currency}, \code{total_liability_of_quote_currency}, \code{debt_ratio},
+\code{status}) are replicated on every row so the caller never needs a sibling method.
+Columns (subset; the exact set depends on the KuCoin payload):
 \itemize{
-\item \code{currency} (character): Currency code.
+\item \code{currency} (character): Currency code (e.g. \code{"USDT"}, \code{"BTC"}).
 \item \code{total} (character): Total balance.
 \item \code{available} (character): Available balance.
 \item \code{hold} (character): Amount on hold.
@@ -866,9 +872,13 @@ Verified: 2026-02-01
 \item \code{max_borrow_size} (character): Maximum borrowable amount.
 \item \code{borrow_enabled} (logical): Whether borrowing is enabled.
 \item \code{transfer_in_enabled} (logical): Whether transfer-in is enabled.
+\item \code{total_asset_of_quote_currency} (character): Account-level total asset (repeated).
+\item \code{total_liability_of_quote_currency} (character): Account-level total liability (repeated).
+\item \code{debt_ratio} (character): Account-level debt ratio (repeated).
+\item \code{status} (character): Account-level status (repeated).
+}
 
 Returns an empty \code{data.table} if no margin accounts exist.
-}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -993,12 +1003,42 @@ Verified: 2026-02-01
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
-Columns are flattened from the nested response and may include:
-\code{symbol} (character), \code{status} (character), \code{debt_ratio} (character),
-and nested \verb{base_asset.*} and \verb{quote_asset.*} fields (currency, total, available, hold,
-liability, liability_principal, liability_interest, max_borrow_size). Returns an empty \code{data.table}
-if no isolated margin accounts exist.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with
+one row per isolated-margin pair (Treatment B) and the nested \code{baseAsset} / \code{quoteAsset}
+objects flattened wide-prefix (Treatment C). The account-level fields
+\code{total_asset_of_quote_currency}, \code{total_liability_of_quote_currency}, and \code{timestamp}
+are replicated on every row.
+Columns:
+\itemize{
+\item \code{symbol} (character): Isolated pair symbol (e.g. \code{"BTC-USDT"}).
+\item \code{status} (character): Account status (e.g. \code{"EFFECTIVE"}).
+\item \code{debt_ratio} (character): Liability-to-asset ratio.
+\item \code{base_asset_currency} (character): Base asset code.
+\item \code{base_asset_borrow_enabled} (logical): Whether borrowing the base asset is allowed.
+\item \code{base_asset_transfer_in_enabled} (logical): Whether transferring the base asset in is allowed.
+\item \code{base_asset_liability} (character): Total base-asset liability.
+\item \code{base_asset_liability_principal} (character): Base-asset liability principal.
+\item \code{base_asset_liability_interest} (character): Base-asset liability interest.
+\item \code{base_asset_total} (character): Base-asset total balance.
+\item \code{base_asset_available} (character): Base-asset available balance.
+\item \code{base_asset_hold} (character): Base-asset amount on hold.
+\item \code{base_asset_max_borrow_size} (character): Base-asset maximum borrowable.
+\item \code{quote_asset_currency} (character): Quote asset code.
+\item \code{quote_asset_borrow_enabled} (logical): Whether borrowing the quote asset is allowed.
+\item \code{quote_asset_transfer_in_enabled} (logical): Whether transferring the quote asset in is allowed.
+\item \code{quote_asset_liability} (character): Total quote-asset liability.
+\item \code{quote_asset_liability_principal} (character): Quote-asset liability principal.
+\item \code{quote_asset_liability_interest} (character): Quote-asset liability interest.
+\item \code{quote_asset_total} (character): Quote-asset total balance.
+\item \code{quote_asset_available} (character): Quote-asset available balance.
+\item \code{quote_asset_hold} (character): Quote-asset amount on hold.
+\item \code{quote_asset_max_borrow_size} (character): Quote-asset maximum borrowable.
+\item \code{total_asset_of_quote_currency} (character): Account-level total asset (repeated).
+\item \code{total_liability_of_quote_currency} (character): Account-level total liability (repeated).
+\item \code{timestamp} (POSIXct): Snapshot timestamp (repeated).
+}
+
+Returns an empty \code{data.table} if no isolated-margin pairs exist.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinDeposit.Rd
+++ b/man/KucoinDeposit.Rd
@@ -238,7 +238,7 @@ deposit addresses (e.g., Lightning Network).}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row and columns:
 \itemize{
 \item \code{address} (character): The generated deposit address.
 \item \code{memo} (character): Memo/tag for the address (empty string if not applicable).
@@ -366,7 +366,7 @@ to generate invoice-based addresses (e.g., Lightning Network).}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row per address and columns:
 \itemize{
 \item \code{address} (character): The deposit address string.
 \item \code{memo} (character): Memo/tag for the address (empty string if not applicable).
@@ -527,7 +527,7 @@ Used to filter deposits created on or before this time.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row per deposit and columns:
 \itemize{
 \item \code{currency} (character): Deposited currency code.
 \item \code{chain} (character): Blockchain network used for the deposit.
@@ -538,9 +538,9 @@ Used to filter deposits created on or before this time.}
 \item \code{amount} (character): Deposit amount.
 \item \code{fee} (character): Deposit fee charged.
 \item \code{wallet_tx_id} (character): On-chain transaction hash.
-\item \code{updated_at} (numeric): Last update timestamp in milliseconds.
-\item \code{remark} (character): Optional remark.
 \item \code{created_at} (POSIXct): Creation datetime (coerced from epoch milliseconds).
+\item \code{updated_at} (POSIXct): Last update datetime (coerced from epoch milliseconds).
+\item \code{remark} (character): Optional remark.
 }
 
 Returns an empty \code{data.table} if no deposits match the filters.

--- a/man/KucoinFuturesAccount.Rd
+++ b/man/KucoinFuturesAccount.Rd
@@ -176,7 +176,8 @@ Default \code{"USDT"}.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{account_equity} (numeric): Total account equity.
 \item \code{unrealised_pnl} (numeric): Unrealised profit and loss.
@@ -277,22 +278,36 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A \code{data.table} with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{id} (character): Position identifier.
 \item \code{symbol} (character): Contract symbol.
+\item \code{auto_deposit} (logical): Auto-deposit margin flag.
 \item \code{real_leverage} (numeric): Effective leverage.
 \item \code{cross_mode} (logical): Whether cross margin mode is active.
+\item \code{delev_percentage} (numeric): Auto-deleveraging percentage.
 \item \code{current_qty} (integer): Current position size in contracts.
 \item \code{current_cost} (character): Cost of the current position.
+\item \code{current_comm} (character): Current commission paid.
+\item \code{unrealised_cost} (character): Unrealised cost.
+\item \code{realised_gross_cost} (character): Realised gross cost.
+\item \code{realised_cost} (character): Realised cost.
 \item \code{is_open} (logical): Whether the position is open.
 \item \code{mark_price} (numeric): Current mark price.
 \item \code{mark_value} (character): Mark value of the position.
+\item \code{pos_cost} (character): Position cost.
+\item \code{pos_init} (character): Initial margin.
+\item \code{pos_comm} (character): Position commission.
 \item \code{pos_margin} (character): Position margin.
-\item \code{unrealised_pnl} (numeric): Unrealised profit and loss.
+\item \code{unrealised_pnl} (character): Unrealised profit and loss.
+\item \code{unrealised_pnl_pcnt} (numeric): Unrealised PnL as a percentage.
 \item \code{avg_entry_price} (character): Average entry price.
 \item \code{liquidation_price} (character): Estimated liquidation price.
+\item \code{bankrupt_price} (character): Bankruptcy price.
+\item \code{settle_currency} (character): Settlement currency.
 \item \code{margin_mode} (character): \code{"ISOLATED"} or \code{"CROSS"}.
+\item \code{position_side} (character): \code{"BOTH"}, \code{"LONG"}, or \code{"SHORT"}.
 \item \code{opening_timestamp} (POSIXct): Position opened time (coerced from milliseconds).
 \item \code{current_timestamp} (POSIXct): Current server time (coerced from milliseconds).
 }
@@ -394,7 +409,10 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A \code{data.table}; same columns as \code{get_position()}.
+A \code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per open position; same columns as
+\code{get_position()}. Returns an empty \code{data.table} when there are no
+open positions.
 }
 }
 \if{html}{\out{<hr>}}
@@ -484,14 +502,26 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A \code{data.table} with columns:
+A \code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per closed position record. Returns an
+empty \code{data.table} when no history records match. Columns:
 \itemize{
+\item \code{close_id} (character): Close-event identifier.
+\item \code{position_id} (character): Position identifier.
+\item \code{uid} (integer): Numeric user ID.
+\item \code{user_id} (character): String user ID.
 \item \code{symbol} (character): Contract symbol.
 \item \code{settle_currency} (character): Settlement currency.
-\item \code{realised_gross_pnl} (character): Gross realised PNL.
-\item \code{realised_pnl} (character): Net realised PNL (after fees).
-\item \code{leverage} (integer): Leverage used.
+\item \code{leverage} (character): Leverage used.
 \item \code{type} (character): Close type (e.g., \code{"Close"}).
+\item \code{pnl} (character): Realised PnL.
+\item \code{realised_gross_cost} (character): Gross realised cost.
+\item \code{withdraw_pnl} (character): Withdrawn PnL.
+\item \code{trade_fee} (character): Trading fee.
+\item \code{funding_fee} (character): Funding fee.
+\item \code{open_price} (character): Average open price.
+\item \code{close_price} (character): Average close price.
+\item \code{margin_mode} (character): \code{"ISOLATED"} or \code{"CROSS"}.
 \item \code{open_time} (POSIXct): Position opened time (coerced from milliseconds).
 \item \code{close_time} (POSIXct): Position closed time (coerced from milliseconds).
 }
@@ -558,7 +588,8 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{margin_mode} (character): \code{"ISOLATED"} or \code{"CROSS"}.
@@ -639,7 +670,8 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{margin_mode} (character): Updated margin mode.
@@ -707,7 +739,8 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{leverage} (character): Current leverage multiplier.
@@ -788,7 +821,8 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{leverage} (character): Updated leverage multiplier.
@@ -861,7 +895,8 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{max_buy_open_size} (integer): Maximum buy contracts.
@@ -927,7 +962,14 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} with the maximum withdrawable margin amount.
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
+\itemize{
+\item \code{max_withdraw_margin} (character): Maximum amount of isolated
+margin that can be withdrawn from the position. Returned by
+KuCoin as a fixed-precision string so the caller controls
+numeric coercion.
+}
 }
 }
 \if{html}{\out{<hr>}}
@@ -1009,7 +1051,8 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{id} (character): Margin operation ID.
 \item \code{symbol} (character): Contract symbol.
@@ -1094,7 +1137,8 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{id} (character): Margin operation ID.
 \item \code{symbol} (character): Contract symbol.
@@ -1189,7 +1233,9 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A \code{data.table} with columns:
+A \code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per risk-limit tier. Returns an empty
+\code{data.table} when KuCoin returns no tiers. Columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{level} (integer): Risk limit tier level.
@@ -1289,7 +1335,9 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A \code{data.table} with columns:
+A \code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per funding settlement. Returns an
+empty \code{data.table} when no records are returned. Columns:
 \itemize{
 \item \code{id} (integer): Record identifier.
 \item \code{symbol} (character): Contract symbol.

--- a/man/KucoinFuturesMarketData.Rd
+++ b/man/KucoinFuturesMarketData.Rd
@@ -388,7 +388,9 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with the contract specification
+flattened to one row per symbol. Key columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{root_symbol} (character): Root symbol (e.g., \code{"USDT"}).
@@ -406,8 +408,17 @@ A single-row \code{data.table} (or \verb{promise<data.table>} if constructed wit
 \item \code{taker_fee_rate} (numeric): Taker fee rate.
 \item \code{status} (character): Contract status (e.g., \code{"Open"}).
 \item \code{mark_price} (numeric): Current mark price.
+\item \code{index_price} (numeric): Underlying index price.
 \item \code{last_trade_price} (numeric): Last traded price.
 \item \code{funding_fee_rate} (numeric): Current funding fee rate.
+\item \code{predicted_funding_fee_rate} (numeric): Predicted next funding fee rate.
+\item \code{open_interest} (character): Current open interest.
+\item \code{turnover_of24h} (numeric): 24h turnover in settlement currency.
+\item \code{volume_of24h} (numeric): 24h trading volume.
+\item \code{low_price} (numeric): 24h low price.
+\item \code{high_price} (numeric): 24h high price.
+\item \code{price_chg_pct} (numeric): 24h price change percentage.
+\item \code{price_chg} (numeric): 24h price change.
 }
 }
 \subsection{Examples}{
@@ -518,7 +529,10 @@ Verified: 2026-03-10
 }
 
 \subsection{Returns}{
-A \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row per contract; same columns as \code{get_contract()}.
+A \code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per active contract; columns match
+\code{get_contract()}. Returns an empty \code{data.table} if no active
+contracts are returned.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -606,12 +620,14 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{sequence} (integer): Sequence number.
 \item \code{symbol} (character): Contract symbol.
 \item \code{side} (character): Side of the last trade (\code{"buy"} or \code{"sell"}).
 \item \code{size} (integer): Size of the last trade.
+\item \code{trade_id} (character): Identifier of the last trade.
 \item \code{price} (character): Last trade price.
 \item \code{best_bid_size} (integer): Quantity at best bid.
 \item \code{best_bid_price} (character): Best bid price.
@@ -712,7 +728,10 @@ Verified: 2026-03-10
 }
 
 \subsection{Returns}{
-A \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row per contract; same columns as \code{get_ticker()}.
+A \code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per contract; columns match
+\code{get_ticker()}. Returns an empty \code{data.table} if no tickers are
+returned.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1015,7 +1034,9 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+A \code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per trade. Returns an empty
+\code{data.table} when KuCoin reports no recent trades. Columns:
 \itemize{
 \item \code{sequence} (integer): Trade sequence number.
 \item \code{trade_id} (character): Unique trade identifier.
@@ -1247,7 +1268,8 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{granularity} (integer): Price granularity in milliseconds.
@@ -1338,7 +1360,8 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{granularity} (integer): Funding interval in milliseconds.
@@ -1446,7 +1469,9 @@ If numeric, assumed to be milliseconds.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+A \code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per funding settlement. Returns an
+empty \code{data.table} when no records cover the time range. Columns:
 \itemize{
 \item \code{symbol} (character): Contract symbol.
 \item \code{funding_rate} (numeric): Funding rate for the period.
@@ -1525,7 +1550,8 @@ Verified: 2026-03-10
 }
 
 \subsection{Returns}{
-A single-row \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{server_time} (POSIXct): Server timestamp (coerced from milliseconds).
 }
@@ -1601,7 +1627,8 @@ Verified: 2026-03-10
 }
 
 \subsection{Returns}{
-A single-row \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+A single-row \code{data.table} (or \verb{promise<data.table>} if
+constructed with \code{async = TRUE}) with columns:
 \itemize{
 \item \code{status} (character): Service status (e.g., \code{"open"}, \code{"close"}).
 \item \code{msg} (character): Status message (empty when operational).

--- a/man/KucoinFuturesMarketData.Rd
+++ b/man/KucoinFuturesMarketData.Rd
@@ -119,7 +119,7 @@ print(all_tickers[, .(symbol, price, best_bid_price, best_ask_price)])
 \dontrun{
 futures_market <- KucoinFuturesMarketData$new()
 ob <- futures_market$get_part_orderbook("XBTUSDTM", size = 20)
-print(ob[side == "bid"][1:5])
+print(ob[side == "bid"][order(level)][1:5])
 }
 
 ## ------------------------------------------------
@@ -831,6 +831,8 @@ A \code{data.table} (or \verb{promise<data.table>} if constructed with \code{asy
 \item \code{ts} (POSIXct): Snapshot timestamp (coerced from nanoseconds).
 \item \code{sequence} (character): Sequence number for change detection.
 \item \code{side} (character): \code{"bid"} or \code{"ask"}.
+\item \code{level} (integer): 1-indexed depth from top-of-book within the side
+(\code{level == 1} is best bid / best ask).
 \item \code{price} (numeric): Price level.
 \item \code{size} (numeric): Size at this price level.
 }
@@ -840,7 +842,7 @@ A \code{data.table} (or \verb{promise<data.table>} if constructed with \code{asy
 \preformatted{\dontrun{
 futures_market <- KucoinFuturesMarketData$new()
 ob <- futures_market$get_part_orderbook("XBTUSDTM", size = 20)
-print(ob[side == "bid"][1:5])
+print(ob[side == "bid"][order(level)][1:5])
 }
 }
 \if{html}{\out{</div>}}
@@ -935,6 +937,8 @@ A \code{data.table} (or \verb{promise<data.table>} if constructed with \code{asy
 \item \code{ts} (POSIXct): Snapshot timestamp (coerced from nanoseconds).
 \item \code{sequence} (character): Sequence number for change detection.
 \item \code{side} (character): \code{"bid"} or \code{"ask"}.
+\item \code{level} (integer): 1-indexed depth from top-of-book within the side
+(\code{level == 1} is best bid / best ask).
 \item \code{price} (numeric): Price level.
 \item \code{size} (numeric): Size at this price level.
 }

--- a/man/KucoinFuturesTrading.Rd
+++ b/man/KucoinFuturesTrading.Rd
@@ -163,7 +163,7 @@ print(results[, .(order_id, client_oid, code)])
 \dontrun{
 ft <- KucoinFuturesTrading$new()
 result <- ft$cancel_order_by_id("234125150956625920")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 
 ## ------------------------------------------------
@@ -185,7 +185,7 @@ ft <- KucoinFuturesTrading$new()
 
 # Cancel all open orders for XBTUSDTM
 result <- ft$cancel_all(symbol = "XBTUSDTM")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 
 # Cancel all open orders across all symbols
 result <- ft$cancel_all()
@@ -200,7 +200,7 @@ ft <- KucoinFuturesTrading$new()
 
 # Cancel all stop orders for XBTUSDTM
 result <- ft$cancel_all_stop_orders(symbol = "XBTUSDTM")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 
 # Cancel all stop orders across all symbols
 result <- ft$cancel_all_stop_orders()
@@ -982,9 +982,11 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per cancelled order, and column:
 \itemize{
-\item \code{cancelled_order_ids} (list): Vector of cancelled order IDs.
+\item \code{cancelled_order_id} (character): Cancelled order ID. Empty
+\code{data.table} (zero rows) if no orders matched.
 }
 }
 \subsection{Examples}{
@@ -992,7 +994,7 @@ A single-row \code{data.table} (or \verb{promise<data.table>} if constructed wit
 \preformatted{\dontrun{
 ft <- KucoinFuturesTrading$new()
 result <- ft$cancel_order_by_id("234125150956625920")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 }
 \if{html}{\out{</div>}}
@@ -1163,9 +1165,11 @@ cancels all open orders across all symbols.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per cancelled order, and column:
 \itemize{
-\item \code{cancelled_order_ids} (list): Vector of cancelled order IDs.
+\item \code{cancelled_order_id} (character): Cancelled order ID. Empty
+\code{data.table} (zero rows) if no orders matched.
 }
 }
 \subsection{Examples}{
@@ -1175,7 +1179,7 @@ ft <- KucoinFuturesTrading$new()
 
 # Cancel all open orders for XBTUSDTM
 result <- ft$cancel_all(symbol = "XBTUSDTM")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 
 # Cancel all open orders across all symbols
 result <- ft$cancel_all()
@@ -1259,9 +1263,11 @@ cancels all untriggered stop orders across all symbols.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A single-row \code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per cancelled order, and column:
 \itemize{
-\item \code{cancelled_order_ids} (list): Vector of cancelled order IDs.
+\item \code{cancelled_order_id} (character): Cancelled order ID. Empty
+\code{data.table} (zero rows) if no orders matched.
 }
 }
 \subsection{Examples}{
@@ -1271,7 +1277,7 @@ ft <- KucoinFuturesTrading$new()
 
 # Cancel all stop orders for XBTUSDTM
 result <- ft$cancel_all_stop_orders(symbol = "XBTUSDTM")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 
 # Cancel all stop orders across all symbols
 result <- ft$cancel_all_stop_orders()

--- a/man/KucoinLending.Rd
+++ b/man/KucoinLending.Rd
@@ -231,7 +231,23 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with lending currency info.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per lending currency} and columns:
+\itemize{
+\item \code{currency} (character): Currency code (e.g. \code{"USDT"}).
+\item \code{purchase_enable} (logical): Whether new purchases are accepted.
+\item \code{redeem_enable} (logical): Whether redemptions are accepted.
+\item \code{increment} (character): Smallest purchase-size step.
+\item \code{min_purchase_size} (character): Minimum purchase amount.
+\item \code{max_purchase_size} (character): Maximum purchase amount.
+\item \code{interest_increment} (character): Smallest interest-rate step.
+\item \code{min_interest_rate} (character): Minimum permitted interest rate.
+\item \code{market_interest_rate} (character): Current market rate.
+\item \code{max_interest_rate} (character): Maximum permitted interest rate.
+\item \code{auto_purchase_enable} (logical): Whether auto-purchase is available.
+}
+
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -303,11 +319,14 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per observation} and columns:
 \itemize{
 \item \code{time} (character): Timestamp string (YYYYMMDDHHmm format).
 \item \code{market_interest_rate} (character): Market interest rate at that time.
 }
+
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -575,7 +594,20 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with purchase order records.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per purchase order} and columns:
+\itemize{
+\item \code{currency} (character): Lent currency.
+\item \code{purchase_order_no} (character): Purchase order number.
+\item \code{purchase_size} (character): Amount lent.
+\item \code{match_size} (character): Amount that has been matched.
+\item \code{interest_rate} (character): Rate of the lending order.
+\item \code{income_size} (character): Accrued income so far.
+\item \code{apply_time} (POSIXct): Order creation time (millisecond epoch coerced).
+\item \code{status} (character): Order status (e.g. \code{"DONE"}).
+}
+
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -753,7 +785,19 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with redeem order records.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per redemption order} and columns:
+\itemize{
+\item \code{currency} (character): Redeemed currency.
+\item \code{purchase_order_no} (character): Source purchase order.
+\item \code{redeem_order_no} (character): Redemption order number.
+\item \code{redeem_size} (character): Requested redeem amount.
+\item \code{receipt_size} (character): Amount actually received.
+\item \code{apply_time} (POSIXct): Order creation time (millisecond epoch coerced).
+\item \code{status} (character): Order status (e.g. \code{"DONE"}).
+}
+
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinMarginData.Rd
+++ b/man/KucoinMarginData.Rd
@@ -217,7 +217,29 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with margin symbol details.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per cross-margin symbol} and the following columns
+(subset shown — KuCoin may add fields):
+\itemize{
+\item \code{symbol} (character): Trading pair identifier (e.g. \code{"BTC-USDT"}).
+\item \code{name} (character): Display name.
+\item \code{enable_trading} (logical): Whether trading is enabled.
+\item \code{market} (character): Market category (e.g. \code{"USDS"}).
+\item \code{base_currency} (character): Base asset code.
+\item \code{quote_currency} (character): Quote asset code.
+\item \code{base_increment} (character): Minimum base-quantity step.
+\item \code{base_min_size} (character): Minimum order base quantity.
+\item \code{base_max_size} (character): Maximum order base quantity.
+\item \code{quote_increment} (character): Minimum quote-quantity step.
+\item \code{quote_min_size} (character): Minimum order quote quantity.
+\item \code{quote_max_size} (character): Maximum order quote quantity.
+\item \code{price_increment} (character): Minimum price step.
+\item \code{fee_currency} (character): Currency charged for trading fees.
+\item \code{price_limit_rate} (character): Maximum allowed price deviation.
+\item \code{min_funds} (character): Minimum order notional.
+}
+
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -291,7 +313,23 @@ Verified: 2026-03-10
 }
 
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with isolated margin symbol details.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per isolated-margin pair} and columns:
+\itemize{
+\item \code{symbol} (character): Trading pair identifier.
+\item \code{symbol_name} (character): Display name.
+\item \code{base_currency} (character): Base asset code.
+\item \code{quote_currency} (character): Quote asset code.
+\item \code{max_leverage} (integer): Maximum leverage available.
+\item \code{fl_debt_ratio} (character): Forced-liquidation debt ratio.
+\item \code{trade_enable} (logical): Whether trading is enabled.
+\item \code{base_borrow_enable} (logical): Base-currency borrow allowed.
+\item \code{quote_borrow_enable} (logical): Quote-currency borrow allowed.
+\item \code{base_transfer_in_enable} (logical): Base-currency transfer-in allowed.
+\item \code{quote_transfer_in_enable} (logical): Quote-currency transfer-in allowed.
+}
+
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -357,14 +395,18 @@ Verified: 2026-03-10
 }
 
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row
-per supported currency, containing:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per supported currency} (the \code{currencyList} array is
+exploded so each currency gets its own row with the config-level fields
+replicated). Columns:
 \itemize{
-\item \code{currency} (character): Supported margin currency (e.g., \code{"BTC"}, \code{"ETH"}).
-\item \code{max_leverage} (numeric): Maximum leverage.
+\item \code{currency} (character): Supported margin currency (e.g. \code{"BTC"}).
+\item \code{max_leverage} (integer): Maximum leverage.
 \item \code{warning_debt_ratio} (character): Warning debt ratio.
 \item \code{liq_debt_ratio} (character): Liquidation debt ratio.
 }
+
+Empty \code{currencyList} yields a zero-row \code{data.table} with this schema.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -446,8 +488,18 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row per currency per tier.
-Columns: \code{currency}, \code{lower_limit}, \code{upper_limit}, \code{collateral_ratio}.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per (currency, tier) pair}. The nested
+\code{currencyList}/\code{items} arrays are cross-joined to a flat long table.
+Columns:
+\itemize{
+\item \code{currency} (character): Currency code.
+\item \code{lower_limit} (character): Lower bound of the collateral range.
+\item \code{upper_limit} (character): Upper bound of the collateral range.
+\item \code{collateral_ratio} (character): Ratio applied in that range.
+}
+
+Empty response yields a zero-row \code{data.table} with this schema.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -535,7 +587,24 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with risk limit details.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per currency} (cross) or \strong{one row per (symbol, currency)
+pair} (isolated). Common columns:
+\itemize{
+\item \code{currency} (character): Currency code.
+\item \code{borrow_max_amount} (character): Maximum borrowable amount.
+\item \code{buy_max_amount} (character): Maximum buyable amount.
+\item \code{hold_max_amount} (character): Maximum hold amount.
+\item \code{borrow_coefficient} (character): Coefficient applied to borrows.
+\item \code{margin_coefficient} (character): Coefficient applied to margin.
+\item \code{precision} (integer): Decimal precision.
+\item \code{borrow_min_amount} (character): Minimum borrowable amount.
+\item \code{borrow_min_unit} (character): Minimum borrow step.
+\item \code{borrow_enabled} (logical): Whether borrowing is currently enabled.
+}
+
+For isolated margin an extra \code{symbol} (character) column is present.
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinMarginTrading.Rd
+++ b/man/KucoinMarginTrading.Rd
@@ -1071,8 +1071,10 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with a single row and columns:
 \itemize{
+\item \code{timestamp} (POSIXct): Server-side acceptance time of the repay.
 \item \code{order_no} (character): Repayment order number.
 \item \code{actual_size} (character): Amount actually repaid.
 }
@@ -1167,7 +1169,19 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with borrow records.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per borrow record} and columns:
+\itemize{
+\item \code{order_no} (character): Borrow order number.
+\item \code{symbol} (character): Trading pair (NA on cross-margin records).
+\item \code{currency} (character): Borrowed currency.
+\item \code{size} (character): Requested borrow amount.
+\item \code{actual_size} (character): Amount actually borrowed.
+\item \code{status} (character): Lifecycle status (e.g. \code{"DONE"}).
+\item \code{created_time} (POSIXct): Borrow timestamp (millisecond epoch coerced).
+}
+
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1249,7 +1263,19 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with repay records.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per repay record} and columns:
+\itemize{
+\item \code{order_no} (character): Repay order number.
+\item \code{symbol} (character): Trading pair (NA on cross-margin records).
+\item \code{currency} (character): Repaid currency.
+\item \code{size} (character): Requested repay amount.
+\item \code{actual_size} (character): Amount actually repaid.
+\item \code{status} (character): Lifecycle status.
+\item \code{created_time} (POSIXct): Repay timestamp (millisecond epoch coerced).
+}
+
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1337,7 +1363,16 @@ Verified: 2026-03-10
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with interest records.
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with \strong{one row per interest record} and columns:
+\itemize{
+\item \code{currency} (character): Currency on which interest accrued.
+\item \code{day_ratio} (character): Daily rate applied.
+\item \code{interest_amount} (character): Interest charged in the period.
+\item \code{created_time} (POSIXct): Accrual timestamp (millisecond epoch coerced).
+}
+
+Empty response yields an empty \code{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinMarketData.Rd
+++ b/man/KucoinMarketData.Rd
@@ -415,11 +415,16 @@ Verified: 2026-03-10
 \itemize{
 \item \code{ann_id} (integer): Announcement identifier.
 \item \code{ann_title} (character): Announcement title.
-\item \code{ann_type} (character): Category tag for the announcement.
-KuCoin returns \code{annType} as an array; the parser explodes to
-long format so an announcement tagged with N types appears in
-N rows with the other columns replicated. \code{NA_character_} if
-KuCoin returned no tags for an announcement.
+\item \code{ann_type} (character): \verb{;}-separated category tags for the
+announcement. KuCoin returns \code{annType} as an array; the parser
+collapses it to a single character column via the shared
+\code{collapse_string_array_fields()} helper (Treatment A —
+matches the cross-package convention used by alpaca/binance
+for plain-string arrays). Filter with
+\code{grepl("latest-announcements", ann_type, fixed = TRUE)};
+recover the vector via
+\code{strsplit(ann_type, ";", fixed = TRUE)[[1]]}. \code{NA_character_}
+if KuCoin returned no tags.
 \item \code{ann_desc} (character): Short description text.
 \item \code{c_time} (POSIXct): Creation datetime (coerced from epoch milliseconds).
 \item \code{language} (character): Language code.

--- a/man/KucoinMarketData.Rd
+++ b/man/KucoinMarketData.Rd
@@ -190,9 +190,9 @@ print(paste("Buy/Sell ratio:", round(buys / sells, 3)))
 \dontrun{
 market <- KucoinMarketData$new()
 ob <- market$get_part_orderbook("BTC-USDT", size = 20)
-bids <- ob[side == "bid"]
-asks <- ob[side == "ask"]
-print(paste("Best bid:", bids$price[1], "Best ask:", asks$price[1]))
+best_bid <- ob[side == "bid" & level == 1L]
+best_ask <- ob[side == "ask" & level == 1L]
+print(paste("Best bid:", best_bid$price, "Best ask:", best_ask$price))
 }
 
 ## ------------------------------------------------
@@ -1305,7 +1305,7 @@ depth on each side (bids and asks). Public endpoint, no authentication required.
 \item \strong{Validation}: Ensures \code{size} is 20 or 100.
 \item \strong{Request}: GET with size embedded in endpoint path.
 \item \strong{Parsing}: Calls \code{parse_orderbook()} to convert nested bid/ask arrays
-into a long-format \code{data.table} with \code{side}, \code{price}, and \code{size} columns.
+into a long-format \code{data.table} with \code{side}, \code{level}, \code{price}, and \code{size} columns.
 }
 }
 
@@ -1368,6 +1368,8 @@ Verified: 2026-03-10
 \item \code{time} (POSIXct): Server timestamp (coerced from epoch milliseconds).
 \item \code{sequence} (character): Order book sequence number.
 \item \code{side} (character): \code{"bid"} or \code{"ask"}.
+\item \code{level} (integer): 1-indexed depth from top-of-book within the side
+(\code{level == 1} is best bid / best ask).
 \item \code{price} (numeric): Price level.
 \item \code{size} (numeric): Size at that price.
 }
@@ -1377,9 +1379,9 @@ Verified: 2026-03-10
 \preformatted{\dontrun{
 market <- KucoinMarketData$new()
 ob <- market$get_part_orderbook("BTC-USDT", size = 20)
-bids <- ob[side == "bid"]
-asks <- ob[side == "ask"]
-print(paste("Best bid:", bids$price[1], "Best ask:", asks$price[1]))
+best_bid <- ob[side == "bid" & level == 1L]
+best_ask <- ob[side == "ask" & level == 1L]
+print(paste("Best bid:", best_bid$price, "Best ask:", best_ask$price))
 }
 }
 \if{html}{\out{</div>}}
@@ -1464,6 +1466,8 @@ Verified: 2026-03-10
 \item \code{time} (POSIXct): Server timestamp (coerced from epoch milliseconds).
 \item \code{sequence} (character): Order book sequence number.
 \item \code{side} (character): \code{"bid"} or \code{"ask"}.
+\item \code{level} (integer): 1-indexed depth from top-of-book within the side
+(\code{level == 1} is best bid / best ask).
 \item \code{price} (numeric): Price level.
 \item \code{size} (numeric): Size at that price.
 }

--- a/man/KucoinMarketData.Rd
+++ b/man/KucoinMarketData.Rd
@@ -415,7 +415,11 @@ Verified: 2026-03-10
 \itemize{
 \item \code{ann_id} (integer): Announcement identifier.
 \item \code{ann_title} (character): Announcement title.
-\item \code{ann_type} (list): Category tags as character vector.
+\item \code{ann_type} (character): Category tag for the announcement.
+KuCoin returns \code{annType} as an array; the parser explodes to
+long format so an announcement tagged with N types appears in
+N rows with the other columns replicated. \code{NA_character_} if
+KuCoin returned no tags for an announcement.
 \item \code{ann_desc} (character): Short description text.
 \item \code{c_time} (POSIXct): Creation datetime (coerced from epoch milliseconds).
 \item \code{language} (character): Language code.

--- a/man/KucoinMarketData.Rd
+++ b/man/KucoinMarketData.Rd
@@ -237,7 +237,7 @@ defi_symbols <- market$get_all_symbols(market = "DeFi")
 \dontrun{
 market <- KucoinMarketData$new()
 
-# Last 24 hours of 15-minute candles
+# Most recent candles (up to 1500)
 klines <- market$get_klines("BTC-USDT")
 print(head(klines))
 
@@ -1723,8 +1723,8 @@ Each candle is an array: \verb{[timestamp, open, close, high, low, volume, turno
 \if{html}{\out{<div class="r">}}\preformatted{KucoinMarketData$get_klines(
   symbol,
   timeframe = "15min",
-  from = lubridate::now() - lubridate::dhours(24),
-  to = lubridate::now()
+  from = NULL,
+  to = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -1738,9 +1738,10 @@ Each candle is an array: \verb{[timestamp, open, close, high, low, volume, turno
 \code{"1hour"}, \code{"2hour"}, \code{"4hour"}, \code{"6hour"}, \code{"8hour"}, \code{"12hour"},
 \code{"1day"}, \code{"1week"}, \code{"1month"}. Default \code{"15min"}.}
 
-\item{\code{from}}{POSIXct; start time (default 24 hours ago).}
+\item{\code{from}}{POSIXct or NULL; start time. When both \code{from} and \code{to} are
+\code{NULL}, the API returns up to 1500 most recent candles.}
 
-\item{\code{to}}{POSIXct; end time (default now).}
+\item{\code{to}}{POSIXct or NULL; end time.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1761,7 +1762,7 @@ Each candle is an array: \verb{[timestamp, open, close, high, low, volume, turno
 \preformatted{\dontrun{
 market <- KucoinMarketData$new()
 
-# Last 24 hours of 15-minute candles
+# Most recent candles (up to 1500)
 klines <- market$get_klines("BTC-USDT")
 print(head(klines))
 

--- a/man/KucoinOcoOrders.Rd
+++ b/man/KucoinOcoOrders.Rd
@@ -111,7 +111,7 @@ oco <- KucoinOcoOrders$new()
 
 # Cancel a specific OCO order
 result <- oco$cancel_order_by_id("674c40d38b4b2f00073deef3")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 
 ## ------------------------------------------------
@@ -123,7 +123,7 @@ oco <- KucoinOcoOrders$new()
 
 # Cancel by client-assigned ID
 result <- oco$cancel_order_by_client_oid("my-bot-oco-001")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 
 ## ------------------------------------------------
@@ -135,7 +135,7 @@ oco <- KucoinOcoOrders$new()
 
 # Cancel all OCO orders for BTC-USDT
 result <- oco$cancel_all(query = list(symbol = "BTC-USDT"))
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 
 # Cancel all OCO orders (no filter)
 result <- oco$cancel_all()
@@ -442,10 +442,12 @@ Verified: 2026-02-01
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per cancelled order, and column:
 \itemize{
-\item \code{cancelled_order_ids} (list): List of cancelled order IDs including the
-parent OCO and its sub-orders.
+\item \code{cancelled_order_id} (character): Cancelled order ID (the parent
+OCO and each of its sub-orders appear as separate rows). Empty
+\code{data.table} if nothing matched.
 }
 }
 \subsection{Examples}{
@@ -455,7 +457,7 @@ oco <- KucoinOcoOrders$new()
 
 # Cancel a specific OCO order
 result <- oco$cancel_order_by_id("674c40d38b4b2f00073deef3")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 }
 \if{html}{\out{</div>}}
@@ -538,10 +540,12 @@ the OCO order (e.g., \code{"my-bot-oco-001"}).}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per cancelled order, and column:
 \itemize{
-\item \code{cancelled_order_ids} (list): List of cancelled order IDs including the
-parent OCO and its sub-orders.
+\item \code{cancelled_order_id} (character): Cancelled order ID (the parent
+OCO and each of its sub-orders appear as separate rows). Empty
+\code{data.table} if nothing matched.
 }
 }
 \subsection{Examples}{
@@ -551,7 +555,7 @@ oco <- KucoinOcoOrders$new()
 
 # Cancel by client-assigned ID
 result <- oco$cancel_order_by_client_oid("my-bot-oco-001")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 }
 \if{html}{\out{</div>}}
@@ -640,9 +644,11 @@ If empty, all active OCO orders are cancelled.
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with
+\code{async = TRUE}) with one row per cancelled order, and column:
 \itemize{
-\item \code{cancelled_order_ids} (list): List of all cancelled order IDs.
+\item \code{cancelled_order_id} (character): Cancelled order ID. Empty
+\code{data.table} if no active OCO orders matched the filter.
 }
 }
 \subsection{Examples}{
@@ -652,7 +658,7 @@ oco <- KucoinOcoOrders$new()
 
 # Cancel all OCO orders for BTC-USDT
 result <- oco$cancel_all(query = list(symbol = "BTC-USDT"))
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 
 # Cancel all OCO orders (no filter)
 result <- oco$cancel_all()
@@ -964,8 +970,20 @@ Verified: 2026-02-01
 \item \code{client_oid} (character): Client-assigned order identifier.
 \item \code{order_time} (POSIXct): Order creation datetime (coerced from epoch milliseconds).
 \item \code{status} (character): Overall OCO order status.
-\item \code{orders} (list): List of sub-order details, each containing \code{id}, \code{symbol},
-\code{side}, \code{price}, \code{size}, \code{status}, and optionally \code{stop_price}.
+}
+
+The nested \code{orders} array (one entry per sub-order — typically the
+limit leg + the stop-limit leg) is exploded to long format: the
+parent OCO row is replicated once per sub-order, and each sub-order's
+fields are added with a \code{sub_order_} prefix. Typical sub-order columns:
+\itemize{
+\item \code{sub_order_id} (character)
+\item \code{sub_order_symbol} (character)
+\item \code{sub_order_side} (character)
+\item \code{sub_order_price} (character)
+\item \code{sub_order_size} (character)
+\item \code{sub_order_status} (character)
+\item \code{sub_order_stop_price} (character; only present on the stop leg)
 }
 }
 \subsection{Examples}{

--- a/man/KucoinOcoOrders.Rd
+++ b/man/KucoinOcoOrders.Rd
@@ -174,10 +174,11 @@ print(order$status)
 \dontrun{
 oco <- KucoinOcoOrders$new()
 
-# Get full OCO order details with sub-orders
+# Get full OCO order details with sub-orders. The `orders` array
+# is exploded to long format, so each sub-order is its own row
+# with `sub_order_*` columns alongside the parent OCO fields.
 details <- oco$get_order_detail_by_id("674c40d38b4b2f00073deef3")
-print(details$status)
-print(details$orders)
+details[, .(order_id, status, sub_order_id, sub_order_side, sub_order_price)]
 }
 
 ## ------------------------------------------------
@@ -991,10 +992,11 @@ fields are added with a \code{sub_order_} prefix. Typical sub-order columns:
 \preformatted{\dontrun{
 oco <- KucoinOcoOrders$new()
 
-# Get full OCO order details with sub-orders
+# Get full OCO order details with sub-orders. The `orders` array
+# is exploded to long format, so each sub-order is its own row
+# with `sub_order_*` columns alongside the parent OCO fields.
 details <- oco$get_order_detail_by_id("674c40d38b4b2f00073deef3")
-print(details$status)
-print(details$orders)
+details[, .(order_id, status, sub_order_id, sub_order_side, sub_order_price)]
 }
 }
 \if{html}{\out{</div>}}

--- a/man/KucoinStopOrders.Rd
+++ b/man/KucoinStopOrders.Rd
@@ -162,7 +162,7 @@ stop <- KucoinStopOrders$new()
 
 # Cancel a specific stop order
 result <- stop$cancel_order_by_id("vs8hoo8q2ceshiue003b67c0")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 
 ## ------------------------------------------------
@@ -186,11 +186,11 @@ stop <- KucoinStopOrders$new()
 
 # Cancel all stop orders for BTC-USDT
 result <- stop$cancel_all(query = list(symbol = "BTC-USDT"))
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 
 # Cancel all stop orders (no filter)
 result <- stop$cancel_all()
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 
 ## ------------------------------------------------
@@ -514,9 +514,12 @@ Verified: 2026-02-01
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with column:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with one row per cancelled stop order (Treatment B — long format):
 \itemize{
-\item \code{cancelled_order_ids} (character): Vector of cancelled stop order IDs.
+\item \code{cancelled_order_id} (character): KuCoin order ID of a cancelled stop order.
+Returns an empty \code{data.table} if no stop orders matched (per the
+"empty response -> empty data.table" cross-package convention).
 }
 }
 \subsection{Examples}{
@@ -526,7 +529,7 @@ stop <- KucoinStopOrders$new()
 
 # Cancel a specific stop order
 result <- stop$cancel_order_by_id("vs8hoo8q2ceshiue003b67c0")
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 }
 \if{html}{\out{</div>}}
@@ -606,7 +609,8 @@ disambiguate client OIDs across different trading pairs.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with a single row:
 \itemize{
 \item \code{cancelled_order_id} (character): The KuCoin order ID of the cancelled stop order.
 \item \code{client_oid} (character): The client-assigned order ID that was cancelled.
@@ -705,9 +709,12 @@ Verified: 2026-02-01
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with column:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with one row per cancelled stop order (Treatment B — long format):
 \itemize{
-\item \code{cancelled_order_ids} (character): Vector of cancelled stop order IDs.
+\item \code{cancelled_order_id} (character): KuCoin order ID of a cancelled stop order.
+Returns an empty \code{data.table} if no stop orders matched the filters
+(per the "empty response -> empty data.table" cross-package convention).
 }
 }
 \subsection{Examples}{
@@ -717,11 +724,11 @@ stop <- KucoinStopOrders$new()
 
 # Cancel all stop orders for BTC-USDT
 result <- stop$cancel_all(query = list(symbol = "BTC-USDT"))
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 
 # Cancel all stop orders (no filter)
 result <- stop$cancel_all()
-print(result$cancelled_order_ids)
+print(result$cancelled_order_id)
 }
 }
 \if{html}{\out{</div>}}
@@ -821,7 +828,8 @@ Verified: 2026-02-01
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row containing order details. Key columns include:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with a single row containing order details (no list columns). Key columns include:
 \itemize{
 \item \code{id} (character): Stop order identifier.
 \item \code{symbol} (character): Trading pair (e.g., \code{"BTC-USDT"}).
@@ -832,6 +840,9 @@ Verified: 2026-02-01
 \item \code{stop_price} (character): Trigger price for the stop order.
 \item \code{stop} (character): Stop direction (\code{"loss"} or \code{"entry"}).
 \item \code{created_at} (POSIXct): Creation datetime (coerced from epoch milliseconds).
+\item \code{order_time} (POSIXct): Order placement datetime (coerced from epoch nanoseconds).
+\item \code{stop_trigger_time} (POSIXct): Trigger datetime if triggered (coerced from
+epoch milliseconds), \code{NA} if not yet triggered.
 }
 }
 \subsection{Examples}{
@@ -948,7 +959,8 @@ scope the search to a specific trading pair.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one or more rows of order details. Key columns include:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with one row per matching stop order (no list columns). Key columns include:
 \itemize{
 \item \code{id} (character): Stop order identifier.
 \item \code{symbol} (character): Trading pair (e.g., \code{"BTC-USDT"}).
@@ -959,6 +971,10 @@ scope the search to a specific trading pair.}
 \item \code{stop_price} (character): Trigger price for the stop order.
 \item \code{client_oid} (character): The client-assigned order ID.
 \item \code{created_at} (POSIXct): Creation datetime (coerced from epoch milliseconds).
+\item \code{order_time} (POSIXct): Order placement datetime (coerced from epoch nanoseconds).
+\item \code{stop_trigger_time} (POSIXct): Trigger datetime if triggered (coerced from
+epoch milliseconds), \code{NA} if not yet triggered.
+Returns an empty \code{data.table} if no stop orders match.
 }
 }
 \subsection{Examples}{
@@ -1089,8 +1105,9 @@ Verified: 2026-02-01
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with zero or more rows. Returns an empty \code{data.table} if no
-stop orders match the query. Key columns include:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE})
+with one row per stop order (no list columns). Returns an empty \code{data.table}
+if no stop orders match the query. Key columns include:
 \itemize{
 \item \code{id} (character): Stop order identifier.
 \item \code{symbol} (character): Trading pair (e.g., \code{"BTC-USDT"}).
@@ -1102,6 +1119,9 @@ stop orders match the query. Key columns include:
 \item \code{stop} (character): Stop direction (\code{"loss"} or \code{"entry"}).
 \item \code{time_in_force} (character): Time-in-force policy.
 \item \code{created_at} (POSIXct): Creation datetime (coerced from epoch milliseconds).
+\item \code{order_time} (POSIXct): Order placement datetime (coerced from epoch nanoseconds).
+\item \code{stop_trigger_time} (POSIXct): Trigger datetime if triggered (coerced from
+epoch milliseconds), \code{NA} if not yet triggered.
 }
 }
 \subsection{Examples}{

--- a/man/KucoinTrading.Rd
+++ b/man/KucoinTrading.Rd
@@ -1295,7 +1295,7 @@ Verified: 2026-02-01
 }\if{html}{\out{</div>}}
 }
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{KucoinTrading$get_order_by_id(orderId, symbol)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{KucoinTrading$get_order_by_id(orderId, symbol = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1303,7 +1303,7 @@ Verified: 2026-02-01
 \describe{
 \item{\code{orderId}}{Character; the KuCoin order ID.}
 
-\item{\code{symbol}}{Character; trading pair (e.g., \code{"BTC-USDT"}).}
+\item{\code{symbol}}{Character (optional); trading pair (e.g., \code{"BTC-USDT"}). Defaults to \code{NULL}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/KucoinTransfer.Rd
+++ b/man/KucoinTransfer.Rd
@@ -259,7 +259,7 @@ Verified: 2026-02-02
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row and columns:
 \itemize{
 \item \code{order_id} (character): The transfer order identifier.
 }
@@ -377,7 +377,7 @@ account type (e.g., \code{"BTC-USDT"}).}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row and columns:
 \itemize{
 \item \code{currency} (character): Currency code.
 \item \code{balance} (character): Total funds in the account.

--- a/man/KucoinWithdrawal.Rd
+++ b/man/KucoinWithdrawal.Rd
@@ -291,7 +291,7 @@ Required by the KuCoin API.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row and columns:
 \itemize{
 \item \code{withdrawal_id} (character): The unique withdrawal identifier.
 }
@@ -394,9 +394,10 @@ Verified: 2026-02-02
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row and columns:
 \itemize{
-\item \code{withdrawal_id} (character): The cancelled withdrawal ID.
+\item \code{withdrawal_id} (character): The cancelled withdrawal ID (echoed from the input
+since KuCoin returns \code{null} data on a successful cancel).
 }
 }
 \subsection{Examples}{
@@ -503,7 +504,7 @@ When NULL, returns quotas for the default chain.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row and columns:
 \itemize{
 \item \code{currency} (character): Currency code.
 \item \code{limit_btc_amount} (character): Daily withdrawal limit in BTC equivalent.
@@ -653,7 +654,7 @@ When NULL, returns withdrawals of all statuses.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row per withdrawal and columns:
 \itemize{
 \item \code{currency} (character): Withdrawn currency code.
 \item \code{chain} (character): Blockchain network used.
@@ -664,10 +665,10 @@ When NULL, returns withdrawals of all statuses.}
 \item \code{amount} (character): Withdrawal amount.
 \item \code{fee} (character): Withdrawal fee charged.
 \item \code{wallet_tx_id} (character): On-chain transaction hash.
-\item \code{updated_at} (numeric): Last update timestamp in milliseconds.
+\item \code{created_at} (POSIXct): Creation datetime (coerced from epoch milliseconds).
+\item \code{updated_at} (POSIXct): Last update datetime (coerced from epoch milliseconds).
 \item \code{remark} (character): Optional remark.
 \item \code{arrears} (logical): Whether the withdrawal is in arrears.
-\item \code{created_at} (POSIXct): Creation datetime (coerced from epoch milliseconds).
 }
 
 Returns an empty \code{data.table} if no withdrawals match the filters.
@@ -781,7 +782,7 @@ Verified: 2026-02-02
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with columns:
+\code{data.table} (or \verb{promise<data.table>} if constructed with \code{async = TRUE}) with one row and columns:
 \itemize{
 \item \code{id} (character): Withdrawal ID.
 \item \code{currency} (character): Currency code.

--- a/tests/testthat/test-KucoinAccount.R
+++ b/tests/testthat/test-KucoinAccount.R
@@ -44,6 +44,8 @@ test_that("get_summary returns data.table with expected columns", {
   expect_true("sub_quantity" %in% names(dt))
   expect_equal(dt$level, 1)
   expect_equal(dt$sub_quantity, 3)
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 # -- get_apikey_info --
@@ -69,6 +71,10 @@ test_that("get_apikey_info returns data.table with key details", {
   expect_equal(dt$api_key, "670c42f1a24b1b0001a5c7e0")
   expect_equal(dt$permission, "General,Spot")
   expect_true(dt$is_master)
+  # created_at coerced to POSIXct
+  expect_s3_class(dt$created_at, "POSIXct")
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 # -- get_spot_account_type --
@@ -115,6 +121,7 @@ test_that("get_spot_accounts returns list of accounts", {
   expect_equal(nrow(dt), 2L)
   expect_true("currency" %in% names(dt))
   expect_true("balance" %in% names(dt))
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_spot_accounts handles empty response", {
@@ -144,6 +151,7 @@ test_that("get_spot_account_detail returns single-row data.table", {
   expect_equal(nrow(dt), 1L)
   expect_equal(dt$currency, "USDT")
   expect_equal(dt$balance, "1250.75")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 # -- get_cross_margin_account --
@@ -187,6 +195,15 @@ test_that("get_cross_margin_account extracts accounts sub-list", {
   expect_true("currency" %in% names(dt))
   expect_true("total_balance" %in% names(dt))
   expect_true("borrow_enabled" %in% names(dt))
+  # Account-level summary fields replicated on every row (Treatment B)
+  expect_true("total_asset_of_quote_currency" %in% names(dt))
+  expect_true("total_liability_of_quote_currency" %in% names(dt))
+  expect_true("debt_ratio" %in% names(dt))
+  expect_true("status" %in% names(dt))
+  expect_equal(unique(dt$total_asset_of_quote_currency), "15234.67")
+  expect_equal(unique(dt$debt_ratio), "0.1641")
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_cross_margin_account handles empty accounts", {
@@ -205,12 +222,42 @@ test_that("get_cross_margin_account handles empty accounts", {
 
 # -- get_isolated_margin_account --
 
-test_that("get_isolated_margin_account extracts assets sub-list", {
+test_that("get_isolated_margin_account flattens baseAsset/quoteAsset wide-prefix", {
   resp <- mock_kucoin_response(
     data = list(
       totalAssetOfQuoteCurrency = "5234.67",
+      totalLiabilityOfQuoteCurrency = "1000.00",
+      timestamp = 1729176273859,
       assets = list(
-        list(symbol = "BTC-USDT", status = "EFFECTIVE", debtRatio = "0.19")
+        list(
+          symbol = "BTC-USDT",
+          status = "EFFECTIVE",
+          debtRatio = "0.1912",
+          baseAsset = list(
+            currency = "BTC",
+            borrowEnabled = TRUE,
+            transferInEnabled = TRUE,
+            liability = "0",
+            liabilityPrincipal = "0",
+            liabilityInterest = "0",
+            total = "0.1",
+            available = "0.1",
+            hold = "0",
+            maxBorrowSize = "1.5"
+          ),
+          quoteAsset = list(
+            currency = "USDT",
+            borrowEnabled = TRUE,
+            transferInEnabled = TRUE,
+            liability = "1000.00",
+            liabilityPrincipal = "950.00",
+            liabilityInterest = "50.00",
+            total = "5000.00",
+            available = "4500.00",
+            hold = "500.00",
+            maxBorrowSize = "25000.00"
+          )
+        )
       )
     )
   )
@@ -219,7 +266,60 @@ test_that("get_isolated_margin_account extracts assets sub-list", {
   dt <- new_account()$get_isolated_margin_account()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
+  # Symbol and pair-level fields
   expect_true("symbol" %in% names(dt))
+  expect_equal(dt$symbol, "BTC-USDT")
+  expect_equal(dt$status, "EFFECTIVE")
+  # Wide-prefixed baseAsset columns (Treatment C)
+  expect_true("base_asset_currency" %in% names(dt))
+  expect_true("base_asset_total" %in% names(dt))
+  expect_true("base_asset_max_borrow_size" %in% names(dt))
+  expect_equal(dt$base_asset_currency, "BTC")
+  expect_equal(dt$base_asset_total, "0.1")
+  # Wide-prefixed quoteAsset columns
+  expect_true("quote_asset_currency" %in% names(dt))
+  expect_true("quote_asset_total" %in% names(dt))
+  expect_equal(dt$quote_asset_currency, "USDT")
+  expect_equal(dt$quote_asset_liability_principal, "950.00")
+  # Account-level summary replicated
+  expect_true("total_asset_of_quote_currency" %in% names(dt))
+  expect_true("total_liability_of_quote_currency" %in% names(dt))
+  expect_equal(dt$total_asset_of_quote_currency, "5234.67")
+  # Timestamp coerced to POSIXct
+  expect_s3_class(dt$timestamp, "POSIXct")
+  # No list columns anywhere
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+})
+
+test_that("get_isolated_margin_account replicates parent across multiple pairs", {
+  resp <- mock_kucoin_response(
+    data = list(
+      totalAssetOfQuoteCurrency = "100",
+      timestamp = 1729176273859,
+      assets = list(
+        list(
+          symbol = "BTC-USDT",
+          status = "EFFECTIVE",
+          debtRatio = "0",
+          baseAsset = list(currency = "BTC", total = "0.1"),
+          quoteAsset = list(currency = "USDT", total = "100")
+        ),
+        list(
+          symbol = "ETH-USDT",
+          status = "EFFECTIVE",
+          debtRatio = "0",
+          baseAsset = list(currency = "ETH", total = "1.0"),
+          quoteAsset = list(currency = "USDT", total = "200")
+        )
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_isolated_margin_account()
+  expect_equal(nrow(dt), 2L)
+  expect_equal(length(unique(dt$total_asset_of_quote_currency)), 1L)
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_isolated_margin_account handles empty assets", {
@@ -265,6 +365,7 @@ test_that("get_spot_ledger returns paginated data with created_at", {
   expect_false("datetime_created" %in% names(dt))
   expect_s3_class(dt$created_at, "POSIXct")
   expect_equal(dt$currency, "USDT")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_spot_ledger handles empty items", {
@@ -315,6 +416,7 @@ test_that("get_hf_ledger returns ledger entries with created_at", {
   expect_false("datetime_created" %in% names(dt))
   expect_s3_class(dt$created_at, "POSIXct")
   expect_equal(dt$biz_type, "TRADE_EXCHANGE")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_hf_ledger handles empty response", {
@@ -342,6 +444,7 @@ test_that("get_base_fee_rate returns fee rates", {
   expect_equal(nrow(dt), 1L)
   expect_equal(dt$taker_fee_rate, "0.001")
   expect_equal(dt$maker_fee_rate, "0.001")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 # -- get_fee_rate --
@@ -360,6 +463,7 @@ test_that("get_fee_rate returns per-symbol rates", {
   expect_equal(nrow(dt), 2L)
   expect_true("symbol" %in% names(dt))
   expect_true("taker_fee_rate" %in% names(dt))
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_fee_rate validates symbols parameter", {

--- a/tests/testthat/test-KucoinDeposit.R
+++ b/tests/testthat/test-KucoinDeposit.R
@@ -39,6 +39,8 @@ test_that("add_deposit_address returns data.table with column reorder", {
   expect_equal(dt$currency, "BTC")
   # Check column ordering starts with address
   expect_equal(names(dt)[1], "address")
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 # -- get_deposit_addresses --
@@ -72,6 +74,7 @@ test_that("get_deposit_addresses returns array as multi-row data.table", {
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 2L)
   expect_equal(names(dt)[1], "address")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_deposit_addresses handles single object response", {
@@ -91,6 +94,7 @@ test_that("get_deposit_addresses handles single object response", {
   dt <- new_deposit()$get_deposit_addresses(currency = "BTC")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_deposit_addresses handles empty response", {
@@ -137,10 +141,14 @@ test_that("get_deposit_history returns paginated data with created_at and column
   expect_true("created_at" %in% names(dt))
   expect_false("datetime_created" %in% names(dt))
   expect_s3_class(dt$created_at, "POSIXct")
+  # updated_at now coerced to POSIXct as well
+  expect_s3_class(dt$updated_at, "POSIXct")
   expect_equal(dt$currency, "BTC")
   expect_equal(dt$status, "SUCCESS")
   # Check column ordering
   expect_equal(names(dt)[1], "currency")
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_deposit_history handles empty items", {

--- a/tests/testthat/test-KucoinFuturesAccount.R
+++ b/tests/testthat/test-KucoinFuturesAccount.R
@@ -255,3 +255,172 @@ test_that("get_funding_history passes symbol in query", {
   new_account()$get_funding_history("XBTUSDTM")
   expect_true(grepl("symbol=XBTUSDTM", captured_url))
 })
+
+# -- Data-shape convention: no list columns, one entity = one row -------------
+#
+# The cross-package convention is documented in
+# `binance::vignette("data-shapes")`. For each method we sanity-check:
+#   - The output is a `data.table`.
+#   - No column is a list (i.e. no list cells / nested objects).
+#   - Empty responses produce empty `data.table`s, not stub rows or errors.
+
+# Helper: count list columns on a data.table.
+n_list_cols <- function(dt) {
+  length(names(dt)[vapply(dt, is.list, logical(1))])
+}
+
+test_that("get_account_overview has no list columns", {
+  resp <- mock_kucoin_response(data = mock_futures_account_overview_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_account_overview()
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("get_position has no list columns; timestamps are POSIXct", {
+  resp <- mock_kucoin_response(data = mock_futures_position_data()[[1]])
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_position("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$opening_timestamp, "POSIXct")
+  expect_s3_class(dt$current_timestamp, "POSIXct")
+})
+
+test_that("get_positions has no list columns; empty array yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_position_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_positions()
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$opening_timestamp, "POSIXct")
+
+  resp_empty <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp_empty)
+  dt_empty <- new_account()$get_positions()
+  expect_s3_class(dt_empty, "data.table")
+  expect_equal(nrow(dt_empty), 0L)
+})
+
+test_that("get_positions_history has no list columns; empty items yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_positions_history_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_positions_history()
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$open_time, "POSIXct")
+  expect_s3_class(dt$close_time, "POSIXct")
+
+  resp_empty <- mock_kucoin_response(data = list(items = list()))
+  httr2::local_mocked_responses(function(req) resp_empty)
+  dt_empty <- new_account()$get_positions_history()
+  expect_s3_class(dt_empty, "data.table")
+  expect_equal(nrow(dt_empty), 0L)
+})
+
+test_that("get_margin_mode has no list columns", {
+  resp <- mock_kucoin_response(data = mock_futures_margin_mode_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_margin_mode("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("set_margin_mode has no list columns", {
+  resp <- mock_kucoin_response(data = mock_futures_margin_mode_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$set_margin_mode("XBTUSDTM", "CROSS")
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("get_cross_margin_leverage has no list columns", {
+  resp <- mock_kucoin_response(data = mock_futures_cross_leverage_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_cross_margin_leverage("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("set_cross_margin_leverage has no list columns", {
+  resp <- mock_kucoin_response(data = mock_futures_cross_leverage_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$set_cross_margin_leverage("XBTUSDTM", 10)
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("get_max_open_size has no list columns", {
+  resp <- mock_kucoin_response(data = mock_futures_max_open_size_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_max_open_size("XBTUSDTM", price = "98000", leverage = 5)
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("get_max_withdraw_margin returns named max_withdraw_margin column", {
+  resp <- mock_kucoin_response(data = mock_futures_max_withdraw_margin_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_max_withdraw_margin("XBTUSDTM")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 1L)
+  expect_equal(names(dt), "max_withdraw_margin")
+  expect_type(dt$max_withdraw_margin, "character")
+  expect_equal(dt$max_withdraw_margin, "15.00")
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("get_max_withdraw_margin handles empty response", {
+  resp <- mock_kucoin_response(data = NULL)
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_max_withdraw_margin("XBTUSDTM")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("add_isolated_margin has no list columns", {
+  resp <- mock_kucoin_response(data = mock_futures_margin_response())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$add_isolated_margin("XBTUSDTM", margin = 10, bizNo = "biz-001")
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("remove_isolated_margin has no list columns", {
+  resp <- mock_kucoin_response(data = mock_futures_margin_response())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$remove_isolated_margin("XBTUSDTM", withdrawAmount = 5)
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("get_risk_limit has no list columns; empty array yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_risk_limit_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_risk_limit("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+
+  resp_empty <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp_empty)
+  dt_empty <- new_account()$get_risk_limit("XBTUSDTM")
+  expect_s3_class(dt_empty, "data.table")
+  expect_equal(nrow(dt_empty), 0L)
+})
+
+test_that("get_funding_history has no list columns; empty dataList yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_private_funding_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_account()$get_funding_history("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$time_point, "POSIXct")
+
+  resp_empty <- mock_kucoin_response(data = list(dataList = list(), hasMore = FALSE))
+  httr2::local_mocked_responses(function(req) resp_empty)
+  dt_empty <- new_account()$get_funding_history("XBTUSDTM")
+  expect_s3_class(dt_empty, "data.table")
+  expect_equal(nrow(dt_empty), 0L)
+})

--- a/tests/testthat/test-KucoinFuturesMarketData.R
+++ b/tests/testthat/test-KucoinFuturesMarketData.R
@@ -101,13 +101,28 @@ test_that("get_part_orderbook returns data.table with bids and asks", {
   dt <- new_market()$get_part_orderbook("XBTUSDTM", size = 20)
   expect_s3_class(dt, "data.table")
   expect_true(nrow(dt) > 0)
-  expect_true(all(c("ts", "sequence", "side", "price", "size") %in% names(dt)))
+  expect_true(all(c("ts", "sequence", "side", "level", "price", "size") %in% names(dt)))
   expect_s3_class(dt$ts, "POSIXct")
+  expect_type(dt$level, "integer")
   expect_true("bid" %in% dt$side)
   expect_true("ask" %in% dt$side)
   # Prices should be numeric
   expect_true(is.numeric(dt$price))
   expect_true(is.numeric(dt$size))
+})
+
+test_that("get_part_orderbook level column is 1-indexed depth within each side", {
+  resp <- mock_kucoin_response(data = mock_futures_orderbook_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_part_orderbook("XBTUSDTM", size = 20)
+
+  expect_equal(dt[side == "bid", level], seq_len(sum(dt$side == "bid")))
+  expect_equal(dt[side == "ask", level], seq_len(sum(dt$side == "ask")))
+  best_bid <- dt[side == "bid"][level == 1L, price]
+  best_ask <- dt[side == "ask"][level == 1L, price]
+  expect_equal(best_bid, max(dt[side == "bid", price]))
+  expect_equal(best_ask, min(dt[side == "ask", price]))
 })
 
 test_that("get_part_orderbook validates size parameter", {
@@ -325,7 +340,7 @@ test_that("get_part_orderbook has no list columns; long-format bids/asks", {
 
   dt <- new_market()$get_part_orderbook("XBTUSDTM", size = 20)
   expect_equal(n_list_cols(dt), 0L)
-  expect_true(all(c("ts", "sequence", "side", "price", "size") %in% names(dt)))
+  expect_true(all(c("ts", "sequence", "side", "level", "price", "size") %in% names(dt)))
   expect_s3_class(dt$ts, "POSIXct")
 })
 

--- a/tests/testthat/test-KucoinFuturesMarketData.R
+++ b/tests/testthat/test-KucoinFuturesMarketData.R
@@ -256,3 +256,151 @@ test_that("get_service_status returns data.table", {
   expect_true("status" %in% names(dt))
   expect_equal(dt$status, "open")
 })
+
+# -- Data-shape convention: no list columns, one entity = one row -------------
+#
+# Cross-package convention from `binance::vignette("data-shapes")`. For each
+# method we check that the parser yields a list-column-free `data.table` and
+# that empty responses produce empty `data.table`s (not stubs or errors).
+
+n_list_cols <- function(dt) {
+  length(names(dt)[vapply(dt, is.list, logical(1))])
+}
+
+test_that("get_contract has no list columns; empty response yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_contract_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_contract("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+
+  resp_empty <- mock_kucoin_response(data = NULL)
+  httr2::local_mocked_responses(function(req) resp_empty)
+  dt_empty <- new_market()$get_contract("XBTUSDTM")
+  expect_s3_class(dt_empty, "data.table")
+  expect_equal(nrow(dt_empty), 0L)
+})
+
+test_that("get_all_contracts has no list columns; empty response yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_all_contracts_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_all_contracts()
+  expect_equal(n_list_cols(dt), 0L)
+
+  resp_empty <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp_empty)
+  dt_empty <- new_market()$get_all_contracts()
+  expect_s3_class(dt_empty, "data.table")
+  expect_equal(nrow(dt_empty), 0L)
+})
+
+test_that("get_ticker has no list columns; ts is POSIXct", {
+  resp <- mock_kucoin_response(data = mock_futures_ticker_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_ticker("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$ts, "POSIXct")
+})
+
+test_that("get_all_tickers has no list columns; ts is POSIXct; empty array yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_all_tickers_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_all_tickers()
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$ts, "POSIXct")
+
+  resp_empty <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp_empty)
+  dt_empty <- new_market()$get_all_tickers()
+  expect_s3_class(dt_empty, "data.table")
+  expect_equal(nrow(dt_empty), 0L)
+})
+
+test_that("get_part_orderbook has no list columns; long-format bids/asks", {
+  resp <- mock_kucoin_response(data = mock_futures_orderbook_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_part_orderbook("XBTUSDTM", size = 20)
+  expect_equal(n_list_cols(dt), 0L)
+  expect_true(all(c("ts", "sequence", "side", "price", "size") %in% names(dt)))
+  expect_s3_class(dt$ts, "POSIXct")
+})
+
+test_that("get_trade_history has no list columns; empty array yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_trade_history_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_trade_history("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$ts, "POSIXct")
+
+  resp_empty <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp_empty)
+  dt_empty <- new_market()$get_trade_history("XBTUSDTM")
+  expect_s3_class(dt_empty, "data.table")
+  expect_equal(nrow(dt_empty), 0L)
+})
+
+test_that("get_klines has no list columns; empty array yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_klines_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_klines("XBTUSDTM", granularity = 60)
+  expect_equal(n_list_cols(dt), 0L)
+})
+
+test_that("get_mark_price has no list columns; time_point is POSIXct", {
+  resp <- mock_kucoin_response(data = mock_futures_mark_price_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_mark_price("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$time_point, "POSIXct")
+})
+
+test_that("get_funding_rate has no list columns; timestamps are POSIXct", {
+  resp <- mock_kucoin_response(data = mock_futures_funding_rate_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_funding_rate("XBTUSDTM")
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$time_point, "POSIXct")
+  expect_s3_class(dt$funding_time, "POSIXct")
+})
+
+test_that("get_funding_history has no list columns; empty array yields empty dt", {
+  resp <- mock_kucoin_response(data = mock_futures_funding_history_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  from_time <- as.POSIXct("2024-10-17 00:00:00", tz = "UTC")
+  to_time <- as.POSIXct("2024-10-18 00:00:00", tz = "UTC")
+  dt <- new_market()$get_funding_history("XBTUSDTM", from = from_time, to = to_time)
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$timepoint, "POSIXct")
+
+  resp_empty <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp_empty)
+  dt_empty <- new_market()$get_funding_history("XBTUSDTM", from = from_time, to = to_time)
+  expect_s3_class(dt_empty, "data.table")
+  expect_equal(nrow(dt_empty), 0L)
+})
+
+test_that("get_server_time has no list columns; server_time is POSIXct", {
+  resp <- mock_kucoin_response(data = mock_futures_server_time_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_server_time()
+  expect_equal(n_list_cols(dt), 0L)
+  expect_s3_class(dt$server_time, "POSIXct")
+})
+
+test_that("get_service_status has no list columns", {
+  resp <- mock_kucoin_response(data = mock_futures_service_status_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_market()$get_service_status()
+  expect_equal(n_list_cols(dt), 0L)
+})

--- a/tests/testthat/test-KucoinFuturesTrading.R
+++ b/tests/testthat/test-KucoinFuturesTrading.R
@@ -151,6 +151,52 @@ test_that("cancel_all_stop_orders hits stopOrders endpoint", {
   expect_s3_class(dt, "data.table")
 })
 
+# -- cancel parsers: NULL / empty payload regression --
+
+test_that("cancel_order_by_id returns 0-row data.table when data is NULL", {
+  resp <- mock_kucoin_response(data = NULL)
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_trading()$cancel_order_by_id("futures-order-001")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("cancel_order_by_client_oid returns 0-row data.table when data is NULL", {
+  # Futures `cancel_order_by_client_oid` returns a `{clientOid}` object,
+  # not a `cancelledOrderIds` array — pin the NULL-payload branch only.
+  resp <- mock_kucoin_response(data = NULL)
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_trading()$cancel_order_by_client_oid("client-001", "XBTUSDTM")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("cancel_all returns 0-row data.table on empty cancelledOrderIds", {
+  resp <- mock_kucoin_response(data = list(cancelledOrderIds = list()))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_trading()$cancel_all()
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("cancel_all explodes cancelledOrderIds into long-format rows", {
+  resp <- mock_kucoin_response(
+    data = list(cancelledOrderIds = list("id-x", "id-y", "id-z"))
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_trading()$cancel_all()
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 3L)
+  expect_true("cancelled_order_id" %in% names(dt))
+  expect_type(dt$cancelled_order_id, "character")
+  expect_equal(dt$cancelled_order_id, c("id-x", "id-y", "id-z"))
+  expect_false("cancelled_order_ids" %in% names(dt))
+})
+
 # -- get_order_by_id --
 
 test_that("get_order_by_id returns data.table with timestamps", {

--- a/tests/testthat/test-KucoinLending.R
+++ b/tests/testthat/test-KucoinLending.R
@@ -200,3 +200,150 @@ test_that("get_redeem_orders returns data.table with apply_time", {
   expect_false("datetime_applied" %in% names(dt))
   expect_equal(names(dt)[1], "currency")
 })
+
+test_that("get_redeem_orders returns empty data.table for empty items", {
+  resp <- mock_kucoin_response(data = list(items = list()))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_lending()$get_redeem_orders()
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+# -- Data-shape regression: no list columns, schema stability --
+#
+# Cross-package convention is "one entity = one row, no list columns".
+
+test_that("get_loan_market produces no list columns and correct types", {
+  resp <- mock_kucoin_response(
+    data = list(
+      list(
+        currency = "USDT",
+        purchaseEnable = TRUE,
+        redeemEnable = TRUE,
+        increment = "0.01",
+        minPurchaseSize = "10",
+        maxPurchaseSize = "1000000",
+        interestIncrement = "0.0001",
+        minInterestRate = "0.004",
+        marketInterestRate = "0.05",
+        maxInterestRate = "0.1",
+        autoPurchaseEnable = TRUE
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_lending()$get_loan_market()
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$currency))
+  expect_true(is.logical(dt$purchase_enable))
+  expect_true(is.logical(dt$redeem_enable))
+  expect_true(is.character(dt$increment))
+  expect_true(is.logical(dt$auto_purchase_enable))
+})
+
+test_that("get_loan_market_rate produces no list columns", {
+  resp <- mock_kucoin_response(
+    data = list(
+      list(time = "202603070000", marketInterestRate = "0.05"),
+      list(time = "202603080000", marketInterestRate = "0.048")
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_lending()$get_loan_market_rate(currency = "USDT")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$time))
+  expect_true(is.character(dt$market_interest_rate))
+})
+
+test_that("get_loan_market_rate returns empty data.table for empty response", {
+  resp <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_lending()$get_loan_market_rate(currency = "USDT")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("purchase returns no list columns", {
+  resp <- mock_kucoin_response(data = list(orderNo = "p-1"))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_lending()$purchase(currency = "USDT", size = 1000, interestRate = 0.05)
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$order_no))
+})
+
+test_that("redeem returns no list columns", {
+  resp <- mock_kucoin_response(data = list(orderNo = "r-1"))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_lending()$redeem(currency = "USDT", size = 500, purchaseOrderNo = "abc123")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$order_no))
+})
+
+test_that("modify_purchase returns no list columns", {
+  resp <- mock_kucoin_response(data = NULL)
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_lending()$modify_purchase(
+    currency = "USDT",
+    purchaseOrderNo = "abc",
+    interestRate = 0.06
+  )
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+})
+
+test_that("get_purchase_orders schema: no list columns, POSIXct apply_time", {
+  resp <- mock_kucoin_response(
+    data = list(
+      items = list(
+        list(
+          currency = "USDT",
+          purchaseOrderNo = "p1",
+          purchaseSize = "1000",
+          matchSize = "800",
+          interestRate = "0.05",
+          incomeSize = "3.42",
+          applyTime = 1729655606816,
+          status = "DONE"
+        )
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_lending()$get_purchase_orders()
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_s3_class(dt$apply_time, "POSIXct")
+  expect_true(is.character(dt$currency))
+  expect_true(is.character(dt$purchase_order_no))
+})
+
+test_that("get_redeem_orders schema: no list columns, POSIXct apply_time", {
+  resp <- mock_kucoin_response(
+    data = list(
+      items = list(
+        list(
+          currency = "USDT",
+          purchaseOrderNo = "p1",
+          redeemOrderNo = "r1",
+          redeemSize = "500",
+          receiptSize = "500",
+          applyTime = 1729655606816,
+          status = "DONE"
+        )
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_lending()$get_redeem_orders()
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_s3_class(dt$apply_time, "POSIXct")
+  expect_true(is.character(dt$currency))
+  expect_true(is.character(dt$redeem_order_no))
+})

--- a/tests/testthat/test-KucoinMarginData.R
+++ b/tests/testthat/test-KucoinMarginData.R
@@ -193,3 +193,187 @@ test_that("get_risk_limit returns empty data.table for empty response", {
   dt <- new_margin_data()$get_risk_limit(isIsolated = FALSE)
   expect_equal(nrow(dt), 0L)
 })
+
+# -- Data-shape regression: no list columns, schema stability --
+#
+# Cross-package convention is "one entity = one row, no list columns". These
+# tests pin the shape for each public method so a future change that would
+# accidentally introduce a list column (e.g. via API drift surfacing a new
+# nested object) fails loudly.
+
+test_that("get_cross_margin_symbols produces no list columns", {
+  resp <- mock_kucoin_response(
+    data = list(
+      timestamp = 1772993986642,
+      items = list(
+        list(
+          symbol = "BTC-USDT",
+          name = "BTC-USDT",
+          enableTrading = TRUE,
+          market = "USDS",
+          baseCurrency = "BTC",
+          quoteCurrency = "USDT",
+          baseIncrement = "0.00000001",
+          baseMinSize = "0.00001",
+          baseMaxSize = "10000000000",
+          quoteIncrement = "0.000001",
+          quoteMinSize = "0.1",
+          quoteMaxSize = "99999999",
+          priceIncrement = "0.1",
+          feeCurrency = "USDT",
+          priceLimitRate = "0.01",
+          minFunds = "0.1"
+        )
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin_data()$get_cross_margin_symbols()
+  expect_s3_class(dt, "data.table")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$symbol))
+  expect_true(is.logical(dt$enable_trading))
+  expect_true(all(c("base_currency", "quote_currency", "min_funds") %in% names(dt)))
+})
+
+test_that("get_isolated_margin_symbols produces no list columns", {
+  resp <- mock_kucoin_response(
+    data = list(
+      list(
+        symbol = "BTC-USDT",
+        symbolName = "BTC-USDT",
+        baseCurrency = "BTC",
+        quoteCurrency = "USDT",
+        maxLeverage = 10L,
+        flDebtRatio = "0.97",
+        tradeEnable = TRUE,
+        baseBorrowEnable = TRUE,
+        quoteBorrowEnable = TRUE,
+        baseTransferInEnable = TRUE,
+        quoteTransferInEnable = TRUE
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin_data()$get_isolated_margin_symbols()
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$symbol))
+  expect_true(is.integer(dt$max_leverage))
+  expect_true(is.logical(dt$trade_enable))
+  expect_true(is.logical(dt$base_borrow_enable))
+})
+
+test_that("get_isolated_margin_symbols returns empty data.table for empty response", {
+  resp <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin_data()$get_isolated_margin_symbols()
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("get_margin_config produces no list columns and integer max_leverage", {
+  resp <- mock_kucoin_response(
+    data = list(
+      maxLeverage = 10L,
+      warningDebtRatio = "0.95",
+      liqDebtRatio = "0.97",
+      currencyList = list("BTC", "ETH", "USDT")
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  config <- new_margin_data()$get_margin_config()
+  expect_equal(length(names(config)[vapply(config, is.list, logical(1))]), 0L)
+  expect_true(is.character(config$currency))
+  expect_true(is.integer(config$max_leverage))
+  expect_true(is.character(config$warning_debt_ratio))
+  expect_true(is.character(config$liq_debt_ratio))
+  expect_equal(names(config)[1], "currency")
+})
+
+test_that("get_margin_config returns zero-row schema-stable table when currencyList is empty", {
+  resp <- mock_kucoin_response(
+    data = list(
+      maxLeverage = 10L,
+      warningDebtRatio = "0.95",
+      liqDebtRatio = "0.97",
+      currencyList = list()
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  config <- new_margin_data()$get_margin_config()
+  expect_s3_class(config, "data.table")
+  expect_equal(nrow(config), 0L)
+  expect_true(all(c("currency", "max_leverage", "warning_debt_ratio", "liq_debt_ratio") %in% names(config)))
+  expect_equal(names(config)[1], "currency")
+})
+
+test_that("get_margin_config returns empty data.table for null data", {
+  resp <- mock_kucoin_response(data = NULL)
+  httr2::local_mocked_responses(function(req) resp)
+
+  config <- new_margin_data()$get_margin_config()
+  expect_s3_class(config, "data.table")
+  expect_equal(nrow(config), 0L)
+})
+
+test_that("get_collateral_ratio produces no list columns", {
+  resp <- mock_kucoin_response(
+    data = list(
+      list(
+        currencyList = list("BTC", "ETH"),
+        items = list(
+          list(lowerLimit = "0", upperLimit = "10", collateralRatio = "1.0")
+        )
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  result <- new_margin_data()$get_collateral_ratio()
+  expect_equal(length(names(result)[vapply(result, is.list, logical(1))]), 0L)
+  expect_true(is.character(result$currency))
+  expect_true(is.character(result$lower_limit))
+  expect_true(is.character(result$upper_limit))
+  expect_true(is.character(result$collateral_ratio))
+  expect_equal(nrow(result), 2L)
+})
+
+test_that("get_collateral_ratio returns empty data.table for empty response", {
+  resp <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin_data()$get_collateral_ratio()
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("get_risk_limit produces no list columns", {
+  resp <- mock_kucoin_response(
+    data = list(
+      list(
+        currency = "BTC",
+        borrowMaxAmount = "100",
+        buyMaxAmount = "100",
+        holdMaxAmount = "100",
+        borrowCoefficient = "1",
+        marginCoefficient = "1",
+        precision = 8L,
+        borrowMinAmount = "0.001",
+        borrowMinUnit = "0.001",
+        borrowEnabled = TRUE
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin_data()$get_risk_limit(isIsolated = FALSE)
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$currency))
+  expect_true(is.integer(dt$precision))
+  expect_true(is.logical(dt$borrow_enabled))
+})

--- a/tests/testthat/test-KucoinMarginTrading.R
+++ b/tests/testthat/test-KucoinMarginTrading.R
@@ -278,3 +278,181 @@ test_that("modify_leverage validates leverage", {
   expect_error(new_margin()$modify_leverage(leverage = -1), "positive")
   expect_error(new_margin()$modify_leverage(leverage = "abc"), "positive")
 })
+
+# -- Data-shape regression: no list columns, schema stability --
+#
+# Cross-package convention is "one entity = one row, no list columns".
+
+test_that("open_short returns no list columns", {
+  resp <- mock_kucoin_response(
+    data = list(
+      orderId = "o1",
+      clientOid = "c1",
+      borrowSize = "0.001",
+      loanApplyId = "loan-1"
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$open_short(symbol = "BTC-USDT", size = 0.001)
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$order_id))
+  expect_true(is.character(dt$client_oid))
+  expect_true(is.character(dt$borrow_size))
+  expect_true(is.character(dt$loan_apply_id))
+})
+
+test_that("close_long returns no list columns", {
+  resp <- mock_kucoin_response(data = list(orderId = "o4", clientOid = "c4"))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$close_long(symbol = "BTC-USDT", size = 0.001)
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$order_id))
+  expect_true(is.character(dt$client_oid))
+})
+
+test_that("borrow returns no list columns", {
+  resp <- mock_kucoin_response(data = list(orderNo = "b1", actualSize = "100"))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$borrow(currency = "USDT", size = 100)
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$order_no))
+  expect_true(is.character(dt$actual_size))
+})
+
+test_that("repay coerces timestamp to POSIXct with no list columns", {
+  resp <- mock_kucoin_response(
+    data = list(timestamp = 1729655606816, orderNo = "r1", actualSize = "100")
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$repay(currency = "USDT", size = 100)
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 1L)
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_s3_class(dt$timestamp, "POSIXct")
+  expect_true(is.character(dt$order_no))
+  expect_true(is.character(dt$actual_size))
+})
+
+test_that("get_borrow_history schema: no list columns, POSIXct created_time", {
+  resp <- mock_kucoin_response(
+    data = list(
+      items = list(
+        list(
+          orderNo = "b1",
+          symbol = "BTC-USDT",
+          currency = "USDT",
+          size = "100",
+          actualSize = "100",
+          status = "DONE",
+          createdTime = 1729655606816
+        )
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$get_borrow_history()
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_s3_class(dt$created_time, "POSIXct")
+  expect_true(is.character(dt$order_no))
+  expect_true(is.character(dt$currency))
+})
+
+test_that("get_repay_history schema: no list columns, POSIXct created_time", {
+  resp <- mock_kucoin_response(
+    data = list(
+      items = list(
+        list(
+          orderNo = "r1",
+          symbol = "BTC-USDT",
+          currency = "USDT",
+          size = "100",
+          actualSize = "100",
+          status = "DONE",
+          createdTime = 1729655606816
+        )
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$get_repay_history()
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_s3_class(dt$created_time, "POSIXct")
+})
+
+test_that("get_interest_history schema: no list columns, POSIXct created_time", {
+  resp <- mock_kucoin_response(
+    data = list(
+      items = list(
+        list(
+          currency = "USDT",
+          dayRatio = "0.0001",
+          interestAmount = "0.01",
+          createdTime = 1729655606816
+        )
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$get_interest_history()
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_s3_class(dt$created_time, "POSIXct")
+  expect_true(is.character(dt$currency))
+})
+
+test_that("get_borrow_rate schema: no list columns", {
+  resp <- mock_kucoin_response(
+    data = list(
+      list(currency = "BTC", hourlyBorrowRate = "0.000004", annualizedBorrowRate = "0.035"),
+      list(currency = "USDT", hourlyBorrowRate = "0.000006", annualizedBorrowRate = "0.0526")
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$get_borrow_rate()
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+  expect_true(is.character(dt$currency))
+  expect_true(is.character(dt$hourly_borrow_rate))
+  expect_true(is.character(dt$annualized_borrow_rate))
+})
+
+test_that("get_borrow_rate returns empty data.table for empty response", {
+  resp <- mock_kucoin_response(data = list())
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$get_borrow_rate()
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("get_interest_history returns empty data.table for empty items", {
+  resp <- mock_kucoin_response(data = list(items = list()))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$get_interest_history()
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("get_repay_history returns empty data.table for empty items", {
+  resp <- mock_kucoin_response(data = list(items = list()))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$get_repay_history()
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("modify_leverage returns no list columns", {
+  resp <- mock_kucoin_response(data = NULL)
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_margin()$modify_leverage(leverage = 5)
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+})

--- a/tests/testthat/test-KucoinMarketData.R
+++ b/tests/testthat/test-KucoinMarketData.R
@@ -102,11 +102,30 @@ test_that("get_part_orderbook returns orderbook with correct structure", {
   dt <- market$get_part_orderbook("BTC-USDT", size = 20)
 
   expect_s3_class(dt, "data.table")
-  expect_equal(names(dt), c("time", "sequence", "side", "price", "size"))
+  expect_equal(names(dt), c("time", "sequence", "side", "level", "price", "size"))
   expect_equal(nrow(dt), 6L)
   expect_s3_class(dt$time, "POSIXct")
+  expect_type(dt$level, "integer")
   expect_type(dt$price, "double")
   expect_type(dt$size, "double")
+})
+
+test_that("get_part_orderbook level column is 1-indexed depth within each side", {
+  resp <- mock_kucoin_response(data = mock_orderbook_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
+  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
+  dt <- market$get_part_orderbook("BTC-USDT", size = 20)
+
+  # Each side should start at level 1 and increment without gaps.
+  expect_equal(dt[side == "bid", level], seq_len(sum(dt$side == "bid")))
+  expect_equal(dt[side == "ask", level], seq_len(sum(dt$side == "ask")))
+  # level == 1 must correspond to best price (highest bid, lowest ask).
+  best_bid <- dt[side == "bid"][level == 1L, price]
+  best_ask <- dt[side == "ask"][level == 1L, price]
+  expect_equal(best_bid, max(dt[side == "bid", price]))
+  expect_equal(best_ask, min(dt[side == "ask", price]))
 })
 
 test_that("get_part_orderbook uses correct endpoint for size 20 vs 100", {
@@ -306,6 +325,29 @@ test_that("get_announcements handles announcements with no annType (NA_character
 
   expect_true(is.na(dt$ann_type[1]))
   expect_equal(dt$ann_type[2], "latest-announcements")
+})
+
+test_that("get_announcements warns once when an annType value contains a literal `;`", {
+  # KuCoin tags don't contain `;` today, but the `;`-collapse contract
+  # is shared cross-package, so pin the warning behaviour: if any value
+  # ever does contain `;` the user gets a once-per-session warning
+  # (silent corruption would be much worse — downstream `strsplit` on
+  # `;` would produce extra spurious tokens).
+  rlang::reset_warning_verbosity("collapse_sep_collision_annType")
+
+  data <- mock_announcements_page_data()
+  data$items[[1]]$annType <- list("clean", "bad;tag")
+  resp <- mock_kucoin_response(data = data)
+  httr2::local_mocked_responses(function(req) resp)
+
+  market <- KucoinMarketData$new()
+  expect_warning(
+    dt <- market$get_announcements(page_size = 50, max_pages = 1),
+    "literal `;`"
+  )
+  # The collision warning does not block the collapse — value is still
+  # joined verbatim so callers see exactly what came off the wire.
+  expect_equal(dt$ann_type[1], "clean;bad;tag")
 })
 
 # -- get_full_orderbook (authenticated) --

--- a/tests/testthat/test-KucoinMarketData.R
+++ b/tests/testthat/test-KucoinMarketData.R
@@ -259,6 +259,55 @@ test_that("get_klines returns OHLCV data.table via kucoin_fetch_klines", {
   expect_gt(nrow(dt), 0L)
 })
 
+# -- get_announcements --
+
+test_that("get_announcements collapses ann_type to a `;`-separated string (Treatment A)", {
+  # Cross-package convention: arrays of plain strings -> single
+  # character column, recoverable via `strsplit(x, ";", fixed = TRUE)`.
+  # The mock has two announcements: the first with two tags, the second
+  # with one.
+  resp <- mock_kucoin_response(data = mock_announcements_page_data())
+  httr2::local_mocked_responses(function(req) resp)
+
+  market <- KucoinMarketData$new()
+  dt <- market$get_announcements(page_size = 50, max_pages = 1)
+
+  expect_s3_class(dt, "data.table")
+  # Two source records -> two rows (NOT four — Treatment A keeps one
+  # row per entity even when the array has multiple values).
+  expect_equal(nrow(dt), 2L)
+
+  # `ann_type` is a character column, `;`-collapsed.
+  expect_type(dt$ann_type, "character")
+  expect_equal(dt$ann_type[1], "latest-announcements;new-listings")
+  expect_equal(dt$ann_type[2], "latest-announcements")
+
+  # No list columns.
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
+
+  # c_time converted to POSIXct.
+  expect_s3_class(dt$c_time, "POSIXct")
+
+  # Recover the original vector for one record.
+  expect_equal(
+    strsplit(dt$ann_type[1], ";", fixed = TRUE)[[1]],
+    c("latest-announcements", "new-listings")
+  )
+})
+
+test_that("get_announcements handles announcements with no annType (NA_character_)", {
+  data <- mock_announcements_page_data()
+  data$items[[1]]$annType <- list()
+  resp <- mock_kucoin_response(data = data)
+  httr2::local_mocked_responses(function(req) resp)
+
+  market <- KucoinMarketData$new()
+  dt <- market$get_announcements(page_size = 50, max_pages = 1)
+
+  expect_true(is.na(dt$ann_type[1]))
+  expect_equal(dt$ann_type[2], "latest-announcements")
+})
+
 # -- get_full_orderbook (authenticated) --
 
 test_that("get_full_orderbook passes authentication headers", {

--- a/tests/testthat/test-KucoinOcoOrders.R
+++ b/tests/testthat/test-KucoinOcoOrders.R
@@ -171,10 +171,11 @@ test_that("get_order_detail_by_id returns data.table with orders list-column", {
 
   dt <- new_oco()$get_order_detail_by_id("674c40d38b4b2f00073deef3")
   expect_s3_class(dt, "data.table")
-  expect_equal(nrow(dt), 1L)
+  expect_equal(nrow(dt), 2L)
   expect_true("order_time" %in% names(dt))
-  expect_true("orders" %in% names(dt))
-  expect_equal(dt$status, "NEW")
+  expect_true("sub_order_id" %in% names(dt))
+  expect_false("orders" %in% names(dt))
+  expect_equal(dt$status[1], "NEW")
 })
 
 # -- get_order_list --

--- a/tests/testthat/test-KucoinOcoOrders.R
+++ b/tests/testthat/test-KucoinOcoOrders.R
@@ -91,6 +91,50 @@ test_that("cancel_all returns data.table", {
   expect_s3_class(dt, "data.table")
 })
 
+# -- cancel parsers: NULL / empty payload regression --
+
+test_that("cancel_order_by_id returns 0-row data.table when data is NULL", {
+  resp <- mock_kucoin_response(data = NULL)
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_oco()$cancel_order_by_id("674c40d38b4b2f00073deef3")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("cancel_order_by_client_oid returns 0-row data.table on empty cancelledOrderIds", {
+  resp <- mock_kucoin_response(data = list(cancelledOrderIds = list()))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_oco()$cancel_order_by_client_oid("my-bot-oco-001")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("cancel_all returns 0-row data.table on empty cancelledOrderIds", {
+  resp <- mock_kucoin_response(data = list(cancelledOrderIds = list()))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_oco()$cancel_all(query = list(symbol = "BTC-USDT"))
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
+})
+
+test_that("cancel_order_by_id explodes cancelledOrderIds into long-format rows", {
+  resp <- mock_kucoin_response(
+    data = list(cancelledOrderIds = list("id-a", "id-b", "id-c"))
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_oco()$cancel_order_by_id("id-a")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 3L)
+  expect_true("cancelled_order_id" %in% names(dt))
+  expect_type(dt$cancelled_order_id, "character")
+  expect_equal(dt$cancelled_order_id, c("id-a", "id-b", "id-c"))
+  expect_false("cancelled_order_ids" %in% names(dt))
+})
+
 # -- get_order_by_id --
 
 test_that("get_order_by_id returns data.table with order_time and column reorder", {

--- a/tests/testthat/test-KucoinStopOrders.R
+++ b/tests/testthat/test-KucoinStopOrders.R
@@ -8,6 +8,11 @@ new_stop <- function() {
   KucoinStopOrders$new(keys = KEYS, base_url = BASE)
 }
 
+expect_no_list_cols <- function(dt) {
+  list_cols <- names(dt)[vapply(dt, is.list, logical(1))]
+  expect_equal(length(list_cols), 0L, info = paste("unexpected list columns:", paste(list_cols, collapse = ", ")))
+}
+
 # -- Construction --
 
 test_that("KucoinStopOrders inherits from KucoinBase", {
@@ -18,7 +23,7 @@ test_that("KucoinStopOrders inherits from KucoinBase", {
 
 # -- add_order --
 
-test_that("add_order limit returns order_id", {
+test_that("add_order limit returns order_id with client_oid column", {
   resp <- mock_kucoin_response(data = list(orderId = "vs8hoo8q2ceshiue003b67c0", clientOid = NA))
   httr2::local_mocked_responses(function(req) resp)
 
@@ -32,6 +37,26 @@ test_that("add_order limit returns order_id", {
   )
   expect_s3_class(dt, "data.table")
   expect_equal(dt$order_id, "vs8hoo8q2ceshiue003b67c0")
+  expect_true("client_oid" %in% names(dt))
+  expect_equal(names(dt)[1], "order_id")
+  expect_no_list_cols(dt)
+})
+
+test_that("add_order injects NA client_oid when API omits it", {
+  resp <- mock_kucoin_response(data = list(orderId = "vs8hoo8q2ceshiue003b67c0"))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_stop()$add_order(
+    type = "limit",
+    symbol = "BTC-USDT",
+    side = "sell",
+    stopPrice = "90000",
+    price = "89500",
+    size = "0.00001"
+  )
+  expect_true("client_oid" %in% names(dt))
+  expect_true(is.na(dt$client_oid))
+  expect_no_list_cols(dt)
 })
 
 test_that("add_order market by size works", {
@@ -46,6 +71,7 @@ test_that("add_order market by size works", {
     size = "0.00001"
   )
   expect_equal(dt$order_id, "mkt1")
+  expect_no_list_cols(dt)
 })
 
 test_that("add_order market by funds works", {
@@ -60,6 +86,7 @@ test_that("add_order market by funds works", {
     funds = "100"
   )
   expect_equal(dt$order_id, "mkt2")
+  expect_no_list_cols(dt)
 })
 
 test_that("add_order validates type-specific constraints", {
@@ -140,17 +167,45 @@ test_that("add_order validates type-specific constraints", {
 
 # -- cancel_order_by_id --
 
-test_that("cancel_order_by_id returns data.table", {
+test_that("cancel_order_by_id returns one row per cancelled id (Treatment B)", {
   resp <- mock_kucoin_response(data = list(cancelledOrderIds = list("vs8hoo8q2ceshiue003b67c0")))
   httr2::local_mocked_responses(function(req) resp)
 
   dt <- new_stop()$cancel_order_by_id("vs8hoo8q2ceshiue003b67c0")
   expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 1L)
+  expect_true("cancelled_order_id" %in% names(dt))
+  expect_false("cancelled_order_ids" %in% names(dt))
+  expect_equal(dt$cancelled_order_id, "vs8hoo8q2ceshiue003b67c0")
+  expect_no_list_cols(dt)
+})
+
+test_that("cancel_order_by_id explodes multi-id payload to long format", {
+  resp <- mock_kucoin_response(
+    data = list(
+      cancelledOrderIds = list("id1", "id2", "id3")
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_stop()$cancel_order_by_id("id1")
+  expect_equal(nrow(dt), 3L)
+  expect_equal(dt$cancelled_order_id, c("id1", "id2", "id3"))
+  expect_no_list_cols(dt)
+})
+
+test_that("cancel_order_by_id returns empty data.table on empty array", {
+  resp <- mock_kucoin_response(data = list(cancelledOrderIds = list()))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_stop()$cancel_order_by_id("xyz")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
 })
 
 # -- cancel_order_by_client_oid --
 
-test_that("cancel_order_by_client_oid returns data.table", {
+test_that("cancel_order_by_client_oid returns single-row data.table", {
   resp <- mock_kucoin_response(
     data = list(
       cancelledOrderId = "vs8hoo8q2ceshiue003b67c0",
@@ -161,12 +216,16 @@ test_that("cancel_order_by_client_oid returns data.table", {
 
   dt <- new_stop()$cancel_order_by_client_oid("my-stop-001", symbol = "BTC-USDT")
   expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 1L)
   expect_equal(dt$client_oid, "my-stop-001")
+  expect_equal(dt$cancelled_order_id, "vs8hoo8q2ceshiue003b67c0")
+  expect_equal(names(dt)[1], "cancelled_order_id")
+  expect_no_list_cols(dt)
 })
 
 # -- cancel_all --
 
-test_that("cancel_all returns data.table", {
+test_that("cancel_all returns one row per cancelled id (Treatment B)", {
   resp <- mock_kucoin_response(
     data = list(
       cancelledOrderIds = list("id1", "id2", "id3")
@@ -176,11 +235,25 @@ test_that("cancel_all returns data.table", {
 
   dt <- new_stop()$cancel_all(query = list(symbol = "BTC-USDT"))
   expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 3L)
+  expect_true("cancelled_order_id" %in% names(dt))
+  expect_false("cancelled_order_ids" %in% names(dt))
+  expect_equal(dt$cancelled_order_id, c("id1", "id2", "id3"))
+  expect_no_list_cols(dt)
+})
+
+test_that("cancel_all returns empty data.table when no matches", {
+  resp <- mock_kucoin_response(data = list(cancelledOrderIds = list()))
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_stop()$cancel_all()
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
 })
 
 # -- get_order_by_id --
 
-test_that("get_order_by_id returns data.table with created_at", {
+test_that("get_order_by_id returns data.table with created_at as POSIXct", {
   resp <- mock_kucoin_response(
     data = list(
       id = "vs8hoo8q2ceshiue003b67c0",
@@ -203,6 +276,29 @@ test_that("get_order_by_id returns data.table with created_at", {
   expect_false("datetime_created" %in% names(dt))
   expect_s3_class(dt$created_at, "POSIXct")
   expect_equal(dt$symbol, "BTC-USDT")
+  expect_no_list_cols(dt)
+})
+
+test_that("get_order_by_id converts order_time (ns) and stop_trigger_time (ms) to POSIXct", {
+  resp <- mock_kucoin_response(
+    data = list(
+      id = "vs8hoo8q2ceshiue003b67c0",
+      symbol = "BTC-USDT",
+      type = "limit",
+      side = "sell",
+      stopPrice = "90000",
+      createdAt = 1706789012000,
+      orderTime = 1706789012345678900,
+      stopTriggerTime = 1706789999000
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_stop()$get_order_by_id("vs8hoo8q2ceshiue003b67c0")
+  expect_s3_class(dt$created_at, "POSIXct")
+  expect_s3_class(dt$order_time, "POSIXct")
+  expect_s3_class(dt$stop_trigger_time, "POSIXct")
+  expect_no_list_cols(dt)
 })
 
 # -- get_order_by_client_oid --
@@ -224,7 +320,9 @@ test_that("get_order_by_client_oid handles array response", {
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("created_at" %in% names(dt))
+  expect_s3_class(dt$created_at, "POSIXct")
   expect_equal(dt$client_oid, "my-stop-001")
+  expect_no_list_cols(dt)
 })
 
 test_that("get_order_by_client_oid handles single object response", {
@@ -241,11 +339,22 @@ test_that("get_order_by_client_oid handles single object response", {
   dt <- new_stop()$get_order_by_client_oid("my-stop-001", symbol = "BTC-USDT")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
+  expect_s3_class(dt$created_at, "POSIXct")
+  expect_no_list_cols(dt)
+})
+
+test_that("get_order_by_client_oid returns empty data.table on null payload", {
+  resp <- mock_kucoin_response(data = NULL)
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_stop()$get_order_by_client_oid("missing", symbol = "BTC-USDT")
+  expect_s3_class(dt, "data.table")
+  expect_equal(nrow(dt), 0L)
 })
 
 # -- get_order_list --
 
-test_that("get_order_list returns orders with created_at", {
+test_that("get_order_list returns orders with timestamp columns as POSIXct", {
   resp <- mock_kucoin_response(
     data = list(
       currentPage = 1,
@@ -260,7 +369,8 @@ test_that("get_order_list returns orders with created_at", {
           side = "sell",
           price = "89500",
           stopPrice = "90000",
-          createdAt = 1706789012000
+          createdAt = 1706789012000,
+          orderTime = 1706789012345678900
         )
       )
     )
@@ -272,6 +382,10 @@ test_that("get_order_list returns orders with created_at", {
   expect_equal(nrow(dt), 1L)
   expect_true("created_at" %in% names(dt))
   expect_false("datetime_created" %in% names(dt))
+  expect_s3_class(dt$created_at, "POSIXct")
+  expect_s3_class(dt$order_time, "POSIXct")
+  expect_equal(names(dt)[1], "id")
+  expect_no_list_cols(dt)
 })
 
 test_that("get_order_list handles empty items", {
@@ -289,4 +403,40 @@ test_that("get_order_list handles empty items", {
   dt <- new_stop()$get_order_list()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 0L)
+})
+
+test_that("get_order_list produces one row per order across multi-item payload", {
+  resp <- mock_kucoin_response(
+    data = list(
+      currentPage = 1,
+      pageSize = 50,
+      totalNum = 2,
+      totalPage = 1,
+      items = list(
+        list(
+          id = "id-1",
+          symbol = "BTC-USDT",
+          type = "limit",
+          side = "sell",
+          stopPrice = "90000",
+          createdAt = 1706789012000
+        ),
+        list(
+          id = "id-2",
+          symbol = "ETH-USDT",
+          type = "market",
+          side = "buy",
+          stopPrice = "3000",
+          createdAt = 1706789013000
+        )
+      )
+    )
+  )
+  httr2::local_mocked_responses(function(req) resp)
+
+  dt <- new_stop()$get_order_list()
+  expect_equal(nrow(dt), 2L)
+  expect_equal(dt$id, c("id-1", "id-2"))
+  expect_equal(dt$symbol, c("BTC-USDT", "ETH-USDT"))
+  expect_no_list_cols(dt)
 })

--- a/tests/testthat/test-KucoinSubAccount.R
+++ b/tests/testthat/test-KucoinSubAccount.R
@@ -172,9 +172,9 @@ test_that("get_detail_balance returns rows across account types", {
   expect_true("account_type" %in% names(dt))
   expect_true("sub_user_id" %in% names(dt))
   expect_true("sub_name" %in% names(dt))
-  expect_equal(sum(dt$account_type == "main_accounts"), 2L)
-  expect_equal(sum(dt$account_type == "trade_accounts"), 1L)
-  expect_equal(sum(dt$account_type == "margin_accounts"), 1L)
+  expect_equal(sum(dt$account_type == "main"), 2L)
+  expect_equal(sum(dt$account_type == "trade"), 1L)
+  expect_equal(sum(dt$account_type == "margin"), 1L)
   # Check column ordering
   expect_equal(names(dt)[1:3], c("sub_user_id", "sub_name", "account_type"))
 })

--- a/tests/testthat/test-KucoinSubAccount.R
+++ b/tests/testthat/test-KucoinSubAccount.R
@@ -172,9 +172,9 @@ test_that("get_detail_balance returns rows across account types", {
   expect_true("account_type" %in% names(dt))
   expect_true("sub_user_id" %in% names(dt))
   expect_true("sub_name" %in% names(dt))
-  expect_equal(sum(dt$account_type == "main"), 2L)
-  expect_equal(sum(dt$account_type == "trade"), 1L)
-  expect_equal(sum(dt$account_type == "margin"), 1L)
+  expect_equal(sum(dt$account_type == "main_accounts"), 2L)
+  expect_equal(sum(dt$account_type == "trade_accounts"), 1L)
+  expect_equal(sum(dt$account_type == "margin_accounts"), 1L)
   # Check column ordering
   expect_equal(names(dt)[1:3], c("sub_user_id", "sub_name", "account_type"))
 })

--- a/tests/testthat/test-KucoinTransfer.R
+++ b/tests/testthat/test-KucoinTransfer.R
@@ -33,6 +33,8 @@ test_that("add_transfer returns data.table with order_id", {
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_equal(dt$order_id, "6705f7248c6954000733ecac")
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("add_transfer validates clientOid", {
@@ -160,6 +162,8 @@ test_that("get_transferable returns data.table with balance breakdown", {
   expect_equal(dt$transferable, "10.5")
   # Check column ordering
   expect_equal(names(dt)[1], "currency")
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_transferable validates currency", {

--- a/tests/testthat/test-KucoinWithdrawal.R
+++ b/tests/testthat/test-KucoinWithdrawal.R
@@ -32,6 +32,7 @@ test_that("add_withdrawal returns data.table with withdrawal_id", {
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_equal(dt$withdrawal_id, "670deec84d64da0007d7c946")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("add_withdrawal validates currency", {
@@ -111,6 +112,7 @@ test_that("cancel_withdrawal returns data.table with withdrawal_id", {
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_equal(dt$withdrawal_id, "670deec84d64da0007d7c946")
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("cancel_withdrawal validates withdrawalId", {
@@ -154,6 +156,8 @@ test_that("get_withdrawal_quotas returns data.table with quota details", {
   expect_equal(dt$precision, 8L)
   # Check column ordering starts with currency
   expect_equal(names(dt)[1], "currency")
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_withdrawal_quotas validates currency", {
@@ -199,10 +203,14 @@ test_that("get_withdrawal_history returns paginated data with created_at", {
   expect_true("created_at" %in% names(dt))
   expect_false("datetime_created" %in% names(dt))
   expect_s3_class(dt$created_at, "POSIXct")
+  # updated_at now coerced to POSIXct
+  expect_s3_class(dt$updated_at, "POSIXct")
   expect_equal(dt$currency, "USDT")
   expect_equal(dt$status, "SUCCESS")
   # Check column ordering
   expect_equal(names(dt)[1], "currency")
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_withdrawal_history handles empty items", {
@@ -275,6 +283,8 @@ test_that("get_withdrawal_by_id returns detailed data.table with created_at", {
   expect_equal(dt$cancel_type, "NON_CANCELABLE")
   # Check column ordering starts with id
   expect_equal(names(dt)[1], "id")
+  # No list columns
+  expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
 })
 
 test_that("get_withdrawal_by_id validates withdrawalId", {

--- a/tests/testthat/test-bug-hunt.R
+++ b/tests/testthat/test-bug-hunt.R
@@ -101,7 +101,7 @@ test_that("kucoin_paginate uses provided timeout, not default 10s", {
   # httr2 stores timeout in options
   req_options <- captured_req$options
   expect_equal(
-    req_options$timeout_ms %||% req_options$timeout,
+    if (is.null(req_options$timeout_ms)) req_options$timeout else req_options$timeout_ms,
     30000,
     info = "Paginated requests should use the specified timeout (30s), not default (10s)"
   )

--- a/tests/testthat/test-helpers_parse.R
+++ b/tests/testthat/test-helpers_parse.R
@@ -84,7 +84,7 @@ test_that("parse_orderbook creates correct data.table from bid/ask arrays", {
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 6L) # 3 bids + 3 asks
-  expect_equal(names(dt), c("time", "sequence", "side", "price", "size"))
+  expect_equal(names(dt), c("time", "sequence", "side", "level", "price", "size"))
 
   # Check sides
   expect_equal(sum(dt$side == "bid"), 3L)
@@ -92,8 +92,13 @@ test_that("parse_orderbook creates correct data.table from bid/ask arrays", {
 
   # Check types
   expect_s3_class(dt$time, "POSIXct")
+  expect_type(dt$level, "integer")
   expect_type(dt$price, "double")
   expect_type(dt$size, "double")
+
+  # `level` resets to 1 per side and increments with source order.
+  expect_equal(dt[side == "bid", level], 1:3)
+  expect_equal(dt[side == "ask", level], 1:3)
 
   # Check values
   expect_equal(dt[side == "bid"][1]$price, 67232.8)

--- a/vignettes/data-shapes.Rmd
+++ b/vignettes/data-shapes.Rmd
@@ -1,0 +1,144 @@
+---
+title: "Data shapes and the one-row-per-entity convention"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Data shapes and the one-row-per-entity convention}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(eval = FALSE, collapse = TRUE, comment = "#>")
+```
+
+## The rule
+
+Every `kucoin` method that returns nested API data follows one rule:
+
+> **Identify the entity for the endpoint, and return one row per entity.**
+
+A trade gets a row. An order gets a row. An asset balance gets a row. A
+candle gets a row. Anything nested under the entity becomes a flat column
+on the same row or an additional row on a different axis — **never a list
+column**.
+
+The same rule applies in the sister `alpaca` and `binance` packages, so
+that switching between exchanges does not mean switching mental models of
+how the data looks.
+
+## The five shape treatments
+
+There are five shapes a nested API field can take, and five treatments. A
+few endpoints use two treatments together when their nesting has two
+layers.
+
+### Treatment A — `;` collapse for arrays of plain strings
+
+When a field is an array of short, plain string values (codes, tags,
+permissions) and the user mostly filters by them, collapse with `;` into a
+single character column. Filter with `grepl`, recover the original vector
+with `strsplit(x, ";", fixed = TRUE)[[1]]`.
+
+The package ships a shared helper `collapse_string_array_fields(x,
+fields)` that does this (NA-safe; emits a once-per-session warning if any
+value contains a literal `;`).
+
+### Treatment B — Long format for arrays of objects
+
+When the array elements are themselves records (each has multiple fields),
+explode to one row per element with the parent fields replicated. Add a
+1-indexed position column where order matters.
+
+```{r}
+# `KucoinSubAccount::get_detail_balance()` returns one row per (sub-account
+# × wallet bucket × asset). The sub-account-level fields (`sub_user_id`,
+# `sub_name`, `account_type`) are replicated on each row.
+sub <- KucoinSubAccount$new()
+bal <- sub$get_detail_balance(sub_user_id)
+bal[account_type == "trade", .(currency, balance, available, holds)]
+```
+
+```{r}
+# `KucoinOcoOrders::get_order_detail_by_id()` explodes the `orders` array
+# into `sub_order_*` columns — one row per child leg.
+oco <- KucoinOcoOrders$new()
+detail <- oco$get_order_detail_by_id(order_id)
+detail[, .(order_id, sub_order_id, sub_order_side, sub_order_price)]
+```
+
+**Schema stability**: when the array is empty, the `<noun>_` columns are
+still present on the row, filled with `NA`. So downstream code that
+always reads `dt$sub_order_id` keeps working whether the OCO had children
+or not.
+
+### Treatment C — Wide prefix for fixed-schema nested objects
+
+When the field is a single nested object with a known fixed key set,
+flatten it to `parent_child` columns.
+
+```{r}
+# `KucoinAccount::get_isolated_margin_account()` flattens the nested
+# `baseAsset` / `quoteAsset` per-pair objects into wide columns.
+acct <- KucoinAccount$new()
+iso <- acct$get_isolated_margin_account()
+iso[, .(symbol, base_asset_currency, base_asset_borrow_enabled,
+        quote_asset_currency, quote_asset_borrow_enabled)]
+```
+
+### Treatment D — Re-route to a sibling method
+
+When a response bundles a collection that doesn't fit the per-entity row
+of the calling endpoint — typically heterogeneous siblings (e.g. an
+account-level summary bundled with per-asset rows) — the parser keeps the
+rows for the entity the method names, and the rest is exposed via a
+dedicated sibling method. Every method still returns one `data.table`; no
+data is lost.
+
+KuCoin uses this less frequently than `binance` because the KuCoin REST
+API tends to namespace different entities to different endpoints already.
+
+### Treatment E — JSON string for dynamic-key or array-of-array objects
+
+When a nested object has dynamic keys (different products have different
+key sets) or is an array of arrays where the inner grouping carries
+semantic meaning, neither `;`-collapse nor wide-prefix preserves the
+structure. Serialise the whole field as a JSON string; recover with
+`jsonlite::fromJSON`.
+
+## Two cross-cutting rules
+
+These apply to every shape treatment:
+
+1. **Empty / null array → `NA_character_`** (no list cells). An order
+   with no fills returns `fill_id = NA`, not `fill_id = list()`.
+2. **Empty response → empty `data.table`** (no synthetic stub rows).
+   `KucoinTrading::cancel_all()` with no open orders returns a zero-row
+   table, not a 1-row `(symbol, status = "cancelled")` fabrication. The
+   absence of an error is the success signal.
+
+## Why this shape works for `data.table`
+
+`data.table` is fast and ergonomic on rectangular long-format data. List
+columns make filtering, grouping, joining, and writing to disk awkward.
+The convention above is what lets you write:
+
+```{r}
+# Top 5 highest-priced asks in the book
+depth[side == "ask"][order(-price)][1:5]
+
+# All BTC-USDT orders that filled at > 50k
+orders <- KucoinTrading$new()$get_all_orders(query = list(symbol = "BTC-USDT"))
+orders[as.numeric(deal_funds) > 50000]
+```
+
+…without escape hatches into `lapply` over hidden lists.
+
+## See also
+
+- `vignette("getting-started", package = "kucoin")` — the package tour.
+- `vignette("async-usage", package = "kucoin")` — using the same methods
+  with `async = TRUE`.
+- The sister `alpaca` and `binance` packages — same convention applied to
+  different exchanges. `binance`'s `vignette("data-shapes")` has a fuller
+  per-class catalogue if you want to see every method's shape in one
+  place.

--- a/vignettes/data-shapes.Rmd
+++ b/vignettes/data-shapes.Rmd
@@ -7,7 +7,14 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r, include = FALSE, purl = FALSE}
+# All example chunks below carry `purl = FALSE` individually so that
+# `R CMD check`'s vignette-tangling step does not extract them as
+# runnable R code (they reference placeholder identifiers like
+# `sub_user_id`, `order_id`, and `depth`). Setting `purl` here in
+# `opts_chunk$set()` does NOT work — `knitr::purl()` does a static
+# extraction and never evaluates this setup chunk, so the per-chunk
+# `purl = FALSE` on each example is what actually skips them.
 knitr::opts_chunk$set(eval = FALSE, collapse = TRUE, comment = "#>")
 ```
 
@@ -49,7 +56,7 @@ When the array elements are themselves records (each has multiple fields),
 explode to one row per element with the parent fields replicated. Add a
 1-indexed position column where order matters.
 
-```{r}
+```{r, purl = FALSE}
 # `KucoinSubAccount::get_detail_balance()` returns one row per (sub-account
 # × wallet bucket × asset). The sub-account-level fields (`sub_user_id`,
 # `sub_name`, `account_type`) are replicated on each row.
@@ -58,7 +65,7 @@ bal <- sub$get_detail_balance(sub_user_id)
 bal[account_type == "trade", .(currency, balance, available, holds)]
 ```
 
-```{r}
+```{r, purl = FALSE}
 # `KucoinOcoOrders::get_order_detail_by_id()` explodes the `orders` array
 # into `sub_order_*` columns — one row per child leg.
 oco <- KucoinOcoOrders$new()
@@ -66,17 +73,21 @@ detail <- oco$get_order_detail_by_id(order_id)
 detail[, .(order_id, sub_order_id, sub_order_side, sub_order_price)]
 ```
 
-**Schema stability**: when the array is empty, the `<noun>_` columns are
-still present on the row, filled with `NA`. So downstream code that
-always reads `dt$sub_order_id` keeps working whether the OCO had children
-or not.
+**Empty arrays**: KuCoin's Treatment B parsers don't know every
+possible child field up-front (some sub-orders carry `stopPrice`, others
+don't), so they don't synthesise an `NA`-filled `<noun>_*` schema when
+the array is empty. `KucoinOcoOrders::get_order_detail_by_id()` with no
+sub-orders returns just the parent columns; cancel parsers with an empty
+`cancelledOrderIds` return a zero-row table. Defensive callers should
+check `<noun>_*` columns with `"sub_order_id" %in% names(dt)` rather
+than assuming they're always present.
 
 ### Treatment C — Wide prefix for fixed-schema nested objects
 
 When the field is a single nested object with a known fixed key set,
 flatten it to `parent_child` columns.
 
-```{r}
+```{r, purl = FALSE}
 # `KucoinAccount::get_isolated_margin_account()` flattens the nested
 # `baseAsset` / `quoteAsset` per-pair objects into wide columns.
 acct <- KucoinAccount$new()
@@ -122,7 +133,7 @@ These apply to every shape treatment:
 columns make filtering, grouping, joining, and writing to disk awkward.
 The convention above is what lets you write:
 
-```{r}
+```{r, purl = FALSE}
 # Top 5 highest-priced asks in the book
 depth[side == "ask"][order(-price)][1:5]
 


### PR DESCRIPTION
# jira ticket

https://dereckmezquita.atlassian.net/browse/TRADE-21

# todo list

-   [ ] Version bump

# breaking changes (user-visible)

The shape changes are listed in `NEWS.md` under the `kucoin 4.0.0`
BREAKING CHANGES section. The behavioural change worth pulling out
here so reviewers don't miss it:

-   **`KucoinMarketData$get_klines()` default window changed.** Calling
    with `from = NULL` / `to = NULL` previously returned a deterministic
    "last 24 hours" window; it now returns the most recent candles for
    the requested timeframe (single request, no synthetic window). This
    is independent of the list-column cleanup the rest of the PR is
    about, and a downstream caller that relied on the old 24h
    fabrication will see different rows after upgrading. The version
    bump above should reflect this.