### PR TITLE
Polish NEWS.md, add README Design Philosophy, surface data-shapes vignette

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -31,6 +31,7 @@ tests-temp/
 log.txt
 ^\.claude$
 ^\.graphics$
+^\.playwright-mcp$
 ^_pkgdown\.yml$
 ^air\.toml$
 ^cran-comments\.md$

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,14 +37,23 @@
 * Fixed `URLencode()` in request signing to coerce query values to character before encoding, preventing errors on numeric parameters.
 * `KucoinMarginTrading$repay()` now coerces the response `timestamp` to `POSIXct` instead of leaving it as a raw millisecond `numeric`, matching the rest of the package's timestamp behaviour.
 * `KucoinMarginData$get_margin_config()` now returns a schema-stable zero-row `data.table` when `currencyList` is empty or `data` is `NULL`, rather than indexing into an empty row.
+* **Orderbook parsers gain a `level` depth column**. `parse_orderbook()` (spot) and `parse_futures_orderbook()` (futures) now emit a 1-indexed position column per side so the on-wire "best price first" ordering survives any later sort or filter (`level == 1` is best bid / best ask). Affects `KucoinMarketData$get_part_orderbook()`, `KucoinMarketData$get_full_orderbook()`, `KucoinFuturesMarketData$get_part_orderbook()`, and `KucoinFuturesMarketData$get_full_orderbook()`.
+* **Cancel-parser NULL / empty-`cancelledOrderIds` guards** on every cancel method that returns `cancelled_order_id` long-format rows. Previously a NULL response or an empty `cancelledOrderIds` array could trigger row-replication errors; the parsers now short-circuit to a zero-row `data.table` with the documented schema. Affects `KucoinOcoOrders` (3 methods), `KucoinFuturesTrading` (3 methods).
+* **`KucoinSubAccount` `account_type` semantic labels**. `get_detail_balance()` and `get_all_spot_balances()` previously emitted the raw response field names (`main_accounts`, `trade_accounts`, `margin_accounts`); these are now the stable semantic labels `"main"`, `"trade"`, `"margin"` so the documented filter idiom `balances[account_type == "trade"]` keeps working.
+* `ms_to_datetime()` / `ns_to_datetime()` (and the alpaca equivalent `rfc3339_to_datetime`) no longer short-circuit on `all(is.na(x))` input. The short-circuit returned a length-1 `NA_POSIXct_` which `data.table::set()` would recycle into the existing column's storage type rather than replacing the column with POSIXct — so all-NA timestamp columns were silently typed as `character`/`numeric` instead of `POSIXct`. The helpers now always produce a length-matching POSIXct vector, even when every input value is missing.
 
 ## IMPROVEMENTS
 
+* **One-entity-per-row, no-list-column convention across every R6 class.** Sweeping pass on all 16 classes to eliminate `data.table` list columns and standardise on one of five shape treatments (`;`-collapse for arrays of plain strings; long-format explode for arrays of objects, with a 1-indexed position column where order matters; wide-prefix flatten for fixed-schema nested objects; sibling-method re-route for collections that don't fit the row entity; JSON-string encode for dynamic-key or array-of-array objects). Matches the convention in the sibling `alpaca` and `binance` packages — see the new `vignette("data-shapes")`.
 * **Consistent `data.table` returns**: All parsers now return `data.table` objects. Fixed four methods that previously returned other types:
     - `KucoinTrading$cancel_all_by_symbol()`: was `character`, now `data.table` with `result` column.
     - `KucoinMarketData$get_market_list()`: was `character` vector, now `data.table` with `market` column.
     - `KucoinMarginData$get_margin_config()`: was raw `list`, now long-format `data.table` with one row per supported `currency`, plus `max_leverage`, `warning_debt_ratio`, `liq_debt_ratio`.
     - `KucoinMarginData$get_collateral_ratio()`: was raw `list`, now flattened `data.table` with `currency`, `lower_limit`, `upper_limit`, `collateral_ratio` columns.
+* **`KucoinMarketData$get_announcements()`**: `ann_type` is now a `;`-collapsed character column (Treatment A) instead of either a list column or a long-format row explosion. Recover with `strsplit(x, ";", fixed = TRUE)[[1]]`. The shared `collapse_string_array_fields()` helper emits a once-per-session warning if a value ever contains a literal `;` so silent corruption is unmissable.
+* **Shared internal helpers** (`@noRd`, ported from the binance package to keep the three packages' parser surface aligned):
+    - `collapse_string_array_fields(x, fields)` — NA-safe Treatment A `;`-collapse.
+    - `coerce_cols(dt, cols, fn)` — applies a coercion function to a set of columns by reference, silently skipping columns that aren't on the table. Replaces the repeated `if (nrow(dt) > 0 && "X" %in% names(dt)) { dt[, X := fn(X)] }` boilerplate across every parser.
 * Increased default request timeout from 10s to 30s.
 * `@import data.table` added centrally via `R/imports.R` to simplify namespace management.
 * Support both `KC-API-KEY` and `KUCOIN_API_KEY` environment variable naming conventions.
@@ -59,7 +68,8 @@
 * Corrected `wrap_list_fields` / `as_dt_row` documentation to accurately describe `length >= 1` wrapping behavior.
 * Expanded `@return` blocks across `KucoinMarginData`, `KucoinMarginTrading`, and `KucoinLending`: every public method now spells out its columns and their R types, the per-method row entity, and how the empty case is shaped — matching the binance/alpaca data-shape vignette.
 * Updated `kucoin_btc_usdt_4h_ohlcv` dataset documentation to reflect 18,351 rows through March 2026.
-* Two new vignettes: "Margin Trading" and "Futures Trading".
+* Three new vignettes: "Margin Trading", "Futures Trading", and "Data shapes and the one-row-per-entity convention".
+* README gains a **Design Philosophy** section explaining the snake_case / timestamp / shape-normalisation contract and pointing at `vignette("data-shapes")` for the full catalogue. Mirrors the section the sibling `alpaca` / `binance` READMEs already carry.
 * Updated ROADMAP to v4.0.0 with Futures classes added to completed items.
 
 ## TESTS
@@ -75,6 +85,17 @@
 ## DATA
 
 * Refreshed bundled `kucoin_btc_usdt_4h_ohlcv` dataset (18,351 rows, Oct 2017 – Mar 2026).
+
+## TOOLING
+
+* **`scripts/LINT.sh`** — new script that runs `air format .` first (so reformatted code is what gets linted, and a passing run leaves the working tree clean) then `lintr::lint_package()` with the package loaded via `devtools::load_all()` so `object_usage_linter` honours `utils::globalVariables()` declarations for `data.table` NSE columns. Matches the binance package's lint script with the air format step folded in.
+* **`.lintr` config repaired**. The previous file started with a leading `# .lintr` comment that made the DCF parser reject it (`Malformed config file`) — `lintr::lint_package()` had been failing silently. Now adopts the binance ruleset: line length 120, indentation 2, explicit `return()` style, and `object_name_linter` allowing `snake_case` / `SNAKE_CASE` / `CamelCase` / `camelCase` so R6 class names and KuCoin's camelCase API params (`clientOid`, `orderId`) are accepted.
+
+## REFACTOR
+
+* **Explicit `return()` everywhere.** Every closure now has an explicit `return(...)` instead of relying on R's implicit-last-expression. Touches 78 sites across the package (9 in `R/`, 69 across `tests/` and `vignettes/`). Side-effect-only closures get `return(invisible(NULL))`.
+* **No `var <- if (...)` style.** Three sites refactored to declare the variable with its default value and conditionally reassign instead (POSIXct-vs-epoch-ms coercion in `KucoinFuturesMarketData$get_klines()`; ticker mock alternation in `vignettes/async-usage.Rmd`). Function-call named args (`f(x = if (...) a else b)`) are out of scope for the rule and were left alone.
+* **`tests/testthat/helper-constants.R`** — shared test-setup file (auto-sourced by `testthat` before tests). Defines `BASE_SPOT` / `BASE_FUTURES`, `TEST_KEYS`, `TEST_SYMBOL_SPOT` / `TEST_SYMBOL_FUTURES`, and one `new_xxx()` constructor helper per R6 class. Strips ~130 lines of duplicated setup boilerplate from the 14 test files; collapses 22 inline `KucoinMarketData$new(...)` calls in `test-KucoinMarketData.R` to `new_market()`. Resolves three name collisions that the per-file scoping had been hiding (`new_account`, `new_market`, `new_trading` now have explicit `new_futures_*` siblings).
 
 ## LICENCE
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,6 +29,56 @@ This software is provided "as is", without warranty of any kind. **This package 
 
 We invite you to read the source code and make contributions if you find a bug or wish to make an improvement.
 
+## Design Philosophy
+
+All API responses are returned as `data.table` objects with three
+transformations applied:
+
+1.  **snake_case column names** — camelCase keys from the JSON response
+    (e.g. `clientOid`, `orderType`, `createdAt`) become snake_case
+    (`client_oid`, `order_type`, `created_at`). A handful of endpoints
+    additionally reshape nested objects to wide `parent_child` columns
+    (e.g. `baseAsset.currency` → `base_asset_currency`) or collapse
+    array fields under a plural form. See each method's `@return` for
+    the exact column list.
+
+2.  **Type coercion** for well-known columns — KuCoin's millisecond
+    timestamps (most endpoints) and nanosecond timestamps (futures
+    orderbooks / klines) are both parsed to `POSIXct` in UTC. Numeric
+    quantities, prices, and ratios stay as `character` strings because
+    KuCoin emits them as strings and the precision matters; cast with
+    `as.numeric()` at the point of use if you need arithmetic.
+
+3.  **One entity = one row, no list columns** — every method follows
+    the rule *"identify the entity for the endpoint, return one row per
+    entity"*. The same convention is shared with the sister `alpaca`
+    and `binance` packages so switching between exchanges doesn't mean
+    switching mental models.
+
+The five shape treatments the parsers apply, depending on the nested
+structure:
+
+| Nested shape | Treatment | Example |
+|----|----|----|
+| Array of plain strings (`annType`, `permissions`) | Collapsed into one `;`-separated character column. Recover with `strsplit(x, ";", fixed = TRUE)[[1]]`. | `dt$ann_type` → `"latest-announcements;new-listings"` |
+| Array of objects (orderbook levels, OCO `orders`, sub-account `balances`) | Exploded to long format with parent fields replicated. A 1-indexed `level` / `sub_order_*` / similar position column is added when order matters. | `get_part_orderbook()` → one row per `(side, level)`. |
+| Fixed-schema nested object (`baseAsset` / `quoteAsset` on isolated-margin pairs) | Flattened to wide `parent_child` columns. | `get_isolated_margin_account()` → `base_asset_currency`, `base_asset_borrow_enabled`, … |
+| Sibling collection that doesn't fit the row entity | Exposed via a sibling method on the same class so every method still returns one `data.table`. | `KucoinAccount$get_isolated_margin_account()` returns per-pair rows; ad-hoc summaries are sibling methods. |
+| Dynamic-key or array-of-array objects | Serialised as a JSON string column; recover with `jsonlite::fromJSON(x)`. | Lending product `tierAnnualPercentageRate` blocks. |
+
+**Two cross-cutting rules** apply to every shape treatment:
+
+1. **Empty / null array → `NA_character_`** (no list cells). An OCO
+   order with no children returns `sub_order_id = NA`, not
+   `sub_order_id = list()`.
+2. **Empty response → empty `data.table`** (no synthetic stub rows).
+   `KucoinTrading$cancel_all()` with no open orders returns a zero-row
+   table, not a fabricated `(symbol, status = "cancelled")` placeholder.
+   The absence of an error is the success signal.
+
+For the full per-treatment catalogue with worked examples, see
+`vignette("data-shapes", package = "kucoin")`.
+
 ## Installation
 
 ```{r, eval = FALSE}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,56 @@ damage arising from the use of this software.
 We invite you to read the source code and make contributions if you find
 a bug or wish to make an improvement.
 
+## Design Philosophy
+
+All API responses are returned as `data.table` objects with three
+transformations applied:
+
+1.  **snake_case column names** — camelCase keys from the JSON response
+    (e.g. `clientOid`, `orderType`, `createdAt`) become snake_case
+    (`client_oid`, `order_type`, `created_at`). A handful of endpoints
+    additionally reshape nested objects to wide `parent_child` columns
+    (e.g. `baseAsset.currency` → `base_asset_currency`) or collapse
+    array fields under a plural form. See each method’s `@return` for
+    the exact column list.
+
+2.  **Type coercion** for well-known columns — KuCoin’s millisecond
+    timestamps (most endpoints) and nanosecond timestamps (futures
+    orderbooks / klines) are both parsed to `POSIXct` in UTC. Numeric
+    quantities, prices, and ratios stay as `character` strings because
+    KuCoin emits them as strings and the precision matters; cast with
+    `as.numeric()` at the point of use if you need arithmetic.
+
+3.  **One entity = one row, no list columns** — every method follows the
+    rule *“identify the entity for the endpoint, return one row per
+    entity”*. The same convention is shared with the sister `alpaca` and
+    `binance` packages so switching between exchanges doesn’t mean
+    switching mental models.
+
+The five shape treatments the parsers apply, depending on the nested
+structure:
+
+| Nested shape | Treatment | Example |
+|----|----|----|
+| Array of plain strings (`annType`, `permissions`) | Collapsed into one `;`-separated character column. Recover with `strsplit(x, ";", fixed = TRUE)[[1]]`. | `dt$ann_type` → `"latest-announcements;new-listings"` |
+| Array of objects (orderbook levels, OCO `orders`, sub-account `balances`) | Exploded to long format with parent fields replicated. A 1-indexed `level` / `sub_order_*` / similar position column is added when order matters. | `get_part_orderbook()` → one row per `(side, level)`. |
+| Fixed-schema nested object (`baseAsset` / `quoteAsset` on isolated-margin pairs) | Flattened to wide `parent_child` columns. | `get_isolated_margin_account()` → `base_asset_currency`, `base_asset_borrow_enabled`, … |
+| Sibling collection that doesn’t fit the row entity | Exposed via a sibling method on the same class so every method still returns one `data.table`. | `KucoinAccount$get_isolated_margin_account()` returns per-pair rows; ad-hoc summaries are sibling methods. |
+| Dynamic-key or array-of-array objects | Serialised as a JSON string column; recover with `jsonlite::fromJSON(x)`. | Lending product `tierAnnualPercentageRate` blocks. |
+
+**Two cross-cutting rules** apply to every shape treatment:
+
+1.  **Empty / null array → `NA_character_`** (no list cells). An OCO
+    order with no children returns `sub_order_id = NA`, not
+    `sub_order_id = list()`.
+2.  **Empty response → empty `data.table`** (no synthetic stub rows).
+    `KucoinTrading$cancel_all()` with no open orders returns a zero-row
+    table, not a fabricated `(symbol, status = "cancelled")`
+    placeholder. The absence of an error is the success signal.
+
+For the full per-treatment catalogue with worked examples, see
+`vignette("data-shapes", package = "kucoin")`.
+
 ## Installation
 
 ``` r
@@ -420,6 +470,28 @@ futures_trading$add_order_test(
 ``` r
 futures_account$get_positions()
 ```
+
+    #>         id   symbol auto_deposit real_leverage cross_mode delev_percentage
+    #>     <char>   <char>       <lgcl>         <int>     <lgcl>            <num>
+    #> 1: pos-001 XBTUSDTM        FALSE             5      FALSE              0.5
+    #>      opening_timestamp   current_timestamp current_qty current_cost
+    #>                 <POSc>              <POSc>       <int>       <char>
+    #> 1: 2024-10-17 10:04:19 2024-10-17 10:46:40           1        98.25
+    #>    current_comm unrealised_cost realised_gross_cost realised_cost is_open
+    #>          <char>          <char>              <char>        <char>  <lgcl>
+    #> 1:      0.05895           98.25                   0       0.05895    TRUE
+    #>    mark_price mark_value pos_cost pos_cross pos_init pos_comm pos_loss
+    #>         <int>     <char>   <char>    <char>   <char>   <char>   <char>
+    #> 1:      98350      98.35    98.25         0    19.65  0.07861        0
+    #>    pos_margin pos_maint maint_margin realised_gross_pnl realised_pnl
+    #>        <char>    <char>       <char>             <char>       <char>
+    #> 1:   19.72861    0.4423     19.82861                  0     -0.05895
+    #>    unrealised_pnl unrealised_pnl_pcnt avg_entry_price liquidation_price
+    #>            <char>               <num>          <char>            <char>
+    #> 1:            0.1               0.001         98250.0           79000.0
+    #>    bankrupt_price settle_currency margin_mode position_side
+    #>            <char>          <char>      <char>        <char>
+    #> 1:        78500.0            USDT    ISOLATED          BOTH
 
 For full futures documentation see `vignette("futures-trading")`.
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -74,6 +74,7 @@ articles:
     contents:
       - getting-started
       - async-usage
+      - data-shapes
       - margin-trading
       - futures-trading
 


### PR DESCRIPTION
## Summary

Closes the documentation parity gap with the sibling `alpaca` and `binance` packages, and back-fills NEWS for the work that landed after the v4.0.0 section was originally written.

### README

New `## Design Philosophy` section between Disclaimer and Installation — mirrors the section both sibling READMEs carry. Explains the three transformations (snake_case, timestamp coercion, one-entity-per-row), the five shape treatments with a worked-example table, the two cross-cutting rules (empty array → `NA_character_`, empty response → empty `data.table`), and links to `vignette("data-shapes")` for the full catalogue. Adapted to kucoin specifics (`clientOid` / `orderType`, `baseAsset` / `quoteAsset`, OCO `sub_order_*`).

### `_pkgdown.yml`

`data-shapes` was missing from the Getting Started articles list — the vignette had landed but the navbar wasn't updated, so it never surfaced on the site.

### `.Rbuildignore`

`^\.playwright-mcp$` added (parity fix; both sibling packages already exclude this MCP cache directory).

### NEWS.md

Extensive expansion of the `kucoin 4.0.0` section for the work that shipped after the original NEWS was written:

- **BUG FIXES** — orderbook `level` depth column on spot + futures parsers; cancel-parser NULL / empty-`cancelledOrderIds` guards across `KucoinOcoOrders` and `KucoinFuturesTrading`; `KucoinSubAccount` `account_type` semantic labels (`"main"` / `"trade"` / `"margin"`); `ms_to_datetime` / `ns_to_datetime` all-NA POSIXct shape fix.
- **IMPROVEMENTS** — the cross-package one-entity-per-row sweep across every R6 class; `get_announcements` Treatment A `;`-collapse; shared internal helpers `collapse_string_array_fields()` + `coerce_cols()`.
- **DOCUMENTATION** — corrected vignette count (2 → 3); called out the new README Design Philosophy section.
- **TOOLING** (new section) — `scripts/LINT.sh` + `.lintr` config repair.
- **REFACTOR** (new section) — explicit `return()` everywhere (78 sites); no `var <- if (...)` style (3 sites); shared `tests/testthat/helper-constants.R` (-133 lines, 3 disambiguating `new_futures_*` renames).

## Test plan

- [x] `devtools::test()` — 440 / 440 pass, 2 live skipped
- [x] `bash scripts/LINT.sh` — air format clean
- [x] README rebuilt cleanly (+72 lines, just the new section, no incidental chunk drift)