### PR TITLE
Migrate KucoinFuturesTrading DCP to the unified /api/ua/v1/dcp/* endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,16 @@
 # kucoin 4.0.3
 
+## BUG FIXES
+
+* **`KucoinFuturesTrading$set_dcp()` / `$get_dcp()` migrated to KuCoin's new unified DCP endpoint.** The legacy futures-specific paths (`POST /api/v1/orders/dead-cancel-all` and `GET /api/v1/orders/dead-cancel-all/query` on `api-futures.kucoin.com`) were retired by KuCoin around 2026-05 — the docs page was withdrawn, the GET path returned HTTP 404 and the POST returned 403 even on accounts with the relevant permission. KuCoin replaced both with a unified Universal-Trading-Account endpoint on the spot host: `POST /api/ua/v1/dcp/set` and `GET /api/ua/v1/dcp/query`, both taking a `tradeType` parameter that accepts `SPOT`, `MARGIN`, or `FUTURES`. We now hardcode `tradeType = "FUTURES"` and override the base URL to the spot host inside both methods, so the public method API stays unchanged — existing `futures_trading$set_dcp(timeout, symbol)` and `$get_dcp(symbol)` calls keep working. Spot DCP (`KucoinTrading$set_dcp()` / `$get_dcp()`) is untouched — it still works against the `/api/v1/hf/orders/dead-cancel-all*` paths on the spot host.
+
+## REFACTOR
+
+* **`KucoinBase$.request()` (private) gains an optional `base_url` parameter** that overrides the instance's configured host for a single call. Used so the migrated futures DCP methods can target the spot host while every other `KucoinFuturesTrading` method keeps using the futures host. No behaviour change for any existing call site — `base_url = NULL` (the default) preserves the previous behaviour exactly.
+
 ## TESTS
 
-* **Live integration coverage for the Futures REST surface.** New `[LIVE]` test blocks in `tests/testthat/test-live-integration-public.R` (7 tests against `KucoinFuturesMarketData` public endpoints) and `test-live-integration-private.R` (11 tests covering authenticated `KucoinFuturesAccount`, `KucoinFuturesMarketData$get_full_orderbook`, and read-only `KucoinFuturesTrading` queries). Pins the 5 path-corrected GET endpoints from v4.0.2 (`get_margin_mode`, `get_cross_margin_leverage`, `get_max_open_size`, `get_max_withdraw_margin`, `get_full_orderbook`) so the next time KuCoin moves a futures endpoint, CI surfaces the 404 instead of waiting for a user report.
+* **Live integration coverage for the Futures REST surface.** New `[LIVE]` test blocks in `tests/testthat/test-live-integration-public.R` (7 tests against `KucoinFuturesMarketData` public endpoints) and `test-live-integration-private.R` (13 tests covering authenticated `KucoinFuturesAccount`, `KucoinFuturesMarketData$get_full_orderbook`, read-only `KucoinFuturesTrading` queries, and the migrated DCP methods). Pins the 5 path-corrected GET endpoints from v4.0.2 (`get_margin_mode`, `get_cross_margin_leverage`, `get_max_open_size`, `get_max_withdraw_margin`, `get_full_orderbook`) plus the migrated DCP endpoints so the next time KuCoin moves a futures endpoint, CI surfaces the 404 instead of waiting for a user report. The DCP `set_dcp` test deliberately uses `timeout = -1` (disable) so it has no real side effects.
 * Write methods (`set_margin_mode`, `set_cross_margin_leverage`, `add_isolated_margin`, `remove_isolated_margin`) are intentionally not exercised — they require real positions / funds.
 * Authenticated futures tests wrap each call in `tryCatch()` and skip with a clear reason if KuCoin returns a no-futures-account / no-permission error, so the suite stays usable for contributors without a funded futures sub-account. Endpoints that genuinely 404 still fail loudly (which is the regression we want to catch).
 

--- a/R/KucoinBase.R
+++ b/R/KucoinBase.R
@@ -132,10 +132,20 @@ KucoinBase <- R6::R6Class(
       body = NULL,
       auth = TRUE,
       .parser = identity,
-      timeout = 30
+      timeout = 30,
+      base_url = NULL
     ) {
+      # `base_url = NULL` (the default) uses the instance's configured host
+      # (spot for most classes, futures for the `KucoinFutures*` classes).
+      # An explicit `base_url` overrides for the rare cross-host endpoint —
+      # e.g. KuCoin's unified `/api/ua/v1/dcp/*` lives on the spot host but
+      # is exposed to futures callers through `KucoinFuturesTrading`.
+      effective_base <- private$.base_url
+      if (!is.null(base_url)) {
+        effective_base <- base_url
+      }
       return(kucoin_build_request(
-        base_url = private$.base_url,
+        base_url = effective_base,
         endpoint = endpoint,
         method = method,
         query = query,

--- a/R/KucoinFuturesTrading.R
+++ b/R/KucoinFuturesTrading.R
@@ -41,8 +41,8 @@
 #' | get_fills | GET /api/v1/fills | GET |
 #' | get_recent_fills | GET /api/v1/recentFills | GET |
 #' | get_open_order_value | GET /api/v1/openOrderStatistics | GET |
-#' | set_dcp | POST /api/v1/orders/dead-cancel-all | POST |
-#' | get_dcp | GET /api/v1/orders/dead-cancel-all/query | GET |
+#' | set_dcp | POST /api/ua/v1/dcp/set (spot host, tradeType=FUTURES) | POST |
+#' | get_dcp | GET /api/ua/v1/dcp/query (spot host, tradeType=FUTURES) | GET |
 #'
 #' @examples
 #' \dontrun{
@@ -1780,12 +1780,18 @@ KucoinFuturesTrading <- R6::R6Class(
     #' 3. **Parsing**: Returns `data.table` with the configured timeout and applicable symbols.
     #'
     #' ### API Endpoint
-    #' `POST https://api-futures.kucoin.com/api/v1/orders/dead-cancel-all`
+    #' `POST https://api.kucoin.com/api/ua/v1/dcp/set`
+    #'
+    #' The legacy futures-specific endpoint
+    #' (`POST /api/v1/orders/dead-cancel-all` on `api-futures.kucoin.com`)
+    #' was retired by KuCoin around 2026-05 and replaced with a unified
+    #' Universal-Trading-Account endpoint on the spot host that accepts a
+    #' `tradeType` parameter. We hardcode `tradeType = "FUTURES"` and
+    #' override the base URL to the spot host so the public method API
+    #' stays unchanged.
     #'
     #' ### Official Documentation
-    #' [KuCoin Set DCP (spot equivalent; futures DCP page withdrawn from
-    #' KuCoin docs as of 2026-05; POST endpoint still accepted by the
-    #' Futures REST API)](https://www.kucoin.com/docs-new/rest/spot-trading/orders/set-dcp)
+    #' [KuCoin Set DCP (Classic)](https://www.kucoin.com/docs-new/rest/ua/set-dcp-classic)
     #'
     #' Verified: 2026-05-23
     #'
@@ -1797,21 +1803,22 @@ KucoinFuturesTrading <- R6::R6Class(
     #'
     #' ### curl
     #' ```
-    #' curl --location --request POST 'https://api-futures.kucoin.com/api/v1/orders/dead-cancel-all' \
+    #' curl --location --request POST 'https://api.kucoin.com/api/ua/v1/dcp/set' \
     #'   --header 'Content-Type: application/json' \
     #'   --header 'KC-API-KEY: your-api-key' \
     #'   --header 'KC-API-SIGN: your-signature' \
     #'   --header 'KC-API-TIMESTAMP: 1729176273859' \
     #'   --header 'KC-API-PASSPHRASE: your-passphrase' \
     #'   --header 'KC-API-KEY-VERSION: 2' \
-    #'   --data-raw '{"timeout": 60, "symbol": "XBTUSDTM"}'
+    #'   --data-raw '{"timeout": 60, "symbol": "XBTUSDTM", "tradeType": "FUTURES"}'
     #' ```
     #'
     #' ### JSON Request
     #' ```json
     #' {
     #'   "timeout": 60,
-    #'   "symbol": "XBTUSDTM"
+    #'   "symbol": "XBTUSDTM",
+    #'   "tradeType": "FUTURES"
     #' }
     #' ```
     #'
@@ -1849,12 +1856,13 @@ KucoinFuturesTrading <- R6::R6Class(
     #' ft$set_dcp(timeout = -1)
     #' }
     set_dcp = function(timeout, symbol = NULL) {
-      body <- list(timeout = timeout, symbol = symbol)
+      body <- list(timeout = timeout, symbol = symbol, tradeType = "FUTURES")
       body <- body[!vapply(body, is.null, logical(1))]
       return(private$.request(
-        endpoint = "/api/v1/orders/dead-cancel-all",
+        endpoint = "/api/ua/v1/dcp/set",
         method = "POST",
         body = body,
+        base_url = get_base_url(),
         .parser = function(data) {
           return(as_dt_row(data))
         }
@@ -1872,12 +1880,19 @@ KucoinFuturesTrading <- R6::R6Class(
     #' 2. **Parsing**: Returns a single-row `data.table` with the current DCP settings.
     #'
     #' ### API Endpoint
-    #' `GET https://api-futures.kucoin.com/api/v1/orders/dead-cancel-all/query`
+    #' `GET https://api.kucoin.com/api/ua/v1/dcp/query`
+    #'
+    #' The legacy futures-specific endpoint
+    #' (`GET /api/v1/orders/dead-cancel-all/query` on
+    #' `api-futures.kucoin.com`) was retired by KuCoin around 2026-05
+    #' (the page was withdrawn and the endpoint now returns HTTP 404) and
+    #' replaced with the unified Universal-Trading-Account endpoint that
+    #' takes a `tradeType` query parameter. We hardcode
+    #' `tradeType = "FUTURES"` and override the base URL to the spot host
+    #' so the public method API stays unchanged.
     #'
     #' ### Official Documentation
-    #' [KuCoin Get DCP (spot equivalent; futures DCP page withdrawn from
-    #' KuCoin docs as of 2026-05; the Futures REST query endpoint now
-    #' returns HTTP 404 — see NEWS for context)](https://www.kucoin.com/docs-new/rest/spot-trading/orders/get-dcp)
+    #' [KuCoin Get DCP (Classic)](https://www.kucoin.com/docs-new/rest/ua/get-dcp-classic)
     #'
     #' Verified: 2026-05-23
     #'
@@ -1888,7 +1903,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #' ### curl
     #' ```
     #' curl --location --request GET \
-    #'   'https://api-futures.kucoin.com/api/v1/orders/dead-cancel-all/query?symbol=XBTUSDTM' \
+    #'   'https://api.kucoin.com/api/ua/v1/dcp/query?tradeType=FUTURES&symbol=XBTUSDTM' \
     #'   --header 'KC-API-KEY: your-api-key' \
     #'   --header 'KC-API-SIGN: your-signature' \
     #'   --header 'KC-API-TIMESTAMP: 1729176273859' \
@@ -1927,9 +1942,12 @@ KucoinFuturesTrading <- R6::R6Class(
     #' dcp_global <- ft$get_dcp()
     #' }
     get_dcp = function(symbol = NULL) {
+      query <- list(tradeType = "FUTURES", symbol = symbol)
+      query <- query[!vapply(query, is.null, logical(1))]
       return(private$.request(
-        endpoint = "/api/v1/orders/dead-cancel-all/query",
-        query = list(symbol = symbol),
+        endpoint = "/api/ua/v1/dcp/query",
+        query = query,
+        base_url = get_base_url(),
         .parser = function(data) {
           return(as_dt_row(data))
         }

--- a/man/KucoinFuturesTrading.Rd
+++ b/man/KucoinFuturesTrading.Rd
@@ -52,8 +52,8 @@ unintended open positions during bot failures.
    get_fills \tab GET /api/v1/fills \tab GET \cr
    get_recent_fills \tab GET /api/v1/recentFills \tab GET \cr
    get_open_order_value \tab GET /api/v1/openOrderStatistics \tab GET \cr
-   set_dcp \tab POST /api/v1/orders/dead-cancel-all \tab POST \cr
-   get_dcp \tab GET /api/v1/orders/dead-cancel-all/query \tab GET \cr
+   set_dcp \tab POST /api/ua/v1/dcp/set (spot host, tradeType=FUTURES) \tab POST \cr
+   get_dcp \tab GET /api/ua/v1/dcp/query (spot host, tradeType=FUTURES) \tab GET \cr
 }
 
 }
@@ -2342,12 +2342,20 @@ connectivity, preventing orders from remaining open indefinitely.
 
 \subsection{API Endpoint}{
 
-\verb{POST https://api-futures.kucoin.com/api/v1/orders/dead-cancel-all}
+\verb{POST https://api.kucoin.com/api/ua/v1/dcp/set}
+
+The legacy futures-specific endpoint
+(\code{POST /api/v1/orders/dead-cancel-all} on \code{api-futures.kucoin.com})
+was retired by KuCoin around 2026-05 and replaced with a unified
+Universal-Trading-Account endpoint on the spot host that accepts a
+\code{tradeType} parameter. We hardcode \code{tradeType = "FUTURES"} and
+override the base URL to the spot host so the public method API
+stays unchanged.
 }
 
 \subsection{Official Documentation}{
 
-\href{https://www.kucoin.com/docs-new/rest/spot-trading/orders/set-dcp}{KuCoin Set DCP (spot equivalent; futures DCP page withdrawn from KuCoin docs as of 2026-05; POST endpoint still accepted by the Futures REST API)}
+\href{https://www.kucoin.com/docs-new/rest/ua/set-dcp-classic}{KuCoin Set DCP (Classic)}
 
 Verified: 2026-05-23
 }
@@ -2363,14 +2371,14 @@ Verified: 2026-05-23
 
 \subsection{curl}{
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{curl --location --request POST 'https://api-futures.kucoin.com/api/v1/orders/dead-cancel-all' \\
+\if{html}{\out{<div class="sourceCode">}}\preformatted{curl --location --request POST 'https://api.kucoin.com/api/ua/v1/dcp/set' \\
   --header 'Content-Type: application/json' \\
   --header 'KC-API-KEY: your-api-key' \\
   --header 'KC-API-SIGN: your-signature' \\
   --header 'KC-API-TIMESTAMP: 1729176273859' \\
   --header 'KC-API-PASSPHRASE: your-passphrase' \\
   --header 'KC-API-KEY-VERSION: 2' \\
-  --data-raw '\{"timeout": 60, "symbol": "XBTUSDTM"\}'
+  --data-raw '\{"timeout": 60, "symbol": "XBTUSDTM", "tradeType": "FUTURES"\}'
 }\if{html}{\out{</div>}}
 }
 
@@ -2378,7 +2386,8 @@ Verified: 2026-05-23
 
 \if{html}{\out{<div class="sourceCode json">}}\preformatted{\{
   "timeout": 60,
-  "symbol": "XBTUSDTM"
+  "symbol": "XBTUSDTM",
+  "tradeType": "FUTURES"
 \}
 }\if{html}{\out{</div>}}
 }
@@ -2455,12 +2464,21 @@ to verify that DCP is correctly configured.
 
 \subsection{API Endpoint}{
 
-\verb{GET https://api-futures.kucoin.com/api/v1/orders/dead-cancel-all/query}
+\verb{GET https://api.kucoin.com/api/ua/v1/dcp/query}
+
+The legacy futures-specific endpoint
+(\code{GET /api/v1/orders/dead-cancel-all/query} on
+\code{api-futures.kucoin.com}) was retired by KuCoin around 2026-05
+(the page was withdrawn and the endpoint now returns HTTP 404) and
+replaced with the unified Universal-Trading-Account endpoint that
+takes a \code{tradeType} query parameter. We hardcode
+\code{tradeType = "FUTURES"} and override the base URL to the spot host
+so the public method API stays unchanged.
 }
 
 \subsection{Official Documentation}{
 
-\href{https://www.kucoin.com/docs-new/rest/spot-trading/orders/get-dcp}{KuCoin Get DCP (spot equivalent; futures DCP page withdrawn from KuCoin docs as of 2026-05; the Futures REST query endpoint now returns HTTP 404 — see NEWS for context)}
+\href{https://www.kucoin.com/docs-new/rest/ua/get-dcp-classic}{KuCoin Get DCP (Classic)}
 
 Verified: 2026-05-23
 }
@@ -2475,7 +2493,7 @@ Verified: 2026-05-23
 \subsection{curl}{
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{curl --location --request GET \\
-  'https://api-futures.kucoin.com/api/v1/orders/dead-cancel-all/query?symbol=XBTUSDTM' \\
+  'https://api.kucoin.com/api/ua/v1/dcp/query?tradeType=FUTURES&symbol=XBTUSDTM' \\
   --header 'KC-API-KEY: your-api-key' \\
   --header 'KC-API-SIGN: your-signature' \\
   --header 'KC-API-TIMESTAMP: 1729176273859' \\

--- a/tests/testthat/mock_router.R
+++ b/tests/testthat/mock_router.R
@@ -109,6 +109,14 @@ box::use(./mockery[
   list(pattern = "api/v1/timestamp", fixture = function() mock_futures_server_time_data()),
   list(pattern = "api/v1/status", fixture = function() mock_futures_service_status_data()),
   # Futures Trading
+  # Futures DCP migrated to the unified `/api/ua/v1/dcp/*` endpoint in
+  # v4.0.3 (the legacy `/api/v1/orders/dead-cancel-all*` paths return
+  # 404/403 since KuCoin's 2026-05 reorganisation). The legacy patterns
+  # are kept second as a fallback for any caller that hasn't migrated
+  # yet — `grepl(..., fixed = TRUE)` short-circuits on the first match
+  # so the new pattern takes precedence.
+  list(pattern = "ua/v1/dcp/query", fixture = function() mock_futures_dcp_data()),
+  list(pattern = "ua/v1/dcp/set", fixture = function() mock_futures_dcp_data(), method = "POST"),
   list(pattern = "orders/dead-cancel-all/query", fixture = function() mock_futures_dcp_data()),
   list(pattern = "orders/dead-cancel-all", fixture = function() mock_futures_dcp_data(), method = "POST"),
   list(pattern = "orders/test", fixture = function() mock_futures_order_response(), method = "POST"),

--- a/tests/testthat/test-live-integration-private.R
+++ b/tests/testthat/test-live-integration-private.R
@@ -526,3 +526,29 @@ test_that("[LIVE] futures get_recent_fills returns data.table (path-refreshed in
   expect_s3_class(dt, "data.table")
   throttle()
 })
+
+# Futures DCP migrated to the unified `/api/ua/v1/dcp/*` endpoint in
+# v4.0.3 — the legacy `/api/v1/orders/dead-cancel-all*` paths returned
+# 404/403 after KuCoin's 2026-05 reorganisation. These tests pin the
+# new endpoint so the next time KuCoin moves DCP, CI catches it.
+
+test_that("[LIVE] futures get_dcp returns data.table via unified endpoint", {
+  dt <- tryCatch(
+    futures_trading$get_dcp(),
+    error = .skip_if_no_futures
+  )
+  expect_s3_class(dt, "data.table")
+  throttle()
+})
+
+test_that("[LIVE] futures set_dcp -1 disables and returns data.table via unified endpoint", {
+  # Use `timeout = -1` (disable) so this test has no real side effects:
+  # it cannot accidentally leave a live dead-man's switch armed on the
+  # account if a later test fails to clear it.
+  dt <- tryCatch(
+    futures_trading$set_dcp(timeout = -1),
+    error = .skip_if_no_futures
+  )
+  expect_s3_class(dt, "data.table")
+  throttle()
+})


### PR DESCRIPTION
> **Stacked PR.** Base is `live-tests-for-futures` (PR #12), not `master`. Merge PR #12 first.

## Summary

Followup to PR #12. The earlier audit flagged that `KucoinFuturesTrading$set_dcp()` / `$get_dcp()` were broken upstream — KuCoin retired the futures-specific dead-cancel-all endpoints around 2026-05. Investigation surfaced the replacement: KuCoin now ships a unified Universal-Trading-Account DCP endpoint on the spot host that accepts a `tradeType` parameter. This PR migrates the futures DCP methods to call the new endpoint internally, keeping the public method API unchanged.

## What's broken before this PR

| Old endpoint | Status |
|---|---|
| `POST api-futures.kucoin.com/api/v1/orders/dead-cancel-all` | 403 (route alive but unusable) |
| `GET  api-futures.kucoin.com/api/v1/orders/dead-cancel-all/query` | **HTTP 404** |
| Docs page `/docs-new/rest/futures-trading/orders/dead-cancel-all` | Withdrawn |

## What this PR ships

| Method | Now calls |
|---|---|
| `KucoinFuturesTrading$set_dcp(timeout, symbol)` | `POST api.kucoin.com/api/ua/v1/dcp/set` with body `{tradeType: "FUTURES", timeout, symbol}` |
| `KucoinFuturesTrading$get_dcp(symbol)` | `GET api.kucoin.com/api/ua/v1/dcp/query?tradeType=FUTURES&symbol=...` |

User-facing API is unchanged: existing `futures_trading$set_dcp(60, "XBTUSDTM")` and `$get_dcp()` calls keep working. Internally they now hit the unified endpoint with `tradeType = "FUTURES"` hardcoded.

## Plumbing change

`KucoinBase$.request()` (private, `@noRd`) gains an optional `base_url` parameter that overrides the instance's configured host for a single call. Default `NULL` preserves the previous behaviour (use instance's configured host). Used here so the futures DCP methods can target the spot host while every other `KucoinFuturesTrading` method keeps using `api-futures.kucoin.com`. No existing call site is affected.

## What's deliberately NOT in this PR

**Spot DCP (`KucoinTrading$*_dcp`) is untouched.** Its endpoints (`/api/v1/hf/orders/dead-cancel-all*` on the spot host) are still alive and working — no migration needed. The new unified endpoint COULD also serve spot DCP via `tradeType = "SPOT"`, but rewriting the working spot methods just to share a code path is scope creep without clear benefit.

A future v5.0 could add a unified cross-product `KucoinAccount$set_dcp(trade_type, ...)` method and `@deprecated` the per-class spot+futures DCP methods, but that's a bigger design discussion worth its own PR.

## Mock router

New `ua/v1/dcp/{set,query}` patterns added to `tests/testthat/mock_router.R`, listed before the legacy `orders/dead-cancel-all*` patterns so the new endpoint takes precedence. Legacy patterns kept as fallback for any caller that hasn't migrated yet.

## Test plan

- [x] `devtools::test()` — 440 / 440 mocked tests pass
- [x] `KUCOIN_LIVE_TESTS=true devtools::test(filter = "live")` against the real KuCoin API — **180 / 180 pass** (was 178 / 178 on PR #12 base; +2 new DCP tests, both green). `set_dcp` test uses `timeout = -1` (disable) so it has no real side effects.

## Sources

- KuCoin Change Log: https://www.kucoin.com/docs-new/change-log
- Get DCP (Classic): https://www.kucoin.com/docs-new/rest/ua/get-dcp-classic
- Set DCP (Classic): https://www.kucoin.com/docs-new/rest/ua/set-dcp-classic