### PR TITLE
Consolidate test setup into helper-constants.R

### DIFF
--- a/tests/testthat/helper-constants.R
+++ b/tests/testthat/helper-constants.R
@@ -1,0 +1,110 @@
+# tests/testthat/helper-constants.R
+# Shared constants and constructor helpers for mocked-HTTP tests.
+# `testthat` auto-sources every `helper-*.R` file in this directory
+# before any test runs, so these are available everywhere without an
+# explicit source().
+
+# ---------------------------------------------------------------------------
+# URL constants
+# ---------------------------------------------------------------------------
+
+# Live KuCoin REST endpoints. We pass these explicitly through the
+# constructors so a test never accidentally hits the real network — the
+# `httr2::local_mocked_responses()` setup short-circuits transport
+# regardless of URL, but pinning the URL keeps test intent obvious.
+BASE_SPOT <- "https://api.kucoin.com"
+BASE_FUTURES <- "https://api-futures.kucoin.com"
+
+# ---------------------------------------------------------------------------
+# Dummy credentials
+# ---------------------------------------------------------------------------
+
+# Single shared set of dummy credentials. Never sent over the wire —
+# tests mock the HTTP transport — but the request-builder still expects
+# them to look syntactically valid (non-empty strings).
+TEST_KEYS <- get_api_keys(
+  api_key = "k",
+  api_secret = "s",
+  api_passphrase = "p"
+)
+
+# ---------------------------------------------------------------------------
+# Default trading symbols
+# ---------------------------------------------------------------------------
+
+# Conventional defaults for fixture symbols. Most tests don't care which
+# pair they exercise, only that the parser handles the response shape.
+# Tests that DO care (futures-only endpoints, OCO-specific behaviour, …)
+# pass an explicit symbol.
+TEST_SYMBOL_SPOT <- "BTC-USDT"
+TEST_SYMBOL_FUTURES <- "XBTUSDTM"
+
+# ---------------------------------------------------------------------------
+# R6 constructor helpers
+# ---------------------------------------------------------------------------
+
+# One helper per R6 class so tests read `new_oco()$cancel_all(...)`
+# instead of repeating the 5-line constructor scaffold. Naming:
+# spot wrappers keep their short name; futures wrappers carry an
+# explicit `futures_` segment to avoid the two `new_account` /
+# `new_trading` / `new_market` name collisions that existed before.
+
+new_account <- function() {
+  return(KucoinAccount$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_deposit <- function() {
+  return(KucoinDeposit$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_lending <- function() {
+  return(KucoinLending$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_margin <- function() {
+  return(KucoinMarginTrading$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_margin_data <- function() {
+  return(KucoinMarginData$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_market <- function() {
+  return(KucoinMarketData$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_oco <- function() {
+  return(KucoinOcoOrders$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_stop <- function() {
+  return(KucoinStopOrders$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_sub <- function() {
+  return(KucoinSubAccount$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_trading <- function() {
+  return(KucoinTrading$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_transfer <- function() {
+  return(KucoinTransfer$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_withdrawal <- function() {
+  return(KucoinWithdrawal$new(keys = TEST_KEYS, base_url = BASE_SPOT))
+}
+
+new_futures_account <- function() {
+  return(KucoinFuturesAccount$new(keys = TEST_KEYS, base_url = BASE_FUTURES))
+}
+
+new_futures_market <- function() {
+  return(KucoinFuturesMarketData$new(keys = TEST_KEYS, base_url = BASE_FUTURES))
+}
+
+new_futures_trading <- function() {
+  return(KucoinFuturesTrading$new(keys = TEST_KEYS, base_url = BASE_FUTURES))
+}

--- a/tests/testthat/test-KucoinAccount.R
+++ b/tests/testthat/test-KucoinAccount.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinAccount.R
 # Tests for KucoinAccount R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_account <- function() {
-  return(KucoinAccount$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinAccount inherits from KucoinBase", {

--- a/tests/testthat/test-KucoinDeposit.R
+++ b/tests/testthat/test-KucoinDeposit.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinDeposit.R
 # Tests for KucoinDeposit R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_deposit <- function() {
-  return(KucoinDeposit$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinDeposit inherits from KucoinBase", {

--- a/tests/testthat/test-KucoinFuturesAccount.R
+++ b/tests/testthat/test-KucoinFuturesAccount.R
@@ -1,17 +1,10 @@
 # tests/testthat/test-KucoinFuturesAccount.R
 # Tests for KucoinFuturesAccount R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api-futures.kucoin.com"
-
-new_account <- function() {
-  return(KucoinFuturesAccount$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinFuturesAccount inherits from KucoinBase", {
-  a <- new_account()
+  a <- new_futures_account()
   expect_s3_class(a, "KucoinFuturesAccount")
   expect_s3_class(a, "KucoinBase")
 })
@@ -22,7 +15,7 @@ test_that("get_account_overview returns data.table with balance fields", {
   resp <- mock_kucoin_response(data = mock_futures_account_overview_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_account_overview()
+  dt <- new_futures_account()$get_account_overview()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("account_equity" %in% names(dt))
@@ -39,7 +32,7 @@ test_that("get_account_overview passes currency query param", {
     return(resp)
   })
 
-  new_account()$get_account_overview(currency = "XBT")
+  new_futures_account()$get_account_overview(currency = "XBT")
   expect_true(grepl("currency=XBT", captured_url))
 })
 
@@ -50,7 +43,7 @@ test_that("get_position returns data.table with timestamps", {
   resp <- mock_kucoin_response(data = mock_futures_position_data()[[1]])
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_position("XBTUSDTM")
+  dt <- new_futures_account()$get_position("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_true(nrow(dt) >= 1L)
   expect_true("opening_timestamp" %in% names(dt))
@@ -66,7 +59,7 @@ test_that("get_positions returns data.table", {
   resp <- mock_kucoin_response(data = mock_futures_position_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_positions()
+  dt <- new_futures_account()$get_positions()
   expect_s3_class(dt, "data.table")
   expect_true(nrow(dt) >= 1L)
 })
@@ -79,7 +72,7 @@ test_that("get_positions passes currency filter", {
     return(resp)
   })
 
-  new_account()$get_positions(currency = "USDT")
+  new_futures_account()$get_positions(currency = "USDT")
   expect_true(grepl("currency=USDT", captured_url))
 })
 
@@ -89,7 +82,7 @@ test_that("get_positions_history returns data.table with timestamps", {
   resp <- mock_kucoin_response(data = mock_futures_positions_history_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_positions_history()
+  dt <- new_futures_account()$get_positions_history()
   expect_s3_class(dt, "data.table")
   expect_true(nrow(dt) >= 1L)
   expect_true("open_time" %in% names(dt))
@@ -104,7 +97,7 @@ test_that("get_margin_mode returns data.table with mode", {
   resp <- mock_kucoin_response(data = mock_futures_margin_mode_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_margin_mode("XBTUSDTM")
+  dt <- new_futures_account()$get_margin_mode("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("margin_mode" %in% names(dt))
@@ -121,7 +114,7 @@ test_that("set_margin_mode sends POST", {
     return(resp)
   })
 
-  dt <- new_account()$set_margin_mode("XBTUSDTM", "CROSS")
+  dt <- new_futures_account()$set_margin_mode("XBTUSDTM", "CROSS")
   expect_equal(captured_method, "POST")
   expect_s3_class(dt, "data.table")
 })
@@ -132,7 +125,7 @@ test_that("get_cross_margin_leverage returns data.table", {
   resp <- mock_kucoin_response(data = mock_futures_cross_leverage_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_cross_margin_leverage("XBTUSDTM")
+  dt <- new_futures_account()$get_cross_margin_leverage("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("leverage" %in% names(dt))
@@ -148,7 +141,7 @@ test_that("set_cross_margin_leverage sends POST", {
     return(resp)
   })
 
-  dt <- new_account()$set_cross_margin_leverage("XBTUSDTM", 10)
+  dt <- new_futures_account()$set_cross_margin_leverage("XBTUSDTM", 10)
   expect_equal(captured_method, "POST")
   expect_s3_class(dt, "data.table")
 })
@@ -159,7 +152,7 @@ test_that("get_max_open_size returns data.table", {
   resp <- mock_kucoin_response(data = mock_futures_max_open_size_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_max_open_size("XBTUSDTM", price = "98000", leverage = 5)
+  dt <- new_futures_account()$get_max_open_size("XBTUSDTM", price = "98000", leverage = 5)
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("max_buy_open_size" %in% names(dt))
@@ -171,7 +164,7 @@ test_that("get_max_withdraw_margin returns data.table", {
   resp <- mock_kucoin_response(data = mock_futures_max_withdraw_margin_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_max_withdraw_margin("XBTUSDTM")
+  dt <- new_futures_account()$get_max_withdraw_margin("XBTUSDTM")
   expect_s3_class(dt, "data.table")
 })
 
@@ -185,7 +178,7 @@ test_that("add_isolated_margin sends POST", {
     return(resp)
   })
 
-  dt <- new_account()$add_isolated_margin("XBTUSDTM", margin = 10, bizNo = "biz-001")
+  dt <- new_futures_account()$add_isolated_margin("XBTUSDTM", margin = 10, bizNo = "biz-001")
   expect_equal(captured_method, "POST")
   expect_s3_class(dt, "data.table")
 })
@@ -200,7 +193,7 @@ test_that("remove_isolated_margin sends POST", {
     return(resp)
   })
 
-  dt <- new_account()$remove_isolated_margin("XBTUSDTM", withdrawAmount = 5)
+  dt <- new_futures_account()$remove_isolated_margin("XBTUSDTM", withdrawAmount = 5)
   expect_equal(captured_method, "POST")
   expect_s3_class(dt, "data.table")
 })
@@ -211,7 +204,7 @@ test_that("get_risk_limit returns multi-row data.table", {
   resp <- mock_kucoin_response(data = mock_futures_risk_limit_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_risk_limit("XBTUSDTM")
+  dt <- new_futures_account()$get_risk_limit("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 2L)
   expect_true("level" %in% names(dt))
@@ -226,7 +219,7 @@ test_that("get_risk_limit hits correct endpoint", {
     return(resp)
   })
 
-  new_account()$get_risk_limit("XBTUSDTM")
+  new_futures_account()$get_risk_limit("XBTUSDTM")
   expect_true(grepl("contracts/risk-limit/XBTUSDTM", captured_url))
 })
 
@@ -236,7 +229,7 @@ test_that("get_funding_history returns data.table with time_point as POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_private_funding_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_funding_history("XBTUSDTM")
+  dt <- new_futures_account()$get_funding_history("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_true(nrow(dt) >= 1L)
   expect_true("time_point" %in% names(dt))
@@ -252,7 +245,7 @@ test_that("get_funding_history passes symbol in query", {
     return(resp)
   })
 
-  new_account()$get_funding_history("XBTUSDTM")
+  new_futures_account()$get_funding_history("XBTUSDTM")
   expect_true(grepl("symbol=XBTUSDTM", captured_url))
 })
 
@@ -273,7 +266,7 @@ test_that("get_account_overview has no list columns", {
   resp <- mock_kucoin_response(data = mock_futures_account_overview_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_account_overview()
+  dt <- new_futures_account()$get_account_overview()
   expect_equal(n_list_cols(dt), 0L)
 })
 
@@ -281,7 +274,7 @@ test_that("get_position has no list columns; timestamps are POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_position_data()[[1]])
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_position("XBTUSDTM")
+  dt <- new_futures_account()$get_position("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$opening_timestamp, "POSIXct")
   expect_s3_class(dt$current_timestamp, "POSIXct")
@@ -291,13 +284,13 @@ test_that("get_positions has no list columns; empty array yields empty dt", {
   resp <- mock_kucoin_response(data = mock_futures_position_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_positions()
+  dt <- new_futures_account()$get_positions()
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$opening_timestamp, "POSIXct")
 
   resp_empty <- mock_kucoin_response(data = list())
   httr2::local_mocked_responses(function(req) resp_empty)
-  dt_empty <- new_account()$get_positions()
+  dt_empty <- new_futures_account()$get_positions()
   expect_s3_class(dt_empty, "data.table")
   expect_equal(nrow(dt_empty), 0L)
 })
@@ -306,14 +299,14 @@ test_that("get_positions_history has no list columns; empty items yields empty d
   resp <- mock_kucoin_response(data = mock_futures_positions_history_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_positions_history()
+  dt <- new_futures_account()$get_positions_history()
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$open_time, "POSIXct")
   expect_s3_class(dt$close_time, "POSIXct")
 
   resp_empty <- mock_kucoin_response(data = list(items = list()))
   httr2::local_mocked_responses(function(req) resp_empty)
-  dt_empty <- new_account()$get_positions_history()
+  dt_empty <- new_futures_account()$get_positions_history()
   expect_s3_class(dt_empty, "data.table")
   expect_equal(nrow(dt_empty), 0L)
 })
@@ -322,7 +315,7 @@ test_that("get_margin_mode has no list columns", {
   resp <- mock_kucoin_response(data = mock_futures_margin_mode_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_margin_mode("XBTUSDTM")
+  dt <- new_futures_account()$get_margin_mode("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
 })
 
@@ -330,7 +323,7 @@ test_that("set_margin_mode has no list columns", {
   resp <- mock_kucoin_response(data = mock_futures_margin_mode_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$set_margin_mode("XBTUSDTM", "CROSS")
+  dt <- new_futures_account()$set_margin_mode("XBTUSDTM", "CROSS")
   expect_equal(n_list_cols(dt), 0L)
 })
 
@@ -338,7 +331,7 @@ test_that("get_cross_margin_leverage has no list columns", {
   resp <- mock_kucoin_response(data = mock_futures_cross_leverage_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_cross_margin_leverage("XBTUSDTM")
+  dt <- new_futures_account()$get_cross_margin_leverage("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
 })
 
@@ -346,7 +339,7 @@ test_that("set_cross_margin_leverage has no list columns", {
   resp <- mock_kucoin_response(data = mock_futures_cross_leverage_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$set_cross_margin_leverage("XBTUSDTM", 10)
+  dt <- new_futures_account()$set_cross_margin_leverage("XBTUSDTM", 10)
   expect_equal(n_list_cols(dt), 0L)
 })
 
@@ -354,7 +347,7 @@ test_that("get_max_open_size has no list columns", {
   resp <- mock_kucoin_response(data = mock_futures_max_open_size_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_max_open_size("XBTUSDTM", price = "98000", leverage = 5)
+  dt <- new_futures_account()$get_max_open_size("XBTUSDTM", price = "98000", leverage = 5)
   expect_equal(n_list_cols(dt), 0L)
 })
 
@@ -362,7 +355,7 @@ test_that("get_max_withdraw_margin returns named max_withdraw_margin column", {
   resp <- mock_kucoin_response(data = mock_futures_max_withdraw_margin_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_max_withdraw_margin("XBTUSDTM")
+  dt <- new_futures_account()$get_max_withdraw_margin("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_equal(names(dt), "max_withdraw_margin")
@@ -375,7 +368,7 @@ test_that("get_max_withdraw_margin handles empty response", {
   resp <- mock_kucoin_response(data = NULL)
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_max_withdraw_margin("XBTUSDTM")
+  dt <- new_futures_account()$get_max_withdraw_margin("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 0L)
 })
@@ -384,7 +377,7 @@ test_that("add_isolated_margin has no list columns", {
   resp <- mock_kucoin_response(data = mock_futures_margin_response())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$add_isolated_margin("XBTUSDTM", margin = 10, bizNo = "biz-001")
+  dt <- new_futures_account()$add_isolated_margin("XBTUSDTM", margin = 10, bizNo = "biz-001")
   expect_equal(n_list_cols(dt), 0L)
 })
 
@@ -392,7 +385,7 @@ test_that("remove_isolated_margin has no list columns", {
   resp <- mock_kucoin_response(data = mock_futures_margin_response())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$remove_isolated_margin("XBTUSDTM", withdrawAmount = 5)
+  dt <- new_futures_account()$remove_isolated_margin("XBTUSDTM", withdrawAmount = 5)
   expect_equal(n_list_cols(dt), 0L)
 })
 
@@ -400,12 +393,12 @@ test_that("get_risk_limit has no list columns; empty array yields empty dt", {
   resp <- mock_kucoin_response(data = mock_futures_risk_limit_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_risk_limit("XBTUSDTM")
+  dt <- new_futures_account()$get_risk_limit("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
 
   resp_empty <- mock_kucoin_response(data = list())
   httr2::local_mocked_responses(function(req) resp_empty)
-  dt_empty <- new_account()$get_risk_limit("XBTUSDTM")
+  dt_empty <- new_futures_account()$get_risk_limit("XBTUSDTM")
   expect_s3_class(dt_empty, "data.table")
   expect_equal(nrow(dt_empty), 0L)
 })
@@ -414,13 +407,13 @@ test_that("get_funding_history has no list columns; empty dataList yields empty 
   resp <- mock_kucoin_response(data = mock_futures_private_funding_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_account()$get_funding_history("XBTUSDTM")
+  dt <- new_futures_account()$get_funding_history("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$time_point, "POSIXct")
 
   resp_empty <- mock_kucoin_response(data = list(dataList = list(), hasMore = FALSE))
   httr2::local_mocked_responses(function(req) resp_empty)
-  dt_empty <- new_account()$get_funding_history("XBTUSDTM")
+  dt_empty <- new_futures_account()$get_funding_history("XBTUSDTM")
   expect_s3_class(dt_empty, "data.table")
   expect_equal(nrow(dt_empty), 0L)
 })

--- a/tests/testthat/test-KucoinFuturesMarketData.R
+++ b/tests/testthat/test-KucoinFuturesMarketData.R
@@ -1,24 +1,17 @@
 # tests/testthat/test-KucoinFuturesMarketData.R
 # Tests for KucoinFuturesMarketData R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api-futures.kucoin.com"
-
-new_market <- function() {
-  return(KucoinFuturesMarketData$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinFuturesMarketData inherits from KucoinBase", {
-  m <- new_market()
+  m <- new_futures_market()
   expect_s3_class(m, "KucoinFuturesMarketData")
   expect_s3_class(m, "KucoinBase")
   expect_false(m$is_async)
 })
 
 test_that("KucoinFuturesMarketData async mode sets is_async = TRUE", {
-  m <- KucoinFuturesMarketData$new(keys = KEYS, base_url = BASE, async = TRUE)
+  m <- KucoinFuturesMarketData$new(keys = TEST_KEYS, base_url = BASE_FUTURES, async = TRUE)
   expect_true(m$is_async)
 })
 
@@ -28,7 +21,7 @@ test_that("get_contract returns single-row data.table", {
   resp <- mock_kucoin_response(data = mock_futures_contract_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_contract("XBTUSDTM")
+  dt <- new_futures_market()$get_contract("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("symbol" %in% names(dt))
@@ -45,7 +38,7 @@ test_that("get_contract hits correct endpoint", {
     return(resp)
   })
 
-  new_market()$get_contract("XBTUSDTM")
+  new_futures_market()$get_contract("XBTUSDTM")
   expect_true(grepl("contracts/XBTUSDTM", captured_url))
 })
 
@@ -55,7 +48,7 @@ test_that("get_all_contracts returns multi-row data.table", {
   resp <- mock_kucoin_response(data = mock_futures_all_contracts_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_all_contracts()
+  dt <- new_futures_market()$get_all_contracts()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 2L)
   expect_true("symbol" %in% names(dt))
@@ -69,7 +62,7 @@ test_that("get_ticker returns single-row data.table with ts as POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_ticker_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_ticker("XBTUSDTM")
+  dt <- new_futures_market()$get_ticker("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("ts" %in% names(dt))
@@ -84,7 +77,7 @@ test_that("get_all_tickers returns multi-row data.table", {
   resp <- mock_kucoin_response(data = mock_futures_all_tickers_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_all_tickers()
+  dt <- new_futures_market()$get_all_tickers()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 2L)
   expect_true("ts" %in% names(dt))
@@ -98,7 +91,7 @@ test_that("get_part_orderbook returns data.table with bids and asks", {
   resp <- mock_kucoin_response(data = mock_futures_orderbook_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_part_orderbook("XBTUSDTM", size = 20)
+  dt <- new_futures_market()$get_part_orderbook("XBTUSDTM", size = 20)
   expect_s3_class(dt, "data.table")
   expect_true(nrow(dt) > 0)
   expect_true(all(c("ts", "sequence", "side", "level", "price", "size") %in% names(dt)))
@@ -115,7 +108,7 @@ test_that("get_part_orderbook level column is 1-indexed depth within each side",
   resp <- mock_kucoin_response(data = mock_futures_orderbook_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_part_orderbook("XBTUSDTM", size = 20)
+  dt <- new_futures_market()$get_part_orderbook("XBTUSDTM", size = 20)
 
   expect_equal(dt[side == "bid", level], seq_len(sum(dt$side == "bid")))
   expect_equal(dt[side == "ask", level], seq_len(sum(dt$side == "ask")))
@@ -126,7 +119,7 @@ test_that("get_part_orderbook level column is 1-indexed depth within each side",
 })
 
 test_that("get_part_orderbook validates size parameter", {
-  expect_error(new_market()$get_part_orderbook("XBTUSDTM", size = 50))
+  expect_error(new_futures_market()$get_part_orderbook("XBTUSDTM", size = 50))
 })
 
 # -- get_full_orderbook --
@@ -139,7 +132,7 @@ test_that("get_full_orderbook returns data.table with auth", {
     return(resp)
   })
 
-  dt <- new_market()$get_full_orderbook("XBTUSDTM")
+  dt <- new_futures_market()$get_full_orderbook("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_true(grepl("level2/snapshot", captured_url))
 })
@@ -150,7 +143,7 @@ test_that("get_trade_history returns data.table with ts as POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_trade_history_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_trade_history("XBTUSDTM")
+  dt <- new_futures_market()$get_trade_history("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 2L)
   expect_true("ts" %in% names(dt))
@@ -164,7 +157,7 @@ test_that("get_klines returns data.table with OHLCV columns", {
   resp <- mock_kucoin_response(data = mock_futures_klines_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_klines("XBTUSDTM", granularity = 60)
+  dt <- new_futures_market()$get_klines("XBTUSDTM", granularity = 60)
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 3L)
   expected_cols <- c("datetime", "open", "high", "low", "close", "volume", "turnover")
@@ -184,7 +177,7 @@ test_that("get_klines converts POSIXct from/to to milliseconds", {
 
   from_time <- as.POSIXct("2024-10-17 00:00:00", tz = "UTC")
   to_time <- as.POSIXct("2024-10-17 01:00:00", tz = "UTC")
-  new_market()$get_klines("XBTUSDTM", granularity = 60, from = from_time, to = to_time)
+  new_futures_market()$get_klines("XBTUSDTM", granularity = 60, from = from_time, to = to_time)
 
   # Should contain millisecond timestamps in query
   expect_true(grepl("from=", captured_url))
@@ -195,7 +188,7 @@ test_that("get_klines handles empty data", {
   resp <- mock_kucoin_response(data = list())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_klines("XBTUSDTM", granularity = 60)
+  dt <- new_futures_market()$get_klines("XBTUSDTM", granularity = 60)
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 0L)
 })
@@ -206,7 +199,7 @@ test_that("get_mark_price returns single-row data.table with time_point as POSIX
   resp <- mock_kucoin_response(data = mock_futures_mark_price_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_mark_price("XBTUSDTM")
+  dt <- new_futures_market()$get_mark_price("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("time_point" %in% names(dt))
@@ -220,7 +213,7 @@ test_that("get_funding_rate returns single-row data.table with timestamps", {
   resp <- mock_kucoin_response(data = mock_futures_funding_rate_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_funding_rate("XBTUSDTM")
+  dt <- new_futures_market()$get_funding_rate("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("time_point" %in% names(dt))
@@ -238,7 +231,7 @@ test_that("get_funding_history returns data.table with timepoint as POSIXct", {
 
   from_time <- as.POSIXct("2024-10-17 00:00:00", tz = "UTC")
   to_time <- as.POSIXct("2024-10-18 00:00:00", tz = "UTC")
-  dt <- new_market()$get_funding_history("XBTUSDTM", from = from_time, to = to_time)
+  dt <- new_futures_market()$get_funding_history("XBTUSDTM", from = from_time, to = to_time)
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 2L)
   expect_true("timepoint" %in% names(dt))
@@ -252,7 +245,7 @@ test_that("get_server_time returns data.table with server_time as POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_server_time_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_server_time()
+  dt <- new_futures_market()$get_server_time()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("server_time" %in% names(dt))
@@ -265,7 +258,7 @@ test_that("get_service_status returns data.table", {
   resp <- mock_kucoin_response(data = mock_futures_service_status_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_service_status()
+  dt <- new_futures_market()$get_service_status()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("status" %in% names(dt))
@@ -286,12 +279,12 @@ test_that("get_contract has no list columns; empty response yields empty dt", {
   resp <- mock_kucoin_response(data = mock_futures_contract_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_contract("XBTUSDTM")
+  dt <- new_futures_market()$get_contract("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
 
   resp_empty <- mock_kucoin_response(data = NULL)
   httr2::local_mocked_responses(function(req) resp_empty)
-  dt_empty <- new_market()$get_contract("XBTUSDTM")
+  dt_empty <- new_futures_market()$get_contract("XBTUSDTM")
   expect_s3_class(dt_empty, "data.table")
   expect_equal(nrow(dt_empty), 0L)
 })
@@ -300,12 +293,12 @@ test_that("get_all_contracts has no list columns; empty response yields empty dt
   resp <- mock_kucoin_response(data = mock_futures_all_contracts_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_all_contracts()
+  dt <- new_futures_market()$get_all_contracts()
   expect_equal(n_list_cols(dt), 0L)
 
   resp_empty <- mock_kucoin_response(data = list())
   httr2::local_mocked_responses(function(req) resp_empty)
-  dt_empty <- new_market()$get_all_contracts()
+  dt_empty <- new_futures_market()$get_all_contracts()
   expect_s3_class(dt_empty, "data.table")
   expect_equal(nrow(dt_empty), 0L)
 })
@@ -314,7 +307,7 @@ test_that("get_ticker has no list columns; ts is POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_ticker_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_ticker("XBTUSDTM")
+  dt <- new_futures_market()$get_ticker("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$ts, "POSIXct")
 })
@@ -323,13 +316,13 @@ test_that("get_all_tickers has no list columns; ts is POSIXct; empty array yield
   resp <- mock_kucoin_response(data = mock_futures_all_tickers_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_all_tickers()
+  dt <- new_futures_market()$get_all_tickers()
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$ts, "POSIXct")
 
   resp_empty <- mock_kucoin_response(data = list())
   httr2::local_mocked_responses(function(req) resp_empty)
-  dt_empty <- new_market()$get_all_tickers()
+  dt_empty <- new_futures_market()$get_all_tickers()
   expect_s3_class(dt_empty, "data.table")
   expect_equal(nrow(dt_empty), 0L)
 })
@@ -338,7 +331,7 @@ test_that("get_part_orderbook has no list columns; long-format bids/asks", {
   resp <- mock_kucoin_response(data = mock_futures_orderbook_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_part_orderbook("XBTUSDTM", size = 20)
+  dt <- new_futures_market()$get_part_orderbook("XBTUSDTM", size = 20)
   expect_equal(n_list_cols(dt), 0L)
   expect_true(all(c("ts", "sequence", "side", "level", "price", "size") %in% names(dt)))
   expect_s3_class(dt$ts, "POSIXct")
@@ -348,13 +341,13 @@ test_that("get_trade_history has no list columns; empty array yields empty dt", 
   resp <- mock_kucoin_response(data = mock_futures_trade_history_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_trade_history("XBTUSDTM")
+  dt <- new_futures_market()$get_trade_history("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$ts, "POSIXct")
 
   resp_empty <- mock_kucoin_response(data = list())
   httr2::local_mocked_responses(function(req) resp_empty)
-  dt_empty <- new_market()$get_trade_history("XBTUSDTM")
+  dt_empty <- new_futures_market()$get_trade_history("XBTUSDTM")
   expect_s3_class(dt_empty, "data.table")
   expect_equal(nrow(dt_empty), 0L)
 })
@@ -363,7 +356,7 @@ test_that("get_klines has no list columns; empty array yields empty dt", {
   resp <- mock_kucoin_response(data = mock_futures_klines_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_klines("XBTUSDTM", granularity = 60)
+  dt <- new_futures_market()$get_klines("XBTUSDTM", granularity = 60)
   expect_equal(n_list_cols(dt), 0L)
 })
 
@@ -371,7 +364,7 @@ test_that("get_mark_price has no list columns; time_point is POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_mark_price_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_mark_price("XBTUSDTM")
+  dt <- new_futures_market()$get_mark_price("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$time_point, "POSIXct")
 })
@@ -380,7 +373,7 @@ test_that("get_funding_rate has no list columns; timestamps are POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_funding_rate_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_funding_rate("XBTUSDTM")
+  dt <- new_futures_market()$get_funding_rate("XBTUSDTM")
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$time_point, "POSIXct")
   expect_s3_class(dt$funding_time, "POSIXct")
@@ -392,13 +385,13 @@ test_that("get_funding_history has no list columns; empty array yields empty dt"
 
   from_time <- as.POSIXct("2024-10-17 00:00:00", tz = "UTC")
   to_time <- as.POSIXct("2024-10-18 00:00:00", tz = "UTC")
-  dt <- new_market()$get_funding_history("XBTUSDTM", from = from_time, to = to_time)
+  dt <- new_futures_market()$get_funding_history("XBTUSDTM", from = from_time, to = to_time)
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$timepoint, "POSIXct")
 
   resp_empty <- mock_kucoin_response(data = list())
   httr2::local_mocked_responses(function(req) resp_empty)
-  dt_empty <- new_market()$get_funding_history("XBTUSDTM", from = from_time, to = to_time)
+  dt_empty <- new_futures_market()$get_funding_history("XBTUSDTM", from = from_time, to = to_time)
   expect_s3_class(dt_empty, "data.table")
   expect_equal(nrow(dt_empty), 0L)
 })
@@ -407,7 +400,7 @@ test_that("get_server_time has no list columns; server_time is POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_server_time_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_server_time()
+  dt <- new_futures_market()$get_server_time()
   expect_equal(n_list_cols(dt), 0L)
   expect_s3_class(dt$server_time, "POSIXct")
 })
@@ -416,6 +409,6 @@ test_that("get_service_status has no list columns", {
   resp <- mock_kucoin_response(data = mock_futures_service_status_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_market()$get_service_status()
+  dt <- new_futures_market()$get_service_status()
   expect_equal(n_list_cols(dt), 0L)
 })

--- a/tests/testthat/test-KucoinFuturesTrading.R
+++ b/tests/testthat/test-KucoinFuturesTrading.R
@@ -1,17 +1,10 @@
 # tests/testthat/test-KucoinFuturesTrading.R
 # Tests for KucoinFuturesTrading R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api-futures.kucoin.com"
-
-new_trading <- function() {
-  return(KucoinFuturesTrading$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinFuturesTrading inherits from KucoinBase", {
-  t <- new_trading()
+  t <- new_futures_trading()
   expect_s3_class(t, "KucoinFuturesTrading")
   expect_s3_class(t, "KucoinBase")
 })
@@ -22,7 +15,7 @@ test_that("add_order returns order_id and client_oid", {
   resp <- mock_kucoin_response(data = mock_futures_order_response())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$add_order(
+  dt <- new_futures_trading()$add_order(
     clientOid = "test-001",
     symbol = "XBTUSDTM",
     side = "buy",
@@ -46,7 +39,7 @@ test_that("add_order strips NULL params from body", {
     return(resp)
   })
 
-  new_trading()$add_order(
+  new_futures_trading()$add_order(
     clientOid = "test-002",
     symbol = "XBTUSDTM",
     side = "buy",
@@ -68,7 +61,7 @@ test_that("add_order_test hits test endpoint", {
     return(resp)
   })
 
-  dt <- new_trading()$add_order_test(
+  dt <- new_futures_trading()$add_order_test(
     clientOid = "test-003",
     symbol = "XBTUSDTM",
     side = "buy",
@@ -90,7 +83,7 @@ test_that("add_order_batch returns data.table", {
   orders <- list(
     list(clientOid = "b1", symbol = "XBTUSDTM", side = "buy", type = "limit", leverage = 5, size = 1, price = "98000")
   )
-  dt <- new_trading()$add_order_batch(orders)
+  dt <- new_futures_trading()$add_order_batch(orders)
   expect_s3_class(dt, "data.table")
   expect_true(nrow(dt) >= 1L)
 })
@@ -105,7 +98,7 @@ test_that("cancel_order_by_id hits correct endpoint", {
     return(resp)
   })
 
-  dt <- new_trading()$cancel_order_by_id("futures-order-001")
+  dt <- new_futures_trading()$cancel_order_by_id("futures-order-001")
   expect_true(grepl("orders/futures-order-001", captured_url))
   expect_s3_class(dt, "data.table")
 })
@@ -120,7 +113,7 @@ test_that("cancel_order_by_client_oid includes symbol in query", {
     return(resp)
   })
 
-  dt <- new_trading()$cancel_order_by_client_oid("client-001", "XBTUSDTM")
+  dt <- new_futures_trading()$cancel_order_by_client_oid("client-001", "XBTUSDTM")
   expect_true(grepl("client-order/client-001", captured_url))
   expect_true(grepl("symbol=XBTUSDTM", captured_url))
   expect_s3_class(dt, "data.table")
@@ -132,7 +125,7 @@ test_that("cancel_all returns data.table", {
   resp <- mock_kucoin_response(data = mock_futures_cancel_order_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$cancel_all()
+  dt <- new_futures_trading()$cancel_all()
   expect_s3_class(dt, "data.table")
 })
 
@@ -146,7 +139,7 @@ test_that("cancel_all_stop_orders hits stopOrders endpoint", {
     return(resp)
   })
 
-  dt <- new_trading()$cancel_all_stop_orders()
+  dt <- new_futures_trading()$cancel_all_stop_orders()
   expect_true(grepl("stopOrders", captured_url))
   expect_s3_class(dt, "data.table")
 })
@@ -157,7 +150,7 @@ test_that("cancel_order_by_id returns 0-row data.table when data is NULL", {
   resp <- mock_kucoin_response(data = NULL)
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$cancel_order_by_id("futures-order-001")
+  dt <- new_futures_trading()$cancel_order_by_id("futures-order-001")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 0L)
 })
@@ -168,7 +161,7 @@ test_that("cancel_order_by_client_oid returns 0-row data.table when data is NULL
   resp <- mock_kucoin_response(data = NULL)
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$cancel_order_by_client_oid("client-001", "XBTUSDTM")
+  dt <- new_futures_trading()$cancel_order_by_client_oid("client-001", "XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 0L)
 })
@@ -177,7 +170,7 @@ test_that("cancel_all returns 0-row data.table on empty cancelledOrderIds", {
   resp <- mock_kucoin_response(data = list(cancelledOrderIds = list()))
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$cancel_all()
+  dt <- new_futures_trading()$cancel_all()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 0L)
 })
@@ -188,7 +181,7 @@ test_that("cancel_all explodes cancelledOrderIds into long-format rows", {
   )
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$cancel_all()
+  dt <- new_futures_trading()$cancel_all()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 3L)
   expect_true("cancelled_order_id" %in% names(dt))
@@ -203,7 +196,7 @@ test_that("get_order_by_id returns data.table with timestamps", {
   resp <- mock_kucoin_response(data = mock_futures_order_detail_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$get_order_by_id("futures-order-001")
+  dt <- new_futures_trading()$get_order_by_id("futures-order-001")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("created_at" %in% names(dt))
@@ -222,7 +215,7 @@ test_that("get_order_by_client_oid includes clientOid in query", {
     return(resp)
   })
 
-  dt <- new_trading()$get_order_by_client_oid("futures-client-001")
+  dt <- new_futures_trading()$get_order_by_client_oid("futures-client-001")
   expect_true(grepl("clientOid=futures-client-001", captured_url))
   expect_s3_class(dt, "data.table")
   expect_s3_class(dt$created_at, "POSIXct")
@@ -234,7 +227,7 @@ test_that("get_order_list returns paginated data.table with timestamps", {
   resp <- mock_kucoin_response(data = mock_futures_order_list_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$get_order_list(query = list(status = "active"))
+  dt <- new_futures_trading()$get_order_list(query = list(status = "active"))
   expect_s3_class(dt, "data.table")
   expect_true(nrow(dt) >= 1L)
   expect_true("created_at" %in% names(dt))
@@ -247,7 +240,7 @@ test_that("get_recent_closed_orders returns data.table", {
   resp <- mock_kucoin_response(data = list(mock_futures_order_detail_data()))
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$get_recent_closed_orders()
+  dt <- new_futures_trading()$get_recent_closed_orders()
   expect_s3_class(dt, "data.table")
   expect_true(nrow(dt) >= 1L)
 })
@@ -258,7 +251,7 @@ test_that("get_recent_fills returns data.table with trade_time as POSIXct", {
   resp <- mock_kucoin_response(data = mock_futures_fills_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$get_recent_fills()
+  dt <- new_futures_trading()$get_recent_fills()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("trade_time" %in% names(dt))
@@ -273,7 +266,7 @@ test_that("get_open_order_value returns data.table", {
   resp <- mock_kucoin_response(data = mock_futures_open_order_value_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$get_open_order_value("XBTUSDTM")
+  dt <- new_futures_trading()$get_open_order_value("XBTUSDTM")
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("open_order_buy_qty" %in% names(dt))
@@ -290,7 +283,7 @@ test_that("set_dcp sends POST with timeout", {
     return(resp)
   })
 
-  dt <- new_trading()$set_dcp(timeout = 5)
+  dt <- new_futures_trading()$set_dcp(timeout = 5)
   expect_equal(captured_method, "POST")
   expect_s3_class(dt, "data.table")
   expect_true("timeout" %in% names(dt))
@@ -300,7 +293,7 @@ test_that("get_dcp returns data.table", {
   resp <- mock_kucoin_response(data = mock_futures_dcp_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_trading()$get_dcp()
+  dt <- new_futures_trading()$get_dcp()
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_true("timeout" %in% names(dt))

--- a/tests/testthat/test-KucoinLending.R
+++ b/tests/testthat/test-KucoinLending.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinLending.R
 # Tests for KucoinLending R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_lending <- function() {
-  return(KucoinLending$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinLending inherits from KucoinBase", {

--- a/tests/testthat/test-KucoinMarginData.R
+++ b/tests/testthat/test-KucoinMarginData.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinMarginData.R
 # Tests for KucoinMarginData R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_margin_data <- function() {
-  return(KucoinMarginData$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinMarginData inherits from KucoinBase", {

--- a/tests/testthat/test-KucoinMarginTrading.R
+++ b/tests/testthat/test-KucoinMarginTrading.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinMarginTrading.R
 # Tests for KucoinMarginTrading R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_margin <- function() {
-  return(KucoinMarginTrading$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinMarginTrading inherits from KucoinBase", {
@@ -29,7 +22,7 @@ test_that("open_short returns order_id and client_oid", {
   )
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_margin()$open_short(symbol = "BTC-USDT", size = 0.001)
+  dt <- new_margin()$open_short(symbol = TEST_SYMBOL_SPOT, size = 0.001)
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
   expect_equal(names(dt)[1:2], c("order_id", "client_oid"))
@@ -47,7 +40,7 @@ test_that("open_short hits margin order endpoint with sell side and autoBorrow",
     return(resp)
   })
 
-  new_margin()$open_short(symbol = "BTC-USDT", size = 0.001)
+  new_margin()$open_short(symbol = TEST_SYMBOL_SPOT, size = 0.001)
   expect_true(grepl("hf/margin/order", captured_url))
   expect_false(grepl("test", captured_url))
   expect_equal(captured_body$side, "sell")
@@ -59,7 +52,7 @@ test_that("open_short sets client_oid to NA when missing", {
   resp <- mock_kucoin_response(data = list(orderId = "abc"))
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_margin()$open_short(symbol = "BTC-USDT", size = 0.001)
+  dt <- new_margin()$open_short(symbol = TEST_SYMBOL_SPOT, size = 0.001)
   expect_true(is.na(dt$client_oid))
 })
 
@@ -73,7 +66,7 @@ test_that("close_short uses buy side and autoRepay", {
     return(resp)
   })
 
-  new_margin()$close_short(symbol = "BTC-USDT", size = 0.001)
+  new_margin()$close_short(symbol = TEST_SYMBOL_SPOT, size = 0.001)
   expect_equal(captured_body$side, "buy")
   expect_true(captured_body$autoRepay)
   expect_null(captured_body$autoBorrow)
@@ -89,7 +82,7 @@ test_that("open_long uses buy side and autoBorrow", {
     return(resp)
   })
 
-  new_margin()$open_long(symbol = "BTC-USDT", size = 0.001)
+  new_margin()$open_long(symbol = TEST_SYMBOL_SPOT, size = 0.001)
   expect_equal(captured_body$side, "buy")
   expect_true(captured_body$autoBorrow)
   expect_null(captured_body$autoRepay)
@@ -105,7 +98,7 @@ test_that("close_long uses sell side and autoRepay", {
     return(resp)
   })
 
-  new_margin()$close_long(symbol = "BTC-USDT", size = 0.001)
+  new_margin()$close_long(symbol = TEST_SYMBOL_SPOT, size = 0.001)
   expect_equal(captured_body$side, "sell")
   expect_true(captured_body$autoRepay)
   expect_null(captured_body$autoBorrow)
@@ -121,7 +114,7 @@ test_that("dry_run hits test endpoint", {
     return(resp)
   })
 
-  dt <- new_margin()$open_short(symbol = "BTC-USDT", size = 0.001, dry_run = TRUE)
+  dt <- new_margin()$open_short(symbol = TEST_SYMBOL_SPOT, size = 0.001, dry_run = TRUE)
   expect_true(grepl("order/test", captured_url))
   expect_equal(dt$order_id, "test-o1")
 })
@@ -136,7 +129,7 @@ test_that("isIsolated flag is passed when TRUE", {
     return(resp)
   })
 
-  new_margin()$open_short(symbol = "BTC-USDT", size = 0.001, isIsolated = TRUE)
+  new_margin()$open_short(symbol = TEST_SYMBOL_SPOT, size = 0.001, isIsolated = TRUE)
   expect_true(captured_body$isIsolated)
 })
 
@@ -294,7 +287,7 @@ test_that("open_short returns no list columns", {
   )
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_margin()$open_short(symbol = "BTC-USDT", size = 0.001)
+  dt <- new_margin()$open_short(symbol = TEST_SYMBOL_SPOT, size = 0.001)
   expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
   expect_true(is.character(dt$order_id))
   expect_true(is.character(dt$client_oid))
@@ -306,7 +299,7 @@ test_that("close_long returns no list columns", {
   resp <- mock_kucoin_response(data = list(orderId = "o4", clientOid = "c4"))
   httr2::local_mocked_responses(function(req) resp)
 
-  dt <- new_margin()$close_long(symbol = "BTC-USDT", size = 0.001)
+  dt <- new_margin()$close_long(symbol = TEST_SYMBOL_SPOT, size = 0.001)
   expect_equal(length(names(dt)[vapply(dt, is.list, logical(1))]), 0L)
   expect_true(is.character(dt$order_id))
   expect_true(is.character(dt$client_oid))

--- a/tests/testthat/test-KucoinMarketData.R
+++ b/tests/testthat/test-KucoinMarketData.R
@@ -4,8 +4,7 @@
 # -- Construction --
 
 test_that("KucoinMarketData inherits from KucoinBase", {
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
+  market <- new_market()
 
   expect_s3_class(market, "KucoinMarketData")
   expect_s3_class(market, "KucoinBase")
@@ -13,8 +12,7 @@ test_that("KucoinMarketData inherits from KucoinBase", {
 })
 
 test_that("KucoinMarketData async mode sets is_async = TRUE", {
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com", async = TRUE)
+  market <- KucoinMarketData$new(keys = TEST_KEYS, base_url = BASE_SPOT, async = TRUE)
   expect_true(market$is_async)
 })
 
@@ -24,9 +22,7 @@ test_that("get_ticker returns data.table with correct columns and types", {
   resp <- mock_kucoin_response(data = mock_ticker_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_ticker("BTC-USDT")
+  dt <- new_market()$get_ticker(TEST_SYMBOL_SPOT)
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
@@ -50,9 +46,7 @@ test_that("get_all_tickers returns multi-row data.table", {
   resp <- mock_kucoin_response(data = mock_all_tickers_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_all_tickers()
+  dt <- new_market()$get_all_tickers()
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 2L)
@@ -70,9 +64,7 @@ test_that("get_trade_history returns correct columns and types", {
   resp <- mock_kucoin_response(data = mock_trade_history_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_trade_history("BTC-USDT")
+  dt <- new_market()$get_trade_history(TEST_SYMBOL_SPOT)
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 3L)
@@ -97,9 +89,7 @@ test_that("get_part_orderbook returns orderbook with correct structure", {
   resp <- mock_kucoin_response(data = mock_orderbook_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_part_orderbook("BTC-USDT", size = 20)
+  dt <- new_market()$get_part_orderbook(TEST_SYMBOL_SPOT, size = 20)
 
   expect_s3_class(dt, "data.table")
   expect_equal(names(dt), c("time", "sequence", "side", "level", "price", "size"))
@@ -114,9 +104,7 @@ test_that("get_part_orderbook level column is 1-indexed depth within each side",
   resp <- mock_kucoin_response(data = mock_orderbook_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_part_orderbook("BTC-USDT", size = 20)
+  dt <- new_market()$get_part_orderbook(TEST_SYMBOL_SPOT, size = 20)
 
   # Each side should start at level 1 and increment without gaps.
   expect_equal(dt[side == "bid", level], seq_len(sum(dt$side == "bid")))
@@ -137,11 +125,10 @@ test_that("get_part_orderbook uses correct endpoint for size 20 vs 100", {
     return(resp)
   })
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
+  market <- new_market()
 
-  market$get_part_orderbook("BTC-USDT", size = 20)
-  market$get_part_orderbook("BTC-USDT", size = 100)
+  market$get_part_orderbook(TEST_SYMBOL_SPOT, size = 20)
+  market$get_part_orderbook(TEST_SYMBOL_SPOT, size = 100)
 
   expect_true(grepl("level2_20", captured_urls[1]))
   expect_true(grepl("level2_100", captured_urls[2]))
@@ -153,9 +140,7 @@ test_that("get_24hr_stats returns correct data.table", {
   resp <- mock_kucoin_response(data = mock_24hr_stats_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_24hr_stats("BTC-USDT")
+  dt <- new_market()$get_24hr_stats("BTC-USDT")
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
@@ -179,9 +164,7 @@ test_that("get_market_list returns data.table", {
   resp <- mock_kucoin_response(data = mock_market_list_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  result <- market$get_market_list()
+  result <- new_market()$get_market_list()
 
   expect_s3_class(result, "data.table")
   expect_true("market" %in% names(result))
@@ -196,9 +179,7 @@ test_that("get_currency returns flattened currency + chain data", {
   resp <- mock_kucoin_response(data = mock_currency_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_currency("BTC")
+  dt <- new_market()$get_currency("BTC")
 
   expect_s3_class(dt, "data.table")
   # BTC has 2 chains in mock data
@@ -220,9 +201,7 @@ test_that("get_symbol returns single-row data.table with snake_case names", {
   resp <- mock_kucoin_response(data = mock_symbol_data())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_symbol("BTC-USDT")
+  dt <- new_market()$get_symbol("BTC-USDT")
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
@@ -247,9 +226,7 @@ test_that("get_all_symbols returns multi-row data.table", {
   resp <- mock_kucoin_response(data = symbols_data)
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_all_symbols()
+  dt <- new_market()$get_all_symbols()
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 2L)
@@ -264,10 +241,8 @@ test_that("get_klines returns OHLCV data.table via kucoin_fetch_klines", {
   resp <- mock_kucoin_response(data = klines)
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_klines(
-    symbol = "BTC-USDT",
+  dt <- new_market()$get_klines(
+    symbol = TEST_SYMBOL_SPOT,
     timeframe = "15min",
     from = 1729100000,
     to = 1729110000
@@ -376,9 +351,7 @@ test_that("get_server_time returns server_time and datetime", {
   resp <- mock_kucoin_response(data = 1729100692873)
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_server_time()
+  dt <- new_market()$get_server_time()
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
@@ -392,9 +365,7 @@ test_that("get_service_status returns status and msg", {
   resp <- mock_kucoin_response(data = list(status = "open", msg = ""))
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_service_status()
+  dt <- new_market()$get_service_status()
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 1L)
@@ -405,9 +376,7 @@ test_that("get_service_status detects maintenance", {
   resp <- mock_kucoin_response(data = list(status = "close", msg = "Scheduled maintenance"))
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_service_status()
+  dt <- new_market()$get_service_status()
 
   expect_equal(dt$status, "close")
   expect_equal(dt$msg, "Scheduled maintenance")
@@ -425,9 +394,7 @@ test_that("get_fiat_prices returns currency-price table", {
   )
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_fiat_prices(base = "USD", currencies = "BTC,ETH,USDT")
+  dt <- new_market()$get_fiat_prices(base = "USD", currencies = "BTC,ETH,USDT")
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 3L)
@@ -440,9 +407,7 @@ test_that("get_fiat_prices handles empty response", {
   resp <- mock_kucoin_response(data = list())
   httr2::local_mocked_responses(function(req) resp)
 
-  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-  market <- KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")
-  dt <- market$get_fiat_prices()
+  dt <- new_market()$get_fiat_prices()
 
   expect_s3_class(dt, "data.table")
   expect_equal(nrow(dt), 0L)

--- a/tests/testthat/test-KucoinOcoOrders.R
+++ b/tests/testthat/test-KucoinOcoOrders.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinOcoOrders.R
 # Tests for KucoinOcoOrders R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_oco <- function() {
-  return(KucoinOcoOrders$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinOcoOrders inherits from KucoinBase", {

--- a/tests/testthat/test-KucoinStopOrders.R
+++ b/tests/testthat/test-KucoinStopOrders.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinStopOrders.R
 # Tests for KucoinStopOrders R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_stop <- function() {
-  return(KucoinStopOrders$new(keys = KEYS, base_url = BASE))
-}
-
 expect_no_list_cols <- function(dt) {
   list_cols <- names(dt)[vapply(dt, is.list, logical(1))]
   return(expect_equal(

--- a/tests/testthat/test-KucoinSubAccount.R
+++ b/tests/testthat/test-KucoinSubAccount.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinSubAccount.R
 # Tests for KucoinSubAccount R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_sub <- function() {
-  return(KucoinSubAccount$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinSubAccount inherits from KucoinBase", {

--- a/tests/testthat/test-KucoinTrading.R
+++ b/tests/testthat/test-KucoinTrading.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinTrading.R
 # Tests for KucoinTrading R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_trading <- function() {
-  return(KucoinTrading$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinTrading inherits from KucoinBase", {

--- a/tests/testthat/test-KucoinTransfer.R
+++ b/tests/testthat/test-KucoinTransfer.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinTransfer.R
 # Tests for KucoinTransfer R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_transfer <- function() {
-  return(KucoinTransfer$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinTransfer inherits from KucoinBase", {

--- a/tests/testthat/test-KucoinWithdrawal.R
+++ b/tests/testthat/test-KucoinWithdrawal.R
@@ -1,13 +1,6 @@
 # tests/testthat/test-KucoinWithdrawal.R
 # Tests for KucoinWithdrawal R6 class with mocked HTTP.
 
-KEYS <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
-BASE <- "https://api.kucoin.com"
-
-new_withdrawal <- function() {
-  return(KucoinWithdrawal$new(keys = KEYS, base_url = BASE))
-}
-
 # -- Construction --
 
 test_that("KucoinWithdrawal inherits from KucoinBase", {


### PR DESCRIPTION
## Summary

Every `tests/testthat/test-Kucoin*.R` previously repeated the same dummy `KEYS`, hard-coded `BASE` URL, and per-file `new_xxx <- function() { ... }` constructor helper. `test-KucoinMarketData.R` was the worst offender — 22 inline `KucoinMarketData$new(keys = keys, base_url = "https://api.kucoin.com")` calls, one `keys <- get_api_keys(...)` line per `test_that` block.

New `tests/testthat/helper-constants.R` (auto-sourced by `testthat` before tests run) defines:

- `BASE_SPOT` / `BASE_FUTURES` — REST endpoint URLs
- `TEST_KEYS` — single shared dummy credential set
- `TEST_SYMBOL_SPOT` / `TEST_SYMBOL_FUTURES` — `"BTC-USDT"` / `"XBTUSDTM"` for incidental fixture symbols
- 15 `new_xxx()` helpers, one per R6 class

## Renames worth noting

The per-file scoping was masking three name collisions. Promoting helpers to global made them visible:

| Old (per-file) | New (global) | Class |
|---|---|---|
| `new_account()` in `test-KucoinFuturesAccount.R` | `new_futures_account()` | `KucoinFuturesAccount` |
| `new_market()` in `test-KucoinFuturesMarketData.R` | `new_futures_market()` | `KucoinFuturesMarketData` |
| `new_trading()` in `test-KucoinFuturesTrading.R` | `new_futures_trading()` | `KucoinFuturesTrading` |

The corresponding spot helpers keep their short names.

## What I left alone

- `"BTC-USDT"` / `"XBTUSDTM"` literals inside round-trip assertions (`expect_equal(dt$symbol, "BTC-USDT")`), mock fixtures, URL/body `grepl()` checks, and the two `test-live-integration-*.R` files — those tests are about the specific symbol, not "any symbol".
- `tests/testthat/mockery.R`, `helper-mock.R`, `mock_router.R` — fixture / utility code, not the subject of this refactor.
- `R/` source — out of scope; the base URL is already centralised there via `R/KucoinBase.R` defaults and `get_base_url()` / `get_futures_base_url()`.

## Numbers

- **-133 net lines** across 15 files (15 changed, 128 insertions, 261 deletions)
- Tests: **440 / 440 pass** (1339 expectations, 2 live skipped, 0 fail, 0 warn)
- Lintr: 230 warnings (+1 vs master — the new helper file's own `# tests/testthat/helper-constants.R` path-comment header trips `commented_code_linter`, the same flag every other test file already has)

## Test plan

- [x] `devtools::test()` — 440 / 440 pass
- [x] `bash scripts/LINT.sh` — air format clean, lintr stable at +1
- [ ] Reviewer eyeball pass on the helper names + the renames table above