### PR TITLE
docs(roxyassert): document data.table columns with typed nested bullets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kucoin
 Type: Package
 Title: API Wrapper to KuCoin Cryptocurrency Exchange
-Version: 4.2.2
+Version: 4.2.3
 URL: https://dereckscompany.github.io/kucoin/
 BugReports: https://github.com/dereckscompany/kucoin/issues
 Authors@R: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# kucoin 4.2.3
+
+## data.table return shapes documented with typed column bullets
+
+The `@return` of every public method that yields a fixed-shape `data.table` now lists each column as a typed nested bullet, following the roxyassert convention: bare element types (`character`, `integer`, `numeric`, `logical`, `POSIXct`) with ` | NA` appended wherever a column can legitimately be missing in a real response. Documenting the columns regenerates `assert_has_columns` plus the per-column type asserts, so the parsed shape is now enforced at the public boundary — for the synchronous value and for the resolved value of a promise alike — rather than relying on the old loose `assert_data_table` check. Methods whose tables are genuinely variable-shape are deliberately left as the generic `(data.table | promise<data.table>)`: those that return a zero-column empty `data.table` on an empty response, the heterogeneous futures position tables whose numeric fields arrive sometimes as numbers and sometimes as strings, and the wide futures-contract metadata tables. This matches the package's existing flattener convention and keeps the empty-response and variable-payload paths working untouched.
+
 # kucoin 4.2.2
 
 ## Live-capture fixture hardening + bugs the synthetic fixtures hid

--- a/R/KucoinAccount.R
+++ b/R/KucoinAccount.R
@@ -134,7 +134,19 @@ KucoinAccount <- R6::R6Class(
     #'
     #' @return (data.table | promise<data.table>) one row giving the VIP tier
     #'   level and the sub-account counts (total, spot, margin, futures, option)
-    #'   alongside their respective maxima.
+    #'   alongside their respective maxima:
+    #' - level (integer) the tier level.
+    #' - sub_quantity (integer) the sub quantity.
+    #' - max_default_sub_quantity (integer) the max default sub quantity.
+    #' - max_sub_quantity (integer) the max sub quantity.
+    #' - spot_sub_quantity (integer) the spot sub quantity.
+    #' - margin_sub_quantity (integer) the margin sub quantity.
+    #' - futures_sub_quantity (integer) the futures sub quantity.
+    #' - option_sub_quantity (integer) the option sub quantity.
+    #' - max_spot_sub_quantity (integer) the max spot sub quantity.
+    #' - max_margin_sub_quantity (integer) the max margin sub quantity.
+    #' - max_futures_sub_quantity (integer) the max futures sub quantity.
+    #' - max_option_sub_quantity (integer) the max option sub quantity.
     #'
     #' @examples
     #' \dontrun{
@@ -210,7 +222,15 @@ KucoinAccount <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row describing the active
     #'   API key: its label, key ID, version, comma-separated permissions and IP
     #'   whitelist, creation datetime (POSIXct, coerced from epoch milliseconds),
-    #'   user ID, and whether it belongs to the master account.
+    #'   user ID, and whether it belongs to the master account:
+    #' - remark (character) an optional remark.
+    #' - api_key (character) the api key.
+    #' - api_version (integer) the api version.
+    #' - permission (character) the permission.
+    #' - ip_whitelist (character) the ip whitelist.
+    #' - created_at (POSIXct) the created at (UTC).
+    #' - uid (integer) the user identifier.
+    #' - is_master (logical) the is master.
     #'
     #' @examples
     #' \dontrun{
@@ -458,7 +478,11 @@ KucoinAccount <- R6::R6Class(
     #'
     #' @return (data.table | promise<data.table>) one row giving the currency
     #'   code, total balance, the amount available for use, and the amount held
-    #'   in open orders for the requested account.
+    #'   in open orders for the requested account:
+    #' - currency (character) the currency code.
+    #' - balance (character) the total balance.
+    #' - available (character) the amount available.
+    #' - holds (character) the amount on hold.
     #'
     #' @examples
     #' \dontrun{
@@ -1191,7 +1215,9 @@ KucoinAccount <- R6::R6Class(
     #' @param currencyType (scalar<count> | NULL) `0` for crypto (default), `1`
     #'   for fiat.
     #' @return (data.table | promise<data.table>) one row giving the base taker
-    #'   fee rate and the base maker fee rate.
+    #'   fee rate and the base maker fee rate:
+    #' - taker_fee_rate (character) the taker fee rate.
+    #' - maker_fee_rate (character) the maker fee rate.
     #'
     #' @examples
     #' \dontrun{
@@ -1266,7 +1292,10 @@ KucoinAccount <- R6::R6Class(
     #'   e.g. `"BTC-USDT,ETH-USDT"`.
     #' @return (data.table | promise<data.table>) one row per trading pair, each
     #'   giving the pair symbol, the actual taker fee rate, and the actual maker
-    #'   fee rate.
+    #'   fee rate:
+    #' - symbol (character) the trading pair symbol.
+    #' - taker_fee_rate (character) the taker fee rate.
+    #' - maker_fee_rate (character) the maker fee rate.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinDeposit.R
+++ b/R/KucoinDeposit.R
@@ -122,7 +122,14 @@ KucoinDeposit <- R6::R6Class(
     #'   created deposit address: the generated address, its memo/tag (empty
     #'   string if not applicable), the blockchain network name, the chain
     #'   identifier, the target account type, the currency code, and the token
-    #'   contract address (empty for native coins) -- all character.
+    #'   contract address (empty for native coins) -- all character:
+    #' - address (character) the address.
+    #' - memo (character) the address memo/tag.
+    #' - chain (character) the chain code.
+    #' - chain_id (character) the chain identifier.
+    #' - to (character) the destination.
+    #' - currency (character) the currency code.
+    #' - contract_address (character) the token contract address.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinFuturesAccount.R
+++ b/R/KucoinFuturesAccount.R
@@ -117,7 +117,15 @@ KucoinFuturesAccount <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the futures
     #'   account overview: total account equity, unrealised profit and loss,
     #'   margin balance, position and order margin, frozen funds, available
-    #'   balance, and the settlement currency code.
+    #'   balance, and the settlement currency code:
+    #' - account_equity (numeric) the account equity.
+    #' - unrealised_pnl (numeric) the unrealised pnl.
+    #' - margin_balance (numeric) the margin balance.
+    #' - available_balance (numeric) the available balance.
+    #' - available_margin (numeric) the available margin.
+    #' - currency (character) the currency code.
+    #' - risk_ratio (numeric) the risk ratio.
+    #' - max_withdraw_amount (numeric) the max withdraw amount.
     get_account_overview = function(currency = "USDT") {
       assert_args_KucoinFuturesAccount__get_account_overview(currency)
       res <- private$.request(
@@ -465,7 +473,9 @@ KucoinFuturesAccount <- R6::R6Class(
     #'
     #' @param symbol (scalar<character>) futures symbol.
     #' @return (data.table | promise<data.table>) one row giving the contract
-    #'   symbol and its current margin mode (`"ISOLATED"` or `"CROSS"`).
+    #'   symbol and its current margin mode (`"ISOLATED"` or `"CROSS"`):
+    #' - symbol (character) the trading pair symbol.
+    #' - margin_mode (character) the margin mode.
     get_margin_mode = function(symbol) {
       assert_args_KucoinFuturesAccount__get_margin_mode(symbol)
       assert::assert_nonempty_strings(symbol)
@@ -534,7 +544,9 @@ KucoinFuturesAccount <- R6::R6Class(
     #' @param symbol (scalar<character>) futures symbol.
     #' @param marginMode (scalar<character>) `"ISOLATED"` or `"CROSS"`.
     #' @return (data.table | promise<data.table>) one row giving the contract
-    #'   symbol and its updated margin mode.
+    #'   symbol and its updated margin mode:
+    #' - symbol (character) the trading pair symbol.
+    #' - margin_mode (character) the margin mode.
     set_margin_mode = function(symbol, marginMode) {
       assert_args_KucoinFuturesAccount__set_margin_mode(symbol, marginMode)
       assert::assert_nonempty_strings(symbol)
@@ -594,7 +606,9 @@ KucoinFuturesAccount <- R6::R6Class(
     #'
     #' @param symbol (scalar<character>) futures symbol.
     #' @return (data.table | promise<data.table>) one row giving the contract
-    #'   symbol and its current cross-margin leverage multiplier.
+    #'   symbol and its current cross-margin leverage multiplier:
+    #' - symbol (character) the trading pair symbol.
+    #' - leverage (character) the leverage.
     get_cross_margin_leverage = function(symbol) {
       assert_args_KucoinFuturesAccount__get_cross_margin_leverage(symbol)
       assert::assert_nonempty_strings(symbol)
@@ -664,7 +678,9 @@ KucoinFuturesAccount <- R6::R6Class(
     #' @param symbol (scalar<character>) futures symbol.
     #' @param leverage (scalar<count in [1, Inf[>) leverage multiplier.
     #' @return (data.table | promise<data.table>) one row giving the contract
-    #'   symbol and its updated cross-margin leverage multiplier.
+    #'   symbol and its updated cross-margin leverage multiplier:
+    #' - symbol (character) the trading pair symbol.
+    #' - leverage (character) the leverage.
     set_cross_margin_leverage = function(symbol, leverage) {
       assert_args_KucoinFuturesAccount__set_cross_margin_leverage(symbol, leverage)
       assert::assert_nonempty_strings(symbol)
@@ -727,7 +743,10 @@ KucoinFuturesAccount <- R6::R6Class(
     #' @param leverage (scalar<count in [1, Inf[>) leverage multiplier.
     #' @return (data.table | promise<data.table>) one row giving the contract
     #'   symbol and the maximum number of contracts that can be opened on the
-    #'   buy and sell sides.
+    #'   buy and sell sides:
+    #' - symbol (character) the trading pair symbol.
+    #' - max_buy_open_size (integer) the max buy open size.
+    #' - max_sell_open_size (integer) the max sell open size.
     get_max_open_size = function(symbol, price, leverage) {
       assert_args_KucoinFuturesAccount__get_max_open_size(symbol, price, leverage)
       assert::assert_nonempty_strings(symbol)
@@ -868,7 +887,11 @@ KucoinFuturesAccount <- R6::R6Class(
     #' @param bizNo (scalar<character>) unique business ID for idempotency.
     #' @return (data.table | promise<data.table>) one row giving the margin
     #'   operation ID, contract symbol, amount deposited, and operation type
-    #'   (e.g., `"ADD"`).
+    #'   (e.g., `"ADD"`):
+    #' - id (character) the record identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - margin (character) the margin amount.
+    #' - margin_type (character) the margin type.
     add_isolated_margin = function(symbol, margin, bizNo) {
       assert_args_KucoinFuturesAccount__add_isolated_margin(symbol, margin, bizNo)
       assert::assert_nonempty_strings(symbol)
@@ -942,7 +965,11 @@ KucoinFuturesAccount <- R6::R6Class(
     #' @param symbol (scalar<character>) futures symbol.
     #' @param withdrawAmount (scalar<numeric>) amount of margin to withdraw.
     #' @return (data.table | promise<data.table>) one row giving the margin
-    #'   operation ID, contract symbol, amount withdrawn, and operation type.
+    #'   operation ID, contract symbol, amount withdrawn, and operation type:
+    #' - id (character) the record identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - margin (character) the margin amount.
+    #' - margin_type (character) the margin type.
     remove_isolated_margin = function(symbol, withdrawAmount) {
       assert_args_KucoinFuturesAccount__remove_isolated_margin(symbol, withdrawAmount)
       assert::assert_nonempty_strings(symbol)

--- a/R/KucoinFuturesMarketData.R
+++ b/R/KucoinFuturesMarketData.R
@@ -366,7 +366,18 @@ KucoinFuturesMarketData <- R6::R6Class(
     #'   ticker snapshot: the sequence number, contract symbol, last trade side,
     #'   size, trade identifier and price, the best bid and ask prices with their
     #'   sizes, and the ticker datetime (POSIXct, coerced from the nanosecond
-    #'   timestamp).
+    #'   timestamp):
+    #' - sequence (integer) the sequence.
+    #' - symbol (character) the trading pair symbol.
+    #' - side (character) the order side.
+    #' - size (integer) the size.
+    #' - price (character) the price.
+    #' - best_bid_size (integer) the best bid size.
+    #' - best_bid_price (character) the best bid price.
+    #' - best_ask_price (character) the best ask price.
+    #' - best_ask_size (integer) the best ask size.
+    #' - trade_id (character) the trade identifier.
+    #' - ts (POSIXct) the ts (UTC).
     #'
     #' @examples
     #' \dontrun{
@@ -543,7 +554,14 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' @param size (scalar<count>) number of levels, either `20` or `100`.
     #'   Default `20`.
     #' @return (data.table | promise<data.table>) the level-2 order book in long
-    #'   format (ts, sequence, side, level, price, size, and symbol when present).
+    #'   format (ts, sequence, side, level, price, size, and symbol when present):
+    #' - ts (POSIXct) the ts (UTC).
+    #' - sequence (character) the sequence.
+    #' - side (character) the order side.
+    #' - level (integer) the tier level.
+    #' - price (numeric) the price.
+    #' - size (numeric) the size.
+    #' - symbol (character) the trading pair symbol.
     #'
     #' @examples
     #' \dontrun{
@@ -628,7 +646,14 @@ KucoinFuturesMarketData <- R6::R6Class(
     #'
     #' @param symbol (scalar<character>) futures symbol (e.g., `"XBTUSDTM"`).
     #' @return (data.table | promise<data.table>) the level-2 order book in long
-    #'   format (ts, sequence, side, level, price, size, and symbol when present).
+    #'   format (ts, sequence, side, level, price, size, and symbol when present):
+    #' - ts (POSIXct) the ts (UTC).
+    #' - sequence (character) the sequence.
+    #' - side (character) the order side.
+    #' - level (integer) the tier level.
+    #' - price (numeric) the price.
+    #' - size (numeric) the size.
+    #' - symbol (character) the trading pair symbol.
     #'
     #' @examples
     #' \dontrun{
@@ -937,7 +962,12 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the current mark
     #'   price: the contract symbol, price granularity in milliseconds, the rate
     #'   datetime (POSIXct, coerced from epoch milliseconds), the mark price, and
-    #'   the underlying index price.
+    #'   the underlying index price:
+    #' - symbol (character) the trading pair symbol.
+    #' - granularity (integer) the granularity.
+    #' - time_point (POSIXct) the time point (UTC).
+    #' - value (numeric) the order value.
+    #' - index_price (numeric) the index price.
     #'
     #' @examples
     #' \dontrun{
@@ -1023,7 +1053,16 @@ KucoinFuturesMarketData <- R6::R6Class(
     #'   rate datetime (POSIXct, coerced from epoch milliseconds), the current
     #'   funding rate, the daily interest rate, the funding-rate cap and floor, the
     #'   funding period, and the next funding settlement datetime (POSIXct, coerced
-    #'   from epoch milliseconds).
+    #'   from epoch milliseconds):
+    #' - symbol (character) the trading pair symbol.
+    #' - granularity (integer) the granularity.
+    #' - time_point (POSIXct) the time point (UTC).
+    #' - value (numeric) the order value.
+    #' - daily_interest_rate (numeric) the daily interest rate.
+    #' - funding_rate_cap (numeric) the funding rate cap.
+    #' - funding_rate_floor (numeric) the funding rate floor.
+    #' - period (integer) the period.
+    #' - funding_time (POSIXct) the funding time (UTC).
     #'
     #' @examples
     #' \dontrun{
@@ -1199,7 +1238,8 @@ KucoinFuturesMarketData <- R6::R6Class(
     #' ```
     #'
     #' @return (data.table | promise<data.table>) one row giving the server
-    #'   datetime (POSIXct, coerced from epoch milliseconds).
+    #'   datetime (POSIXct, coerced from epoch milliseconds):
+    #' - server_time (POSIXct) the server time (UTC).
     #'
     #' @examples
     #' \dontrun{
@@ -1267,7 +1307,9 @@ KucoinFuturesMarketData <- R6::R6Class(
     #'
     #' @return (data.table | promise<data.table>) one row giving the operational
     #'   status (`"open"`, `"close"`, or `"cancelonly"`) and an optional
-    #'   remark/message.
+    #'   remark/message:
+    #' - status (character) the status.
+    #' - msg (character) the msg.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinFuturesTrading.R
+++ b/R/KucoinFuturesTrading.R
@@ -191,7 +191,9 @@ KucoinFuturesTrading <- R6::R6Class(
     #' @param remark (scalar<character> | NULL) order notes.
     #' @param ... Additional order parameters.
     #' @return (data.table | promise<data.table>) one row giving the system-assigned order ID and the client-provided
-    #'   order ID.
+    #'   order ID:
+    #' - order_id (character) the system order identifier.
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -371,7 +373,9 @@ KucoinFuturesTrading <- R6::R6Class(
     #' @param remark (scalar<character> | NULL) order notes.
     #' @param ... Additional order parameters.
     #' @return (data.table | promise<data.table>) one row giving the simulated order ID and the client-provided order
-    #'   ID.
+    #'   ID:
+    #' - order_id (character) the system order identifier.
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -559,7 +563,9 @@ KucoinFuturesTrading <- R6::R6Class(
     #'   (i.e., `clientOid`, `symbol`, `side`, `type`, `leverage`, `size`, and optional
     #'   `price`, `marginMode`, `positionSide`, etc.).
     #' @return (data.table | promise<data.table>) one row per order result giving the system-assigned order ID, the
-    #'   client-provided order ID, the futures symbol, the per-order status code, and the per-order status message.
+    #'   client-provided order ID, the futures symbol, the per-order status code, and the per-order status message:
+    #' - order_id (character) the system order identifier.
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -900,7 +906,8 @@ KucoinFuturesTrading <- R6::R6Class(
     #' @param symbol (scalar<character> | NULL) filter by futures symbol. When NULL,
     #'   cancels all untriggered stop orders across all symbols.
     #' @return (data.table | promise<data.table>) one row per cancelled order giving the cancelled order ID; an empty
-    #'   data.table if no orders matched.
+    #'   data.table if no orders matched:
+    #' - cancelled_order_id (character) the cancelled order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1031,7 +1038,23 @@ KucoinFuturesTrading <- R6::R6Class(
     #'
     #' @param orderId (scalar<character>) the system order ID.
     #' @return (data.table | promise<data.table>) one row of full order details, including the creation and last-updated
-    #'   datetimes (POSIXct, coerced from epoch milliseconds).
+    #'   datetimes (POSIXct, coerced from epoch milliseconds):
+    #' - id (character) the record identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - type (character) the type.
+    #' - side (character) the order side.
+    #' - price (character) the price.
+    #' - size (integer) the size.
+    #' - value (character) the order value.
+    #' - deal_value (character) the filled value.
+    #' - deal_size (integer) the filled size.
+    #' - leverage (integer) the leverage.
+    #' - margin_mode (character) the margin mode.
+    #' - position_side (character) the position side.
+    #' - status (character) the status.
+    #' - created_at (POSIXct) the created at (UTC).
+    #' - updated_at (POSIXct) the updated at (UTC).
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1150,7 +1173,23 @@ KucoinFuturesTrading <- R6::R6Class(
     #' ```
     #'
     #' @param clientOid (scalar<character>) the client order ID.
-    #' @return (data.table | promise<data.table>) one row of full order details; same columns as `get_order_by_id()`.
+    #' @return (data.table | promise<data.table>) one row of full order details; same columns as `get_order_by_id()`:
+    #' - id (character) the record identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - type (character) the type.
+    #' - side (character) the order side.
+    #' - price (character) the price.
+    #' - size (integer) the size.
+    #' - value (character) the order value.
+    #' - deal_value (character) the filled value.
+    #' - deal_size (integer) the filled size.
+    #' - leverage (integer) the leverage.
+    #' - margin_mode (character) the margin mode.
+    #' - position_side (character) the position side.
+    #' - status (character) the status.
+    #' - created_at (POSIXct) the created at (UTC).
+    #' - updated_at (POSIXct) the updated at (UTC).
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1276,7 +1315,23 @@ KucoinFuturesTrading <- R6::R6Class(
     #'   open orders, `status = "done"` for closed orders. Optional: `symbol`,
     #'   `side`, `type`, `startAt`, `endAt`.
     #' @return (data.table | promise<data.table>) one row per order record (same columns as `get_order_by_id()`); an
-    #'   empty data.table if no orders match the filters.
+    #'   empty data.table if no orders match the filters:
+    #' - id (character) the record identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - type (character) the type.
+    #' - side (character) the order side.
+    #' - price (character) the price.
+    #' - size (integer) the size.
+    #' - value (character) the order value.
+    #' - deal_value (character) the filled value.
+    #' - deal_size (integer) the filled size.
+    #' - leverage (integer) the leverage.
+    #' - margin_mode (character) the margin mode.
+    #' - position_side (character) the position side.
+    #' - status (character) the status.
+    #' - created_at (POSIXct) the created at (UTC).
+    #' - updated_at (POSIXct) the updated at (UTC).
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1405,7 +1460,23 @@ KucoinFuturesTrading <- R6::R6Class(
     #'
     #' @param symbol (scalar<character> | NULL) filter by futures symbol.
     #' @return (data.table | promise<data.table>) one row per order record (same columns as `get_order_by_id()`); an
-    #'   empty data.table if no recently closed orders exist.
+    #'   empty data.table if no recently closed orders exist:
+    #' - id (character) the record identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - type (character) the type.
+    #' - side (character) the order side.
+    #' - price (character) the price.
+    #' - size (integer) the size.
+    #' - value (character) the order value.
+    #' - deal_value (character) the filled value.
+    #' - deal_size (integer) the filled size.
+    #' - leverage (integer) the leverage.
+    #' - margin_mode (character) the margin mode.
+    #' - position_side (character) the position side.
+    #' - status (character) the status.
+    #' - created_at (POSIXct) the created at (UTC).
+    #' - updated_at (POSIXct) the updated at (UTC).
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1759,7 +1830,24 @@ KucoinFuturesTrading <- R6::R6Class(
     #'
     #' @param symbol (scalar<character> | NULL) filter by futures symbol.
     #' @return (data.table | promise<data.table>) one row per fill (same columns as `get_fills()`); an empty data.table
-    #'   if no recent fills exist.
+    #'   if no recent fills exist:
+    #' - symbol (character) the trading pair symbol.
+    #' - trade_id (character) the trade identifier.
+    #' - order_id (character) the system order identifier.
+    #' - side (character) the order side.
+    #' - liquidity (character) the liquidity role.
+    #' - force_taker (logical) the force taker.
+    #' - price (character) the price.
+    #' - size (integer) the size.
+    #' - value (character) the order value.
+    #' - fee_rate (character) the fee rate.
+    #' - fix_fee (character) the fix fee.
+    #' - fee_currency (character) the fee currency.
+    #' - fee (character) the fee.
+    #' - order_type (character) the order type.
+    #' - trade_type (character) the trade type.
+    #' - trade_time (POSIXct) the trade time (UTC).
+    #' - created_at (POSIXct) the created at (UTC).
     #'
     #' @examples
     #' \dontrun{
@@ -1845,7 +1933,12 @@ KucoinFuturesTrading <- R6::R6Class(
     #'
     #' @param symbol (scalar<character>) futures symbol (e.g., `"XBTUSDTM"`).
     #' @return (data.table | promise<data.table>) one row giving the total buy order size, total sell order
-    #'   size, total buy order cost, total sell order cost, and the settlement currency.
+    #'   size, total buy order cost, total sell order cost, and the settlement currency:
+    #' - open_order_buy_size (integer) the open order buy size.
+    #' - open_order_sell_size (integer) the open order sell size.
+    #' - open_order_buy_cost (character) the open order buy cost.
+    #' - open_order_sell_cost (character) the open order sell cost.
+    #' - settle_currency (character) the settle currency.
     #'
     #' @examples
     #' \dontrun{
@@ -1944,7 +2037,10 @@ KucoinFuturesTrading <- R6::R6Class(
     #' @param symbol (scalar<character> | NULL) restrict DCP to a specific futures symbol.
     #'   When NULL, DCP applies to all symbols.
     #' @return (data.table | promise<data.table>) one row giving the configured timeout in seconds, the applicable
-    #'   symbols (empty for all), and the server time when DCP was set.
+    #'   symbols (empty for all), and the server time when DCP was set:
+    #' - timeout (integer) the timeout.
+    #' - symbols (character) the symbols.
+    #' - current_time (numeric) the current time.
     #'
     #' @examples
     #' \dontrun{
@@ -2034,7 +2130,10 @@ KucoinFuturesTrading <- R6::R6Class(
     #' @param symbol (scalar<character> | NULL) query DCP settings for a specific futures symbol.
     #'   When NULL, returns the global DCP configuration.
     #' @return (data.table | promise<data.table>) one row giving the configured timeout in seconds, the applicable
-    #'   symbols, and the server time of the query.
+    #'   symbols, and the server time of the query:
+    #' - timeout (integer) the timeout.
+    #' - symbols (character) the symbols.
+    #' - current_time (numeric) the current time.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinLending.R
+++ b/R/KucoinLending.R
@@ -262,7 +262,8 @@ KucoinLending <- R6::R6Class(
     #' @param interestRate (scalar<numeric>) the interest rate (e.g., `0.05` for
     #'   5%).
     #' @return (data.table | promise<data.table>) one row with the lending order
-    #'   number.
+    #'   number:
+    #' - order_no (character) the order number.
     #'
     #' @examples
     #' \dontrun{
@@ -351,7 +352,11 @@ KucoinLending <- R6::R6Class(
     #' - currency (character) the lending currency.
     #' - purchase_order_no (character) the modified order number.
     #' - interest_rate (numeric) the new interest rate.
-    #' - status (character) the local outcome marker, always `"success"`.
+    #' - status (character) the local outcome marker, always `"success"`:
+    #' - currency (character) the currency code.
+    #' - purchase_order_no (character) the purchase order no.
+    #' - interest_rate (numeric) the interest rate.
+    #' - status (character) the status.
     #'
     #' @examples
     #' \dontrun{
@@ -556,7 +561,8 @@ KucoinLending <- R6::R6Class(
     #' @param purchaseOrderNo (scalar<character>) the purchase order to redeem
     #'   from.
     #' @return (data.table | promise<data.table>) one row with the redemption order
-    #'   number.
+    #'   number:
+    #' - order_no (character) the order number.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinMarginData.R
+++ b/R/KucoinMarginData.R
@@ -258,7 +258,11 @@ KucoinMarginData <- R6::R6Class(
     #'
     #' @return (data.table | promise<data.table>) one row per supported currency, with the `currencyList` array exploded
     #'   so each currency carries the replicated config-level fields for maximum leverage, warning debt ratio and
-    #'   liquidation debt ratio; an empty `currencyList` yields a zero-row data.table with this schema.
+    #'   liquidation debt ratio; an empty `currencyList` yields a zero-row data.table with this schema:
+    #' - currency (character) the currency code.
+    #' - max_leverage (integer) the max leverage.
+    #' - warning_debt_ratio (character) the warning debt ratio.
+    #' - liq_debt_ratio (character) the liq debt ratio.
     #'
     #' @examples
     #' \dontrun{
@@ -354,7 +358,11 @@ KucoinMarginData <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row per (currency, tier) pair, with the nested `currencyList` and
     #'   `items` arrays cross-joined into a flat long table carrying the currency code, lower and upper bounds of the
     #'   collateral range, and the collateral ratio applied in that range; an empty response yields a zero-row
-    #'   data.table with this schema.
+    #'   data.table with this schema:
+    #' - currency (character) the currency code.
+    #' - lower_limit (character) the lower limit.
+    #' - upper_limit (character) the upper limit.
+    #' - collateral_ratio (character) the collateral ratio.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinMarginTrading.R
+++ b/R/KucoinMarginTrading.R
@@ -357,7 +357,9 @@ KucoinMarginTrading <- R6::R6Class(
     #'   Default `FALSE`.
     #' @return (data.table | promise<data.table>) one row giving the
     #'   KuCoin-assigned order identifier and the client-provided order
-    #'   identifier (NA if not supplied).
+    #'   identifier (NA if not supplied):
+    #' - order_id (character) the system order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -517,7 +519,9 @@ KucoinMarginTrading <- R6::R6Class(
     #'   Default `FALSE`.
     #' @return (data.table | promise<data.table>) one row giving the
     #'   KuCoin-assigned order identifier, the client-provided order identifier,
-    #'   the amount borrowed, and the loan application ID.
+    #'   the amount borrowed, and the loan application ID:
+    #' - order_id (character) the system order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -678,7 +682,9 @@ KucoinMarginTrading <- R6::R6Class(
     #'   Default `FALSE`.
     #' @return (data.table | promise<data.table>) one row giving the
     #'   KuCoin-assigned order identifier and the client-provided order
-    #'   identifier (NA if not supplied).
+    #'   identifier (NA if not supplied):
+    #' - order_id (character) the system order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -822,7 +828,9 @@ KucoinMarginTrading <- R6::R6Class(
     #' @param isHf (scalar<logical>) `TRUE` for high-frequency trading mode,
     #'   `FALSE` (default).
     #' @return (data.table | promise<data.table>) one row giving the borrow order
-    #'   number and the amount actually borrowed.
+    #'   number and the amount actually borrowed:
+    #' - order_no (character) the order number.
+    #' - actual_size (character) the actual filled size.
     #'
     #' @examples
     #' \dontrun{
@@ -1380,7 +1388,9 @@ KucoinMarginTrading <- R6::R6Class(
     #'   `3`, `5`, `10`).
     #' @return (data.table | promise<data.table>) one row:
     #' - leverage (numeric) the new leverage multiplier.
-    #' - status (character) the local outcome marker, always `"success"`.
+    #' - status (character) the local outcome marker, always `"success"`:
+    #' - leverage (numeric) the leverage.
+    #' - status (character) the status.
     #' @noassert leverage
     #'
     #' @examples

--- a/R/KucoinMarketData.R
+++ b/R/KucoinMarketData.R
@@ -141,7 +141,14 @@ KucoinMarketData <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row per announcement, each
     #'   giving the announcement ID, title, `;`-separated category tags, short
     #'   description, creation datetime (POSIXct, coerced from epoch milliseconds),
-    #'   language code, and the full announcement URL.
+    #'   language code, and the full announcement URL:
+    #' - ann_id (integer) the ann id.
+    #' - ann_title (character) the ann title.
+    #' - ann_type (character | NA) the ann type.
+    #' - ann_desc (character) the ann desc.
+    #' - c_time (POSIXct) the c time (UTC).
+    #' - language (character) the language.
+    #' - ann_url (character) the ann url.
     #'
     #' @examples
     #' \dontrun{
@@ -493,7 +500,35 @@ KucoinMarketData <- R6::R6Class(
     #'   the base and quote minimum and maximum order sizes, the base and quote
     #'   size increments, the price increment and price-limit rate, the minimum
     #'   order value in quote currency, the margin- and trading-enabled flags, and
-    #'   the maker and taker fee coefficients.
+    #'   the maker and taker fee coefficients:
+    #' - symbol (character) the trading pair symbol.
+    #' - name (character) the name.
+    #' - base_currency (character) the base currency.
+    #' - quote_currency (character) the quote currency.
+    #' - fee_currency (character) the fee currency.
+    #' - market (character) the market.
+    #' - base_min_size (character) the base min size.
+    #' - quote_min_size (character) the quote min size.
+    #' - base_max_size (character) the base max size.
+    #' - quote_max_size (character) the quote max size.
+    #' - base_increment (character) the base increment.
+    #' - quote_increment (character) the quote increment.
+    #' - price_increment (character) the price increment.
+    #' - price_limit_rate (character) the price limit rate.
+    #' - min_funds (character) the min funds.
+    #' - is_margin_enabled (logical) the is margin enabled.
+    #' - enable_trading (logical) the enable trading.
+    #' - fee_category (integer) the fee category.
+    #' - maker_fee_coefficient (character) the maker fee coefficient.
+    #' - taker_fee_coefficient (character) the taker fee coefficient.
+    #' - st (logical) whether the symbol is in special treatment.
+    #' - callauction_is_enabled (logical) the callauction is enabled.
+    #' - callauction_price_floor (logical | NA) the callauction price floor.
+    #' - callauction_price_ceiling (logical | NA) the callauction price ceiling.
+    #' - callauction_first_stage_start_time (logical | NA) the callauction first stage start time.
+    #' - callauction_second_stage_start_time (logical | NA) the callauction second stage start time.
+    #' - callauction_third_stage_start_time (logical | NA) the callauction third stage start time.
+    #' - trading_start_time (logical | NA) the trading start time.
     #'
     #' @examples
     #' \dontrun{
@@ -605,7 +640,35 @@ KucoinMarketData <- R6::R6Class(
     #'   `"USDS"`, `"BTC"`, `"KCS"`, `"DeFi"`). Use `get_market_list()` for
     #'   available values.
     #' @return (data.table | promise<data.table>) one row per trading pair,
-    #'   carrying the same symbol metadata as `get_symbol()`.
+    #'   carrying the same symbol metadata as `get_symbol()`:
+    #' - symbol (character) the trading pair symbol.
+    #' - name (character) the name.
+    #' - base_currency (character) the base currency.
+    #' - quote_currency (character) the quote currency.
+    #' - fee_currency (character) the fee currency.
+    #' - market (character) the market.
+    #' - base_min_size (character) the base min size.
+    #' - quote_min_size (character) the quote min size.
+    #' - base_max_size (character) the base max size.
+    #' - quote_max_size (character) the quote max size.
+    #' - base_increment (character) the base increment.
+    #' - quote_increment (character) the quote increment.
+    #' - price_increment (character) the price increment.
+    #' - price_limit_rate (character) the price limit rate.
+    #' - min_funds (character) the min funds.
+    #' - is_margin_enabled (logical) the is margin enabled.
+    #' - enable_trading (logical) the enable trading.
+    #' - fee_category (integer) the fee category.
+    #' - maker_fee_coefficient (character) the maker fee coefficient.
+    #' - taker_fee_coefficient (character) the taker fee coefficient.
+    #' - st (logical) whether the symbol is in special treatment.
+    #' - callauction_is_enabled (logical) the callauction is enabled.
+    #' - callauction_price_floor (logical | NA) the callauction price floor.
+    #' - callauction_price_ceiling (logical | NA) the callauction price ceiling.
+    #' - callauction_first_stage_start_time (logical | NA) the callauction first stage start time.
+    #' - callauction_second_stage_start_time (logical | NA) the callauction second stage start time.
+    #' - callauction_third_stage_start_time (logical | NA) the callauction third stage start time.
+    #' - trading_start_time (logical | NA) the trading start time.
     #'
     #' @examples
     #' \dontrun{
@@ -689,7 +752,15 @@ KucoinMarketData <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the Level 1
     #'   snapshot: server datetime (POSIXct, coerced from epoch milliseconds), the
     #'   order book sequence number, the last trade price and size, and the best
-    #'   bid and ask prices with their sizes.
+    #'   bid and ask prices with their sizes:
+    #' - time (POSIXct) the time (UTC).
+    #' - sequence (character) the sequence.
+    #' - price (character) the price.
+    #' - size (character) the size.
+    #' - best_bid (character) the best bid price.
+    #' - best_bid_size (character) the best bid size.
+    #' - best_ask (character) the best ask price.
+    #' - best_ask_size (character) the best ask size.
     #'
     #' @examples
     #' \dontrun{
@@ -787,7 +858,22 @@ KucoinMarketData <- R6::R6Class(
     #'   their sizes, the 24-hour change rate and amount, the 24-hour high, low,
     #'   base-currency volume and quote-currency volume, the last trade and average
     #'   prices, the taker and maker fee rates, and the snapshot datetime (POSIXct,
-    #'   coerced from epoch milliseconds).
+    #'   coerced from epoch milliseconds):
+    #' - symbol (character) the trading pair symbol.
+    #' - symbol_name (character) the symbol name.
+    #' - buy (character) the best bid price.
+    #' - sell (character) the best ask price.
+    #' - change_rate (character) the 24h change rate.
+    #' - change_price (character) the 24h change in price.
+    #' - high (character) the 24h high price.
+    #' - low (character) the 24h low price.
+    #' - vol (character) the 24h traded volume.
+    #' - vol_value (character) the 24h traded turnover.
+    #' - last (character) the last traded price.
+    #' - average_price (character) the average price.
+    #' - taker_fee_rate (character) the taker fee rate.
+    #' - maker_fee_rate (character) the maker fee rate.
+    #' - time (POSIXct) the time (UTC).
     #'
     #' @examples
     #' \dontrun{
@@ -874,7 +960,13 @@ KucoinMarketData <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row per recent trade, each
     #'   giving the trade sequence number, price, quantity, direction (`"buy"` or
     #'   `"sell"`), and the trade datetime (POSIXct, coerced from the nanosecond
-    #'   timestamp).
+    #'   timestamp):
+    #' - sequence (character) the sequence.
+    #' - side (character) the order side.
+    #' - price (character) the price.
+    #' - size (character) the size.
+    #' - time (POSIXct) the time (UTC).
+    #' - trade_id (character) the trade identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1128,7 +1220,23 @@ KucoinMarketData <- R6::R6Class(
     #'   milliseconds), the trading pair, the best bid and ask prices, the 24-hour
     #'   change rate and amount, the 24-hour high, low, base-currency volume and
     #'   quote-currency volume, the last trade and average prices, and the taker
-    #'   and maker fee rates.
+    #'   and maker fee rates:
+    #' - time (POSIXct) the time (UTC).
+    #' - symbol (character) the trading pair symbol.
+    #' - buy (character) the best bid price.
+    #' - sell (character) the best ask price.
+    #' - change_rate (character) the 24h change rate.
+    #' - change_price (character) the 24h change in price.
+    #' - high (character) the 24h high price.
+    #' - low (character) the 24h low price.
+    #' - vol (character) the 24h traded volume.
+    #' - vol_value (character) the 24h traded turnover.
+    #' - last (character) the last traded price.
+    #' - average_price (character) the average price.
+    #' - taker_fee_rate (character) the taker fee rate.
+    #' - maker_fee_rate (character) the maker fee rate.
+    #' - taker_coefficient (character) the taker fee coefficient.
+    #' - maker_coefficient (character) the maker fee coefficient.
     #'
     #' @examples
     #' \dontrun{
@@ -1198,7 +1306,8 @@ KucoinMarketData <- R6::R6Class(
     #' ```
     #'
     #' @return (data.table | promise<data.table>) one row per market segment:
-    #' - market (character) the segment identifier, e.g. `"USDS"`, `"DeFi"`.
+    #' - market (character) the segment identifier, e.g. `"USDS"`, `"DeFi"`:
+    #' - market (character) the market.
     #'
     #' @examples
     #' \dontrun{
@@ -1357,7 +1466,9 @@ KucoinMarketData <- R6::R6Class(
     #'
     #' @return (data.table | promise<data.table>) one row:
     #' - server_time (numeric) the server clock in epoch milliseconds.
-    #' - datetime (POSIXct) the same instant as a POSIXct (UTC).
+    #' - datetime (POSIXct) the same instant as a POSIXct (UTC):
+    #' - server_time (numeric) the server time.
+    #' - datetime (POSIXct) the datetime (UTC).
     #'
     #' @examples
     #' \dontrun{
@@ -1423,7 +1534,9 @@ KucoinMarketData <- R6::R6Class(
     #'
     #' @return (data.table | promise<data.table>) one row giving the operational
     #'   status (`"open"`, `"close"`, or `"cancelonly"`) and an optional
-    #'   remark/message.
+    #'   remark/message:
+    #' - status (character) the status.
+    #' - msg (character) the msg.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinOcoOrders.R
+++ b/R/KucoinOcoOrders.R
@@ -146,7 +146,9 @@ KucoinOcoOrders <- R6::R6Class(
     #'   spot trading.
     #' @return (data.table | promise<data.table>) one row giving the
     #'   KuCoin-assigned OCO order identifier and the client-provided order
-    #'   identifier (NA if not supplied).
+    #'   identifier (NA if not supplied):
+    #' - order_id (character) the system order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -587,7 +589,12 @@ KucoinOcoOrders <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the OCO order
     #'   identifier, trading pair, client-assigned order identifier, order
     #'   creation datetime (POSIXct, coerced from epoch milliseconds), and order
-    #'   status (e.g., `"NEW"`, `"DONE"`, `"TRIGGERED"`).
+    #'   status (e.g., `"NEW"`, `"DONE"`, `"TRIGGERED"`):
+    #' - order_id (character) the system order identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - client_oid (character) the client-supplied order identifier.
+    #' - order_time (POSIXct) the order time (UTC).
+    #' - status (character) the status.
     #'
     #' @examples
     #' \dontrun{
@@ -676,7 +683,12 @@ KucoinOcoOrders <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the
     #'   KuCoin-assigned OCO order identifier, trading pair, client-assigned order
     #'   identifier, order creation datetime (POSIXct, coerced from epoch
-    #'   milliseconds), and order status (e.g., `"NEW"`, `"DONE"`, `"TRIGGERED"`).
+    #'   milliseconds), and order status (e.g., `"NEW"`, `"DONE"`, `"TRIGGERED"`):
+    #' - order_id (character) the system order identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - client_oid (character) the client-supplied order identifier.
+    #' - order_time (POSIXct) the order time (UTC).
+    #' - status (character) the status.
     #'
     #' @examples
     #' \dontrun{
@@ -787,7 +799,19 @@ KucoinOcoOrders <- R6::R6Class(
     #'   array (typically the limit leg plus the stop-limit leg) exploded to long
     #'   format by replicating the parent OCO row once per sub-order and adding
     #'   each sub-order's id, symbol, side, price, size, status, and stop price
-    #'   (present only on the stop leg) as `sub_order_`-prefixed columns.
+    #'   (present only on the stop leg) as `sub_order_`-prefixed columns:
+    #' - order_id (character) the system order identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - client_oid (character) the client-supplied order identifier.
+    #' - order_time (POSIXct) the order time (UTC).
+    #' - status (character) the status.
+    #' - sub_order_id (character) the sub order id.
+    #' - sub_order_symbol (character) the sub order symbol.
+    #' - sub_order_side (character) the sub order side.
+    #' - sub_order_price (character) the sub order price.
+    #' - sub_order_size (character) the sub order size.
+    #' - sub_order_status (character) the sub order status.
+    #' - sub_order_stop_price (character | NA) the sub order stop price.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinStopOrders.R
+++ b/R/KucoinStopOrders.R
@@ -204,7 +204,8 @@ KucoinStopOrders <- R6::R6Class(
     #'   spot trading.
     #' @return (data.table | promise<data.table>) one row giving the
     #'   KuCoin-assigned stop order identifier and the client-provided order
-    #'   identifier (NA if not supplied).
+    #'   identifier (NA if not supplied):
+    #' - order_id (character) the system order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -500,7 +501,9 @@ KucoinStopOrders <- R6::R6Class(
     #' @param symbol (scalar<character>) trading pair symbol (e.g., `"BTC-USDT"`).
     #'   Required to disambiguate client OIDs across different trading pairs.
     #' @return (data.table | promise<data.table>) one row giving the KuCoin order
-    #'   ID and the client-assigned order ID of the cancelled stop order.
+    #'   ID and the client-assigned order ID of the cancelled stop order:
+    #' - cancelled_order_id (character) the cancelled order identifier.
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinSubAccount.R
+++ b/R/KucoinSubAccount.R
@@ -125,7 +125,11 @@ KucoinSubAccount <- R6::R6Class(
     #'   the sub-account (1-24 chars).
     #' @return (data.table | promise<data.table>) one row with the newly created
     #'   sub-account details: the unique user ID `uid`, the login name `sub_name`,
-    #'   the `remarks` string, and the granted permission `access`.
+    #'   the `remarks` string, and the granted permission `access`:
+    #' - uid (integer) the user identifier.
+    #' - sub_name (character) the sub name.
+    #' - remarks (character) an optional remark.
+    #' - access (character) the access.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinTrading.R
+++ b/R/KucoinTrading.R
@@ -179,7 +179,9 @@ KucoinTrading <- R6::R6Class(
     #' @param iceberg (scalar<logical> | NULL) if TRUE, only `visibleSize` is shown.
     #' @param visibleSize (scalar<numeric> | scalar<character> | NULL) visible quantity for iceberg orders.
     #' @return (data.table | promise<data.table>) one row giving the KuCoin-assigned order identifier and the
-    #'   client-provided order identifier.
+    #'   client-provided order identifier:
+    #' - order_id (character) the system order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -348,7 +350,9 @@ KucoinTrading <- R6::R6Class(
     #' @param iceberg (scalar<logical> | NULL) if TRUE, only `visibleSize` is shown.
     #' @param visibleSize (scalar<numeric> | scalar<character> | NULL) visible quantity for iceberg orders.
     #' @return (data.table | promise<data.table>) one row giving the simulated order identifier and the client-provided
-    #'   order identifier.
+    #'   order identifier:
+    #' - order_id (character) the system order identifier.
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -517,7 +521,11 @@ KucoinTrading <- R6::R6Class(
     #' @param order_list (list) list of named lists; each containing order parameters
     #'   (`type`, `symbol`, `side`, plus optional fields). Maximum 20 orders.
     #' @return (data.table | promise<data.table>) one row per order giving the KuCoin order ID, client order ID, the
-    #'   success flag, and any failure message.
+    #'   success flag, and any failure message:
+    #' - order_id (character | NA) the system order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
+    #' - success (logical) whether the order succeeded.
+    #' - fail_msg (character | NA) the failure message.
     #'
     #' @examples
     #' \dontrun{
@@ -605,7 +613,8 @@ KucoinTrading <- R6::R6Class(
     #'
     #' @param orderId (scalar<character>) the KuCoin order ID to cancel.
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
-    #' @return (data.table | promise<data.table>) one row giving the cancelled order ID.
+    #' @return (data.table | promise<data.table>) one row giving the cancelled order ID:
+    #' - order_id (character) the system order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -676,7 +685,8 @@ KucoinTrading <- R6::R6Class(
     #'
     #' @param clientOid (scalar<character>) client order ID.
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
-    #' @return (data.table | promise<data.table>) one row giving the cancelled client order ID.
+    #' @return (data.table | promise<data.table>) one row giving the cancelled client order ID:
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -752,7 +762,9 @@ KucoinTrading <- R6::R6Class(
     #' @param orderId (scalar<character>) order ID.
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
     #' @param cancelSize (scalar<numeric> | scalar<character>) quantity to cancel from the order.
-    #' @return (data.table | promise<data.table>) one row giving the cancellation result.
+    #' @return (data.table | promise<data.table>) one row giving the cancellation result:
+    #' - order_id (character) the system order identifier.
+    #' - cancel_size (character) the cancelled size.
     #'
     #' @examples
     #' \dontrun{
@@ -823,7 +835,8 @@ KucoinTrading <- R6::R6Class(
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
     #' @return (data.table | promise<data.table>) one row giving the cancellation
     #'   response:
-    #' - result (character) the KuCoin response string, e.g. `"success"`.
+    #' - result (character) the KuCoin response string, e.g. `"success"`:
+    #' - result (character) the result.
     #'
     #' @examples
     #' \dontrun{
@@ -893,7 +906,9 @@ KucoinTrading <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row per cancelled symbol;
     #'   an empty (but typed) data.table if no orders were open:
     #' - symbol (character) the trading pair, e.g. `"BTC-USDT"`.
-    #' - status (character) per-symbol outcome, `"succeed"` or `"failed"`.
+    #' - status (character) per-symbol outcome, `"succeed"` or `"failed"`:
+    #' - symbol (character) the trading pair symbol.
+    #' - status (character) the status.
     #'
     #' @examples
     #' \dontrun{
@@ -1010,7 +1025,15 @@ KucoinTrading <- R6::R6Class(
     #' @param orderId (scalar<character>) the KuCoin order ID.
     #' @param symbol (scalar<character> | NULL) trading pair (e.g., `"BTC-USDT"`). Defaults to `NULL`.
     #' @return (data.table | promise<data.table>) one row of full order details, including the creation and last-updated
-    #'   datetimes (POSIXct) when timestamps are present.
+    #'   datetimes (POSIXct) when timestamps are present:
+    #' - order_id (character) the system order identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - side (character) the order side.
+    #' - type (character) the type.
+    #' - price (character) the price.
+    #' - size (character) the size.
+    #' - created_at (POSIXct) the created at (UTC).
+    #' - last_updated_at (POSIXct) the last updated at (UTC).
     #'
     #' @examples
     #' \dontrun{
@@ -1118,7 +1141,11 @@ KucoinTrading <- R6::R6Class(
     #' @param clientOid (scalar<character>) client order ID.
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
     #' @return (data.table | promise<data.table>) one row of full order details, including the creation and last-updated
-    #'   datetimes (POSIXct).
+    #'   datetimes (POSIXct):
+    #' - client_oid (character) the client-supplied order identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - side (character) the order side.
+    #' - created_at (POSIXct) the created at (UTC).
     #'
     #' @examples
     #' \dontrun{
@@ -1371,7 +1398,8 @@ KucoinTrading <- R6::R6Class(
     #'
     #' @return (data.table | promise<data.table>) one row per trading pair that
     #'   has at least one open order:
-    #' - symbols (character) the trading pair, e.g. `"BTC-USDT"`.
+    #' - symbols (character) the trading pair, e.g. `"BTC-USDT"`:
+    #' - symbols (character) the symbols.
     #'
     #' @examples
     #' \dontrun{
@@ -1601,7 +1629,11 @@ KucoinTrading <- R6::R6Class(
     #' @param endAt (scalar<numeric> | NULL) end timestamp in milliseconds.
     #' @param limit (scalar<count> | NULL) results per page (max 200).
     #' @param lastId (scalar<character> | NULL) pagination cursor.
-    #' @return (data.table | promise<data.table>) one row per closed order, including the creation datetime (POSIXct).
+    #' @return (data.table | promise<data.table>) one row per closed order, including the creation datetime (POSIXct):
+    #' - order_id (character) the system order identifier.
+    #' - symbol (character) the trading pair symbol.
+    #' - side (character) the order side.
+    #' - created_at (POSIXct) the created at (UTC).
     #'
     #' @examples
     #' \dontrun{
@@ -1947,7 +1979,15 @@ KucoinTrading <- R6::R6Class(
     #'
     #' @param order_list (list) list of named lists; each containing order parameters. Maximum 20 orders.
     #' @return (data.table | promise<data.table>) one row per order giving the order and client identifiers, the success
-    #'   flag, the fill status, and the filled, remaining, and cancelled quantities.
+    #'   flag, the fill status, and the filled, remaining, and cancelled quantities:
+    #' - order_id (character | NA) the system order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
+    #' - success (logical) whether the order succeeded.
+    #' - status (character | NA) the status.
+    #' - deal_size (character | NA) the filled size.
+    #' - remain_size (character | NA) the unfilled size.
+    #' - canceled_size (character | NA) the cancelled size.
+    #' - fail_msg (character | NA) the failure message.
     #'
     #' @examples
     #' \dontrun{
@@ -2049,7 +2089,13 @@ KucoinTrading <- R6::R6Class(
     #' @param orderId (scalar<character>) the KuCoin order ID to cancel.
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
     #' @return (data.table | promise<data.table>) one row giving the order ID, the original, filled, remaining, and
-    #'   cancelled sizes, and the fill status.
+    #'   cancelled sizes, and the fill status:
+    #' - order_id (character) the system order identifier.
+    #' - origin_size (character) the original size.
+    #' - deal_size (character) the filled size.
+    #' - remain_size (character) the unfilled size.
+    #' - canceled_size (character) the cancelled size.
+    #' - status (character) the status.
     #'
     #' @examples
     #' \dontrun{
@@ -2123,7 +2169,13 @@ KucoinTrading <- R6::R6Class(
     #' @param clientOid (scalar<character>) client order ID.
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
     #' @return (data.table | promise<data.table>) one row giving the client order ID, the original, filled, remaining,
-    #'   and cancelled sizes, and the fill status.
+    #'   and cancelled sizes, and the fill status:
+    #' - client_oid (character) the client-supplied order identifier.
+    #' - origin_size (character) the original size.
+    #' - deal_size (character) the filled size.
+    #' - remain_size (character) the unfilled size.
+    #' - canceled_size (character) the cancelled size.
+    #' - status (character) the status.
     #'
     #' @examples
     #' \dontrun{
@@ -2216,7 +2268,9 @@ KucoinTrading <- R6::R6Class(
     #' @param newSize (scalar<numeric> | scalar<character> | NULL) new order size. At least one of `newPrice` or
     #'   `newSize` required.
     #' @return (data.table | promise<data.table>) one row giving the replacement order's ID and the original client
-    #'   order ID.
+    #'   order ID:
+    #' - new_order_id (character) the new order identifier.
+    #' - client_oid (character) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -2325,7 +2379,9 @@ KucoinTrading <- R6::R6Class(
     #' @param symbols (scalar<character> | NULL) comma-separated trading pairs (max 50).
     #'   Empty or NULL applies to all pairs.
     #' @return (data.table | promise<data.table>) one row giving the current server time and the time at which
-    #'   cancellation will trigger, both in seconds.
+    #'   cancellation will trigger, both in seconds:
+    #' - current_time (integer) the current server time, in epoch seconds.
+    #' - trigger_time (integer) the time at which cancellation triggers, in epoch seconds.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinTransfer.R
+++ b/R/KucoinTransfer.R
@@ -148,7 +148,8 @@ KucoinTransfer <- R6::R6Class(
     #' @param toAccountTag (scalar<character> | NULL) symbol for
     #'   ISOLATED/ISOLATED_V2 destination accounts (e.g., `"BTC-USDT"`).
     #' @return (data.table | promise<data.table>) one row with column `order_id`
-    #'   (character): the transfer order identifier.
+    #'   (character): the transfer order identifier:
+    #' - order_id (character) the system order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -326,7 +327,12 @@ KucoinTransfer <- R6::R6Class(
     #'   breakdown: `currency` (currency code), `balance` (total funds),
     #'   `available` (funds available to withdraw or trade), `holds` (funds
     #'   locked in open orders), and `transferable` (funds available for
-    #'   transfer) -- all character.
+    #'   transfer) -- all character:
+    #' - currency (character) the currency code.
+    #' - balance (character) the total balance.
+    #' - available (character) the amount available.
+    #' - holds (character) the amount on hold.
+    #' - transferable (character) the transferable amount.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinWithdrawal.R
+++ b/R/KucoinWithdrawal.R
@@ -138,7 +138,8 @@ KucoinWithdrawal <- R6::R6Class(
     #' @param feeDeductType (scalar<character> | NULL) fee deduction type:
     #'   `"INTERNAL"` or `"EXTERNAL"`.
     #' @return (data.table | promise<data.table>) one row with column
-    #'   `withdrawal_id` (character): the unique withdrawal identifier.
+    #'   `withdrawal_id` (character): the unique withdrawal identifier:
+    #' - withdrawal_id (character) the withdrawal id.
     #'
     #' @examples
     #' \dontrun{
@@ -290,7 +291,8 @@ KucoinWithdrawal <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row, the cancelled
     #'   withdrawal ID echoed from the input (KuCoin returns `null` data on a
     #'   successful cancel):
-    #' - withdrawal_id (character) the cancelled withdrawal ID.
+    #' - withdrawal_id (character) the cancelled withdrawal ID:
+    #' - withdrawal_id (character) the withdrawal id.
     #'
     #' @examples
     #' \dontrun{
@@ -392,7 +394,23 @@ KucoinWithdrawal <- R6::R6Class(
     #'   quota_currency, limit_quota_currency_amount, used_quota_currency_amount,
     #'   remain_amount, available_amount, withdraw_min_fee, inner_withdraw_min_fee,
     #'   withdraw_min_size, is_withdraw_enabled, precision, chain, reason,
-    #'   locked_amount, ...).
+    #'   locked_amount, ...):
+    #' - currency (character) the currency code.
+    #' - chain (character) the chain code.
+    #' - is_withdraw_enabled (logical) the is withdraw enabled.
+    #' - available_amount (character) the available amount.
+    #' - remain_amount (character) the remain amount.
+    #' - withdraw_min_fee (character) the withdraw min fee.
+    #' - inner_withdraw_min_fee (character) the inner withdraw min fee.
+    #' - withdraw_min_size (character) the withdraw min size.
+    #' - precision (integer) the decimal precision.
+    #' - limit_btc_amount (character) the limit btc amount.
+    #' - used_btc_amount (character) the used btc amount.
+    #' - locked_amount (character) the locked amount.
+    #' - quota_currency (character) the quota currency.
+    #' - limit_quota_currency_amount (character) the limit quota currency amount.
+    #' - used_quota_currency_amount (character) the used quota currency amount.
+    #' - reason (logical | NA) the reason, when present.
     #'
     #' @examples
     #' \dontrun{
@@ -683,7 +701,32 @@ KucoinWithdrawal <- R6::R6Class(
     #'   withdrawal detail (id, currency, chain_id, chain_name, status, address,
     #'   memo, is_inner, amount, fee, wallet_tx_id, cancel_type, failure_reason,
     #'   failure_reason_msg, created_at, ...), with `created_at` coerced to
-    #'   POSIXct.
+    #'   POSIXct:
+    #' - id (character) the record identifier.
+    #' - currency (character) the currency code.
+    #' - chain_id (character) the chain identifier.
+    #' - chain_name (character) the chain name.
+    #' - status (character) the status.
+    #' - address (character) the address.
+    #' - memo (character) the address memo/tag.
+    #' - is_inner (logical) the is inner.
+    #' - amount (character) the amount.
+    #' - fee (character) the fee.
+    #' - wallet_tx_id (logical | NA) the wallet tx id.
+    #' - created_at (POSIXct) the created at (UTC).
+    #' - cancel_type (character) the cancel type.
+    #' - uid (integer) the user identifier.
+    #' - currency_name (character) the currency name.
+    #' - failure_reason (character) the failure reason.
+    #' - failure_reason_msg (logical | NA) the failure reason msg.
+    #' - address_remark (character) the address remark.
+    #' - remark (character) an optional remark.
+    #' - taxes (logical | NA) the taxes.
+    #' - tax_description (logical | NA) the tax description.
+    #' - tx_id (logical | NA) the tx id.
+    #' - return_status (character) the return status.
+    #' - return_amount (logical | NA) the return amount.
+    #' - return_currency (character) the return currency.
     #'
     #' @examples
     #' \dontrun{

--- a/R/contracts-generated.R
+++ b/R/contracts-generated.R
@@ -3,11 +3,53 @@
 
 assert_return_KucoinAccount__get_summary <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("level", "sub_quantity", "max_default_sub_quantity", "max_sub_quantity", "spot_sub_quantity", "margin_sub_quantity", "futures_sub_quantity", "option_sub_quantity", "max_spot_sub_quantity", "max_margin_sub_quantity", "max_futures_sub_quantity", "max_option_sub_quantity"))
+  assert_integer(value[["level"]])
+  assert_no_missing_values(value[["level"]])
+  assert_integer(value[["sub_quantity"]])
+  assert_no_missing_values(value[["sub_quantity"]])
+  assert_integer(value[["max_default_sub_quantity"]])
+  assert_no_missing_values(value[["max_default_sub_quantity"]])
+  assert_integer(value[["max_sub_quantity"]])
+  assert_no_missing_values(value[["max_sub_quantity"]])
+  assert_integer(value[["spot_sub_quantity"]])
+  assert_no_missing_values(value[["spot_sub_quantity"]])
+  assert_integer(value[["margin_sub_quantity"]])
+  assert_no_missing_values(value[["margin_sub_quantity"]])
+  assert_integer(value[["futures_sub_quantity"]])
+  assert_no_missing_values(value[["futures_sub_quantity"]])
+  assert_integer(value[["option_sub_quantity"]])
+  assert_no_missing_values(value[["option_sub_quantity"]])
+  assert_integer(value[["max_spot_sub_quantity"]])
+  assert_no_missing_values(value[["max_spot_sub_quantity"]])
+  assert_integer(value[["max_margin_sub_quantity"]])
+  assert_no_missing_values(value[["max_margin_sub_quantity"]])
+  assert_integer(value[["max_futures_sub_quantity"]])
+  assert_no_missing_values(value[["max_futures_sub_quantity"]])
+  assert_integer(value[["max_option_sub_quantity"]])
+  assert_no_missing_values(value[["max_option_sub_quantity"]])
   return(value)
 }
 
 assert_return_KucoinAccount__get_apikey_info <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("remark", "api_key", "api_version", "permission", "ip_whitelist", "created_at", "uid", "is_master"))
+  assert_character(value[["remark"]])
+  assert_no_missing_values(value[["remark"]])
+  assert_character(value[["api_key"]])
+  assert_no_missing_values(value[["api_key"]])
+  assert_integer(value[["api_version"]])
+  assert_no_missing_values(value[["api_version"]])
+  assert_character(value[["permission"]])
+  assert_no_missing_values(value[["permission"]])
+  assert_character(value[["ip_whitelist"]])
+  assert_no_missing_values(value[["ip_whitelist"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
+  assert_integer(value[["uid"]])
+  assert_no_missing_values(value[["uid"]])
+  assert_logical(value[["is_master"]])
+  assert_no_missing_values(value[["is_master"]])
   return(value)
 }
 
@@ -33,6 +75,15 @@ assert_args_KucoinAccount__get_spot_account_detail <- function(accountId) {
 
 assert_return_KucoinAccount__get_spot_account_detail <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("currency", "balance", "available", "holds"))
+  assert_character(value[["currency"]])
+  assert_no_missing_values(value[["currency"]])
+  assert_character(value[["balance"]])
+  assert_no_missing_values(value[["balance"]])
+  assert_character(value[["available"]])
+  assert_no_missing_values(value[["available"]])
+  assert_character(value[["holds"]])
+  assert_no_missing_values(value[["holds"]])
   return(value)
 }
 
@@ -109,6 +160,11 @@ assert_args_KucoinAccount__get_base_fee_rate <- function(currencyType) {
 
 assert_return_KucoinAccount__get_base_fee_rate <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("taker_fee_rate", "maker_fee_rate"))
+  assert_character(value[["taker_fee_rate"]])
+  assert_no_missing_values(value[["taker_fee_rate"]])
+  assert_character(value[["maker_fee_rate"]])
+  assert_no_missing_values(value[["maker_fee_rate"]])
   return(value)
 }
 
@@ -119,6 +175,13 @@ assert_args_KucoinAccount__get_fee_rate <- function(symbols) {
 
 assert_return_KucoinAccount__get_fee_rate <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "taker_fee_rate", "maker_fee_rate"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["taker_fee_rate"]])
+  assert_no_missing_values(value[["taker_fee_rate"]])
+  assert_character(value[["maker_fee_rate"]])
+  assert_no_missing_values(value[["maker_fee_rate"]])
   return(value)
 }
 
@@ -150,6 +213,21 @@ assert_args_KucoinDeposit__add_deposit_address <- function(currency, chain, to, 
 
 assert_return_KucoinDeposit__add_deposit_address <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("address", "memo", "chain", "chain_id", "to", "currency", "contract_address"))
+  assert_character(value[["address"]])
+  assert_no_missing_values(value[["address"]])
+  assert_character(value[["memo"]])
+  assert_no_missing_values(value[["memo"]])
+  assert_character(value[["chain"]])
+  assert_no_missing_values(value[["chain"]])
+  assert_character(value[["chain_id"]])
+  assert_no_missing_values(value[["chain_id"]])
+  assert_character(value[["to"]])
+  assert_no_missing_values(value[["to"]])
+  assert_character(value[["currency"]])
+  assert_no_missing_values(value[["currency"]])
+  assert_character(value[["contract_address"]])
+  assert_no_missing_values(value[["contract_address"]])
   return(value)
 }
 
@@ -213,6 +291,23 @@ assert_args_KucoinFuturesAccount__get_account_overview <- function(currency) {
 
 assert_return_KucoinFuturesAccount__get_account_overview <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("account_equity", "unrealised_pnl", "margin_balance", "available_balance", "available_margin", "currency", "risk_ratio", "max_withdraw_amount"))
+  assert_double(value[["account_equity"]])
+  assert_no_missing_values(value[["account_equity"]])
+  assert_double(value[["unrealised_pnl"]])
+  assert_no_missing_values(value[["unrealised_pnl"]])
+  assert_double(value[["margin_balance"]])
+  assert_no_missing_values(value[["margin_balance"]])
+  assert_double(value[["available_balance"]])
+  assert_no_missing_values(value[["available_balance"]])
+  assert_double(value[["available_margin"]])
+  assert_no_missing_values(value[["available_margin"]])
+  assert_character(value[["currency"]])
+  assert_no_missing_values(value[["currency"]])
+  assert_double(value[["risk_ratio"]])
+  assert_no_missing_values(value[["risk_ratio"]])
+  assert_double(value[["max_withdraw_amount"]])
+  assert_no_missing_values(value[["max_withdraw_amount"]])
   return(value)
 }
 
@@ -255,6 +350,11 @@ assert_args_KucoinFuturesAccount__get_margin_mode <- function(symbol) {
 
 assert_return_KucoinFuturesAccount__get_margin_mode <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "margin_mode"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["margin_mode"]])
+  assert_no_missing_values(value[["margin_mode"]])
   return(value)
 }
 
@@ -266,6 +366,11 @@ assert_args_KucoinFuturesAccount__set_margin_mode <- function(symbol, marginMode
 
 assert_return_KucoinFuturesAccount__set_margin_mode <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "margin_mode"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["margin_mode"]])
+  assert_no_missing_values(value[["margin_mode"]])
   return(value)
 }
 
@@ -276,6 +381,11 @@ assert_args_KucoinFuturesAccount__get_cross_margin_leverage <- function(symbol) 
 
 assert_return_KucoinFuturesAccount__get_cross_margin_leverage <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "leverage"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["leverage"]])
+  assert_no_missing_values(value[["leverage"]])
   return(value)
 }
 
@@ -288,6 +398,11 @@ assert_args_KucoinFuturesAccount__set_cross_margin_leverage <- function(symbol, 
 
 assert_return_KucoinFuturesAccount__set_cross_margin_leverage <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "leverage"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["leverage"]])
+  assert_no_missing_values(value[["leverage"]])
   return(value)
 }
 
@@ -302,6 +417,13 @@ assert_args_KucoinFuturesAccount__get_max_open_size <- function(symbol, price, l
 
 assert_return_KucoinFuturesAccount__get_max_open_size <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "max_buy_open_size", "max_sell_open_size"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_integer(value[["max_buy_open_size"]])
+  assert_no_missing_values(value[["max_buy_open_size"]])
+  assert_integer(value[["max_sell_open_size"]])
+  assert_no_missing_values(value[["max_sell_open_size"]])
   return(value)
 }
 
@@ -324,6 +446,15 @@ assert_args_KucoinFuturesAccount__add_isolated_margin <- function(symbol, margin
 
 assert_return_KucoinFuturesAccount__add_isolated_margin <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("id", "symbol", "margin", "margin_type"))
+  assert_character(value[["id"]])
+  assert_no_missing_values(value[["id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["margin"]])
+  assert_no_missing_values(value[["margin"]])
+  assert_character(value[["margin_type"]])
+  assert_no_missing_values(value[["margin_type"]])
   return(value)
 }
 
@@ -335,6 +466,15 @@ assert_args_KucoinFuturesAccount__remove_isolated_margin <- function(symbol, wit
 
 assert_return_KucoinFuturesAccount__remove_isolated_margin <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("id", "symbol", "margin", "margin_type"))
+  assert_character(value[["id"]])
+  assert_no_missing_values(value[["id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["margin"]])
+  assert_no_missing_values(value[["margin"]])
+  assert_character(value[["margin_type"]])
+  assert_no_missing_values(value[["margin_type"]])
   return(value)
 }
 
@@ -393,6 +533,29 @@ assert_args_KucoinFuturesMarketData__get_ticker <- function(symbol) {
 
 assert_return_KucoinFuturesMarketData__get_ticker <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("sequence", "symbol", "side", "size", "price", "best_bid_size", "best_bid_price", "best_ask_price", "best_ask_size", "trade_id", "ts"))
+  assert_integer(value[["sequence"]])
+  assert_no_missing_values(value[["sequence"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_integer(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_character(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_integer(value[["best_bid_size"]])
+  assert_no_missing_values(value[["best_bid_size"]])
+  assert_character(value[["best_bid_price"]])
+  assert_no_missing_values(value[["best_bid_price"]])
+  assert_character(value[["best_ask_price"]])
+  assert_no_missing_values(value[["best_ask_price"]])
+  assert_integer(value[["best_ask_size"]])
+  assert_no_missing_values(value[["best_ask_size"]])
+  assert_character(value[["trade_id"]])
+  assert_no_missing_values(value[["trade_id"]])
+  assert_datetime(value[["ts"]])
+  assert_no_missing_values(value[["ts"]])
   return(value)
 }
 
@@ -408,6 +571,21 @@ assert_args_KucoinFuturesMarketData__get_part_orderbook <- function(symbol) {
 
 assert_return_KucoinFuturesMarketData__get_part_orderbook <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("ts", "sequence", "side", "level", "price", "size", "symbol"))
+  assert_datetime(value[["ts"]])
+  assert_no_missing_values(value[["ts"]])
+  assert_character(value[["sequence"]])
+  assert_no_missing_values(value[["sequence"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_integer(value[["level"]])
+  assert_no_missing_values(value[["level"]])
+  assert_double(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_double(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
   return(value)
 }
 
@@ -418,6 +596,21 @@ assert_args_KucoinFuturesMarketData__get_full_orderbook <- function(symbol) {
 
 assert_return_KucoinFuturesMarketData__get_full_orderbook <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("ts", "sequence", "side", "level", "price", "size", "symbol"))
+  assert_datetime(value[["ts"]])
+  assert_no_missing_values(value[["ts"]])
+  assert_character(value[["sequence"]])
+  assert_no_missing_values(value[["sequence"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_integer(value[["level"]])
+  assert_no_missing_values(value[["level"]])
+  assert_double(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_double(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
   return(value)
 }
 
@@ -468,6 +661,17 @@ assert_args_KucoinFuturesMarketData__get_mark_price <- function(symbol) {
 
 assert_return_KucoinFuturesMarketData__get_mark_price <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "granularity", "time_point", "value", "index_price"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_integer(value[["granularity"]])
+  assert_no_missing_values(value[["granularity"]])
+  assert_datetime(value[["time_point"]])
+  assert_no_missing_values(value[["time_point"]])
+  assert_double(value[["value"]])
+  assert_no_missing_values(value[["value"]])
+  assert_double(value[["index_price"]])
+  assert_no_missing_values(value[["index_price"]])
   return(value)
 }
 
@@ -478,6 +682,25 @@ assert_args_KucoinFuturesMarketData__get_funding_rate <- function(symbol) {
 
 assert_return_KucoinFuturesMarketData__get_funding_rate <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "granularity", "time_point", "value", "daily_interest_rate", "funding_rate_cap", "funding_rate_floor", "period", "funding_time"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_integer(value[["granularity"]])
+  assert_no_missing_values(value[["granularity"]])
+  assert_datetime(value[["time_point"]])
+  assert_no_missing_values(value[["time_point"]])
+  assert_double(value[["value"]])
+  assert_no_missing_values(value[["value"]])
+  assert_double(value[["daily_interest_rate"]])
+  assert_no_missing_values(value[["daily_interest_rate"]])
+  assert_double(value[["funding_rate_cap"]])
+  assert_no_missing_values(value[["funding_rate_cap"]])
+  assert_double(value[["funding_rate_floor"]])
+  assert_no_missing_values(value[["funding_rate_floor"]])
+  assert_integer(value[["period"]])
+  assert_no_missing_values(value[["period"]])
+  assert_datetime(value[["funding_time"]])
+  assert_no_missing_values(value[["funding_time"]])
   return(value)
 }
 
@@ -493,11 +716,19 @@ assert_return_KucoinFuturesMarketData__get_funding_history <- function(value) {
 
 assert_return_KucoinFuturesMarketData__get_server_time <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("server_time"))
+  assert_datetime(value[["server_time"]])
+  assert_no_missing_values(value[["server_time"]])
   return(value)
 }
 
 assert_return_KucoinFuturesMarketData__get_service_status <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("status", "msg"))
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
+  assert_character(value[["msg"]])
+  assert_no_missing_values(value[["msg"]])
   return(value)
 }
 
@@ -578,6 +809,11 @@ assert_args_KucoinFuturesTrading__add_order <- function(clientOid, symbol, side,
 
 assert_return_KucoinFuturesTrading__add_order <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -609,6 +845,11 @@ assert_args_KucoinFuturesTrading__add_order_test <- function(clientOid, symbol, 
 
 assert_return_KucoinFuturesTrading__add_order_test <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -619,6 +860,11 @@ assert_args_KucoinFuturesTrading__add_order_batch <- function(orders) {
 
 assert_return_KucoinFuturesTrading__add_order_batch <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -664,6 +910,9 @@ assert_args_KucoinFuturesTrading__cancel_all_stop_orders <- function(symbol) {
 
 assert_return_KucoinFuturesTrading__cancel_all_stop_orders <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("cancelled_order_id"))
+  assert_character(value[["cancelled_order_id"]])
+  assert_no_missing_values(value[["cancelled_order_id"]])
   return(value)
 }
 
@@ -674,6 +923,39 @@ assert_args_KucoinFuturesTrading__get_order_by_id <- function(orderId) {
 
 assert_return_KucoinFuturesTrading__get_order_by_id <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("id", "symbol", "type", "side", "price", "size", "value", "deal_value", "deal_size", "leverage", "margin_mode", "position_side", "status", "created_at", "updated_at", "client_oid"))
+  assert_character(value[["id"]])
+  assert_no_missing_values(value[["id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["type"]])
+  assert_no_missing_values(value[["type"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_character(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_integer(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_character(value[["value"]])
+  assert_no_missing_values(value[["value"]])
+  assert_character(value[["deal_value"]])
+  assert_no_missing_values(value[["deal_value"]])
+  assert_integer(value[["deal_size"]])
+  assert_no_missing_values(value[["deal_size"]])
+  assert_integer(value[["leverage"]])
+  assert_no_missing_values(value[["leverage"]])
+  assert_character(value[["margin_mode"]])
+  assert_no_missing_values(value[["margin_mode"]])
+  assert_character(value[["position_side"]])
+  assert_no_missing_values(value[["position_side"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
+  assert_datetime(value[["updated_at"]])
+  assert_no_missing_values(value[["updated_at"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -684,6 +966,39 @@ assert_args_KucoinFuturesTrading__get_order_by_client_oid <- function(clientOid)
 
 assert_return_KucoinFuturesTrading__get_order_by_client_oid <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("id", "symbol", "type", "side", "price", "size", "value", "deal_value", "deal_size", "leverage", "margin_mode", "position_side", "status", "created_at", "updated_at", "client_oid"))
+  assert_character(value[["id"]])
+  assert_no_missing_values(value[["id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["type"]])
+  assert_no_missing_values(value[["type"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_character(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_integer(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_character(value[["value"]])
+  assert_no_missing_values(value[["value"]])
+  assert_character(value[["deal_value"]])
+  assert_no_missing_values(value[["deal_value"]])
+  assert_integer(value[["deal_size"]])
+  assert_no_missing_values(value[["deal_size"]])
+  assert_integer(value[["leverage"]])
+  assert_no_missing_values(value[["leverage"]])
+  assert_character(value[["margin_mode"]])
+  assert_no_missing_values(value[["margin_mode"]])
+  assert_character(value[["position_side"]])
+  assert_no_missing_values(value[["position_side"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
+  assert_datetime(value[["updated_at"]])
+  assert_no_missing_values(value[["updated_at"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -694,6 +1009,39 @@ assert_args_KucoinFuturesTrading__get_order_list <- function(query) {
 
 assert_return_KucoinFuturesTrading__get_order_list <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("id", "symbol", "type", "side", "price", "size", "value", "deal_value", "deal_size", "leverage", "margin_mode", "position_side", "status", "created_at", "updated_at", "client_oid"))
+  assert_character(value[["id"]])
+  assert_no_missing_values(value[["id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["type"]])
+  assert_no_missing_values(value[["type"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_character(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_integer(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_character(value[["value"]])
+  assert_no_missing_values(value[["value"]])
+  assert_character(value[["deal_value"]])
+  assert_no_missing_values(value[["deal_value"]])
+  assert_integer(value[["deal_size"]])
+  assert_no_missing_values(value[["deal_size"]])
+  assert_integer(value[["leverage"]])
+  assert_no_missing_values(value[["leverage"]])
+  assert_character(value[["margin_mode"]])
+  assert_no_missing_values(value[["margin_mode"]])
+  assert_character(value[["position_side"]])
+  assert_no_missing_values(value[["position_side"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
+  assert_datetime(value[["updated_at"]])
+  assert_no_missing_values(value[["updated_at"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -706,6 +1054,39 @@ assert_args_KucoinFuturesTrading__get_recent_closed_orders <- function(symbol) {
 
 assert_return_KucoinFuturesTrading__get_recent_closed_orders <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("id", "symbol", "type", "side", "price", "size", "value", "deal_value", "deal_size", "leverage", "margin_mode", "position_side", "status", "created_at", "updated_at", "client_oid"))
+  assert_character(value[["id"]])
+  assert_no_missing_values(value[["id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["type"]])
+  assert_no_missing_values(value[["type"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_character(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_integer(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_character(value[["value"]])
+  assert_no_missing_values(value[["value"]])
+  assert_character(value[["deal_value"]])
+  assert_no_missing_values(value[["deal_value"]])
+  assert_integer(value[["deal_size"]])
+  assert_no_missing_values(value[["deal_size"]])
+  assert_integer(value[["leverage"]])
+  assert_no_missing_values(value[["leverage"]])
+  assert_character(value[["margin_mode"]])
+  assert_no_missing_values(value[["margin_mode"]])
+  assert_character(value[["position_side"]])
+  assert_no_missing_values(value[["position_side"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
+  assert_datetime(value[["updated_at"]])
+  assert_no_missing_values(value[["updated_at"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -738,6 +1119,41 @@ assert_args_KucoinFuturesTrading__get_recent_fills <- function(symbol) {
 
 assert_return_KucoinFuturesTrading__get_recent_fills <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "trade_id", "order_id", "side", "liquidity", "force_taker", "price", "size", "value", "fee_rate", "fix_fee", "fee_currency", "fee", "order_type", "trade_type", "trade_time", "created_at"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["trade_id"]])
+  assert_no_missing_values(value[["trade_id"]])
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_character(value[["liquidity"]])
+  assert_no_missing_values(value[["liquidity"]])
+  assert_logical(value[["force_taker"]])
+  assert_no_missing_values(value[["force_taker"]])
+  assert_character(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_integer(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_character(value[["value"]])
+  assert_no_missing_values(value[["value"]])
+  assert_character(value[["fee_rate"]])
+  assert_no_missing_values(value[["fee_rate"]])
+  assert_character(value[["fix_fee"]])
+  assert_no_missing_values(value[["fix_fee"]])
+  assert_character(value[["fee_currency"]])
+  assert_no_missing_values(value[["fee_currency"]])
+  assert_character(value[["fee"]])
+  assert_no_missing_values(value[["fee"]])
+  assert_character(value[["order_type"]])
+  assert_no_missing_values(value[["order_type"]])
+  assert_character(value[["trade_type"]])
+  assert_no_missing_values(value[["trade_type"]])
+  assert_datetime(value[["trade_time"]])
+  assert_no_missing_values(value[["trade_time"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
   return(value)
 }
 
@@ -748,6 +1164,17 @@ assert_args_KucoinFuturesTrading__get_open_order_value <- function(symbol) {
 
 assert_return_KucoinFuturesTrading__get_open_order_value <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("open_order_buy_size", "open_order_sell_size", "open_order_buy_cost", "open_order_sell_cost", "settle_currency"))
+  assert_integer(value[["open_order_buy_size"]])
+  assert_no_missing_values(value[["open_order_buy_size"]])
+  assert_integer(value[["open_order_sell_size"]])
+  assert_no_missing_values(value[["open_order_sell_size"]])
+  assert_character(value[["open_order_buy_cost"]])
+  assert_no_missing_values(value[["open_order_buy_cost"]])
+  assert_character(value[["open_order_sell_cost"]])
+  assert_no_missing_values(value[["open_order_sell_cost"]])
+  assert_character(value[["settle_currency"]])
+  assert_no_missing_values(value[["settle_currency"]])
   return(value)
 }
 
@@ -760,6 +1187,13 @@ assert_args_KucoinFuturesTrading__set_dcp <- function(symbol) {
 
 assert_return_KucoinFuturesTrading__set_dcp <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("timeout", "symbols", "current_time"))
+  assert_integer(value[["timeout"]])
+  assert_no_missing_values(value[["timeout"]])
+  assert_character(value[["symbols"]])
+  assert_no_missing_values(value[["symbols"]])
+  assert_double(value[["current_time"]])
+  assert_no_missing_values(value[["current_time"]])
   return(value)
 }
 
@@ -772,6 +1206,13 @@ assert_args_KucoinFuturesTrading__get_dcp <- function(symbol) {
 
 assert_return_KucoinFuturesTrading__get_dcp <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("timeout", "symbols", "current_time"))
+  assert_integer(value[["timeout"]])
+  assert_no_missing_values(value[["timeout"]])
+  assert_character(value[["symbols"]])
+  assert_no_missing_values(value[["symbols"]])
+  assert_double(value[["current_time"]])
+  assert_no_missing_values(value[["current_time"]])
   return(value)
 }
 
@@ -804,6 +1245,9 @@ assert_args_KucoinLending__purchase <- function(currency, size, interestRate) {
 
 assert_return_KucoinLending__purchase <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_no"))
+  assert_character(value[["order_no"]])
+  assert_no_missing_values(value[["order_no"]])
   return(value)
 }
 
@@ -816,7 +1260,15 @@ assert_args_KucoinLending__modify_purchase <- function(currency, purchaseOrderNo
 
 assert_return_KucoinLending__modify_purchase <- function(value) {
   assert_data_table(value)
-  assert_has_columns(value, c("currency", "purchase_order_no", "interest_rate", "status"))
+  assert_has_columns(value, c("currency", "purchase_order_no", "interest_rate", "status", "currency", "purchase_order_no", "interest_rate", "status"))
+  assert_character(value[["currency"]])
+  assert_no_missing_values(value[["currency"]])
+  assert_character(value[["purchase_order_no"]])
+  assert_no_missing_values(value[["purchase_order_no"]])
+  assert_double(value[["interest_rate"]])
+  assert_no_missing_values(value[["interest_rate"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
   assert_character(value[["currency"]])
   assert_no_missing_values(value[["currency"]])
   assert_character(value[["purchase_order_no"]])
@@ -847,6 +1299,9 @@ assert_args_KucoinLending__redeem <- function(currency, size, purchaseOrderNo) {
 
 assert_return_KucoinLending__redeem <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_no"))
+  assert_character(value[["order_no"]])
+  assert_no_missing_values(value[["order_no"]])
   return(value)
 }
 
@@ -877,6 +1332,15 @@ assert_return_KucoinMarginData__get_isolated_margin_symbols <- function(value) {
 
 assert_return_KucoinMarginData__get_margin_config <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("currency", "max_leverage", "warning_debt_ratio", "liq_debt_ratio"))
+  assert_character(value[["currency"]])
+  assert_no_missing_values(value[["currency"]])
+  assert_integer(value[["max_leverage"]])
+  assert_no_missing_values(value[["max_leverage"]])
+  assert_character(value[["warning_debt_ratio"]])
+  assert_no_missing_values(value[["warning_debt_ratio"]])
+  assert_character(value[["liq_debt_ratio"]])
+  assert_no_missing_values(value[["liq_debt_ratio"]])
   return(value)
 }
 
@@ -887,6 +1351,15 @@ assert_args_KucoinMarginData__get_collateral_ratio <- function(query) {
 
 assert_return_KucoinMarginData__get_collateral_ratio <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("currency", "lower_limit", "upper_limit", "collateral_ratio"))
+  assert_character(value[["currency"]])
+  assert_no_missing_values(value[["currency"]])
+  assert_character(value[["lower_limit"]])
+  assert_no_missing_values(value[["lower_limit"]])
+  assert_character(value[["upper_limit"]])
+  assert_no_missing_values(value[["upper_limit"]])
+  assert_character(value[["collateral_ratio"]])
+  assert_no_missing_values(value[["collateral_ratio"]])
   return(value)
 }
 
@@ -996,6 +1469,10 @@ assert_args_KucoinMarginTrading__close_short <- function(symbol, size, funds, ty
 
 assert_return_KucoinMarginTrading__close_short <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["client_oid"]])
   return(value)
 }
 
@@ -1045,6 +1522,10 @@ assert_args_KucoinMarginTrading__open_long <- function(symbol, size, funds, type
 
 assert_return_KucoinMarginTrading__open_long <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["client_oid"]])
   return(value)
 }
 
@@ -1094,6 +1575,10 @@ assert_args_KucoinMarginTrading__close_long <- function(symbol, size, funds, typ
 
 assert_return_KucoinMarginTrading__close_long <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["client_oid"]])
   return(value)
 }
 
@@ -1111,6 +1596,11 @@ assert_args_KucoinMarginTrading__borrow <- function(currency, size, timeInForce,
 
 assert_return_KucoinMarginTrading__borrow <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_no", "actual_size"))
+  assert_character(value[["order_no"]])
+  assert_no_missing_values(value[["order_no"]])
+  assert_character(value[["actual_size"]])
+  assert_no_missing_values(value[["actual_size"]])
   return(value)
 }
 
@@ -1167,7 +1657,11 @@ assert_return_KucoinMarginTrading__get_borrow_rate <- function(value) {
 
 assert_return_KucoinMarginTrading__modify_leverage <- function(value) {
   assert_data_table(value)
-  assert_has_columns(value, c("leverage", "status"))
+  assert_has_columns(value, c("leverage", "status", "leverage", "status"))
+  assert_double(value[["leverage"]])
+  assert_no_missing_values(value[["leverage"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
   assert_double(value[["leverage"]])
   assert_no_missing_values(value[["leverage"]])
   assert_character(value[["status"]])
@@ -1186,6 +1680,20 @@ assert_args_KucoinMarketData__get_announcements <- function(query, page_size, ma
 
 assert_return_KucoinMarketData__get_announcements <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("ann_id", "ann_title", "ann_type", "ann_desc", "c_time", "language", "ann_url"))
+  assert_integer(value[["ann_id"]])
+  assert_no_missing_values(value[["ann_id"]])
+  assert_character(value[["ann_title"]])
+  assert_no_missing_values(value[["ann_title"]])
+  assert_character(value[["ann_type"]])
+  assert_character(value[["ann_desc"]])
+  assert_no_missing_values(value[["ann_desc"]])
+  assert_datetime(value[["c_time"]])
+  assert_no_missing_values(value[["c_time"]])
+  assert_character(value[["language"]])
+  assert_no_missing_values(value[["language"]])
+  assert_character(value[["ann_url"]])
+  assert_no_missing_values(value[["ann_url"]])
   return(value)
 }
 
@@ -1214,6 +1722,57 @@ assert_args_KucoinMarketData__get_symbol <- function(symbol) {
 
 assert_return_KucoinMarketData__get_symbol <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "name", "base_currency", "quote_currency", "fee_currency", "market", "base_min_size", "quote_min_size", "base_max_size", "quote_max_size", "base_increment", "quote_increment", "price_increment", "price_limit_rate", "min_funds", "is_margin_enabled", "enable_trading", "fee_category", "maker_fee_coefficient", "taker_fee_coefficient", "st", "callauction_is_enabled", "callauction_price_floor", "callauction_price_ceiling", "callauction_first_stage_start_time", "callauction_second_stage_start_time", "callauction_third_stage_start_time", "trading_start_time"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["name"]])
+  assert_no_missing_values(value[["name"]])
+  assert_character(value[["base_currency"]])
+  assert_no_missing_values(value[["base_currency"]])
+  assert_character(value[["quote_currency"]])
+  assert_no_missing_values(value[["quote_currency"]])
+  assert_character(value[["fee_currency"]])
+  assert_no_missing_values(value[["fee_currency"]])
+  assert_character(value[["market"]])
+  assert_no_missing_values(value[["market"]])
+  assert_character(value[["base_min_size"]])
+  assert_no_missing_values(value[["base_min_size"]])
+  assert_character(value[["quote_min_size"]])
+  assert_no_missing_values(value[["quote_min_size"]])
+  assert_character(value[["base_max_size"]])
+  assert_no_missing_values(value[["base_max_size"]])
+  assert_character(value[["quote_max_size"]])
+  assert_no_missing_values(value[["quote_max_size"]])
+  assert_character(value[["base_increment"]])
+  assert_no_missing_values(value[["base_increment"]])
+  assert_character(value[["quote_increment"]])
+  assert_no_missing_values(value[["quote_increment"]])
+  assert_character(value[["price_increment"]])
+  assert_no_missing_values(value[["price_increment"]])
+  assert_character(value[["price_limit_rate"]])
+  assert_no_missing_values(value[["price_limit_rate"]])
+  assert_character(value[["min_funds"]])
+  assert_no_missing_values(value[["min_funds"]])
+  assert_logical(value[["is_margin_enabled"]])
+  assert_no_missing_values(value[["is_margin_enabled"]])
+  assert_logical(value[["enable_trading"]])
+  assert_no_missing_values(value[["enable_trading"]])
+  assert_integer(value[["fee_category"]])
+  assert_no_missing_values(value[["fee_category"]])
+  assert_character(value[["maker_fee_coefficient"]])
+  assert_no_missing_values(value[["maker_fee_coefficient"]])
+  assert_character(value[["taker_fee_coefficient"]])
+  assert_no_missing_values(value[["taker_fee_coefficient"]])
+  assert_logical(value[["st"]])
+  assert_no_missing_values(value[["st"]])
+  assert_logical(value[["callauction_is_enabled"]])
+  assert_no_missing_values(value[["callauction_is_enabled"]])
+  assert_logical(value[["callauction_price_floor"]])
+  assert_logical(value[["callauction_price_ceiling"]])
+  assert_logical(value[["callauction_first_stage_start_time"]])
+  assert_logical(value[["callauction_second_stage_start_time"]])
+  assert_logical(value[["callauction_third_stage_start_time"]])
+  assert_logical(value[["trading_start_time"]])
   return(value)
 }
 
@@ -1226,6 +1785,57 @@ assert_args_KucoinMarketData__get_all_symbols <- function(market) {
 
 assert_return_KucoinMarketData__get_all_symbols <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "name", "base_currency", "quote_currency", "fee_currency", "market", "base_min_size", "quote_min_size", "base_max_size", "quote_max_size", "base_increment", "quote_increment", "price_increment", "price_limit_rate", "min_funds", "is_margin_enabled", "enable_trading", "fee_category", "maker_fee_coefficient", "taker_fee_coefficient", "st", "callauction_is_enabled", "callauction_price_floor", "callauction_price_ceiling", "callauction_first_stage_start_time", "callauction_second_stage_start_time", "callauction_third_stage_start_time", "trading_start_time"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["name"]])
+  assert_no_missing_values(value[["name"]])
+  assert_character(value[["base_currency"]])
+  assert_no_missing_values(value[["base_currency"]])
+  assert_character(value[["quote_currency"]])
+  assert_no_missing_values(value[["quote_currency"]])
+  assert_character(value[["fee_currency"]])
+  assert_no_missing_values(value[["fee_currency"]])
+  assert_character(value[["market"]])
+  assert_no_missing_values(value[["market"]])
+  assert_character(value[["base_min_size"]])
+  assert_no_missing_values(value[["base_min_size"]])
+  assert_character(value[["quote_min_size"]])
+  assert_no_missing_values(value[["quote_min_size"]])
+  assert_character(value[["base_max_size"]])
+  assert_no_missing_values(value[["base_max_size"]])
+  assert_character(value[["quote_max_size"]])
+  assert_no_missing_values(value[["quote_max_size"]])
+  assert_character(value[["base_increment"]])
+  assert_no_missing_values(value[["base_increment"]])
+  assert_character(value[["quote_increment"]])
+  assert_no_missing_values(value[["quote_increment"]])
+  assert_character(value[["price_increment"]])
+  assert_no_missing_values(value[["price_increment"]])
+  assert_character(value[["price_limit_rate"]])
+  assert_no_missing_values(value[["price_limit_rate"]])
+  assert_character(value[["min_funds"]])
+  assert_no_missing_values(value[["min_funds"]])
+  assert_logical(value[["is_margin_enabled"]])
+  assert_no_missing_values(value[["is_margin_enabled"]])
+  assert_logical(value[["enable_trading"]])
+  assert_no_missing_values(value[["enable_trading"]])
+  assert_integer(value[["fee_category"]])
+  assert_no_missing_values(value[["fee_category"]])
+  assert_character(value[["maker_fee_coefficient"]])
+  assert_no_missing_values(value[["maker_fee_coefficient"]])
+  assert_character(value[["taker_fee_coefficient"]])
+  assert_no_missing_values(value[["taker_fee_coefficient"]])
+  assert_logical(value[["st"]])
+  assert_no_missing_values(value[["st"]])
+  assert_logical(value[["callauction_is_enabled"]])
+  assert_no_missing_values(value[["callauction_is_enabled"]])
+  assert_logical(value[["callauction_price_floor"]])
+  assert_logical(value[["callauction_price_ceiling"]])
+  assert_logical(value[["callauction_first_stage_start_time"]])
+  assert_logical(value[["callauction_second_stage_start_time"]])
+  assert_logical(value[["callauction_third_stage_start_time"]])
+  assert_logical(value[["trading_start_time"]])
   return(value)
 }
 
@@ -1236,11 +1846,59 @@ assert_args_KucoinMarketData__get_ticker <- function(symbol) {
 
 assert_return_KucoinMarketData__get_ticker <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("time", "sequence", "price", "size", "best_bid", "best_bid_size", "best_ask", "best_ask_size"))
+  assert_datetime(value[["time"]])
+  assert_no_missing_values(value[["time"]])
+  assert_character(value[["sequence"]])
+  assert_no_missing_values(value[["sequence"]])
+  assert_character(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_character(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_character(value[["best_bid"]])
+  assert_no_missing_values(value[["best_bid"]])
+  assert_character(value[["best_bid_size"]])
+  assert_no_missing_values(value[["best_bid_size"]])
+  assert_character(value[["best_ask"]])
+  assert_no_missing_values(value[["best_ask"]])
+  assert_character(value[["best_ask_size"]])
+  assert_no_missing_values(value[["best_ask_size"]])
   return(value)
 }
 
 assert_return_KucoinMarketData__get_all_tickers <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("symbol", "symbol_name", "buy", "sell", "change_rate", "change_price", "high", "low", "vol", "vol_value", "last", "average_price", "taker_fee_rate", "maker_fee_rate", "time"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["symbol_name"]])
+  assert_no_missing_values(value[["symbol_name"]])
+  assert_character(value[["buy"]])
+  assert_no_missing_values(value[["buy"]])
+  assert_character(value[["sell"]])
+  assert_no_missing_values(value[["sell"]])
+  assert_character(value[["change_rate"]])
+  assert_no_missing_values(value[["change_rate"]])
+  assert_character(value[["change_price"]])
+  assert_no_missing_values(value[["change_price"]])
+  assert_character(value[["high"]])
+  assert_no_missing_values(value[["high"]])
+  assert_character(value[["low"]])
+  assert_no_missing_values(value[["low"]])
+  assert_character(value[["vol"]])
+  assert_no_missing_values(value[["vol"]])
+  assert_character(value[["vol_value"]])
+  assert_no_missing_values(value[["vol_value"]])
+  assert_character(value[["last"]])
+  assert_no_missing_values(value[["last"]])
+  assert_character(value[["average_price"]])
+  assert_no_missing_values(value[["average_price"]])
+  assert_character(value[["taker_fee_rate"]])
+  assert_no_missing_values(value[["taker_fee_rate"]])
+  assert_character(value[["maker_fee_rate"]])
+  assert_no_missing_values(value[["maker_fee_rate"]])
+  assert_datetime(value[["time"]])
+  assert_no_missing_values(value[["time"]])
   return(value)
 }
 
@@ -1251,6 +1909,19 @@ assert_args_KucoinMarketData__get_trade_history <- function(symbol) {
 
 assert_return_KucoinMarketData__get_trade_history <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("sequence", "side", "price", "size", "time", "trade_id"))
+  assert_character(value[["sequence"]])
+  assert_no_missing_values(value[["sequence"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_character(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_character(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_datetime(value[["time"]])
+  assert_no_missing_values(value[["time"]])
+  assert_character(value[["trade_id"]])
+  assert_no_missing_values(value[["trade_id"]])
   return(value)
 }
 
@@ -1305,12 +1976,47 @@ assert_args_KucoinMarketData__get_24hr_stats <- function(symbol) {
 
 assert_return_KucoinMarketData__get_24hr_stats <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("time", "symbol", "buy", "sell", "change_rate", "change_price", "high", "low", "vol", "vol_value", "last", "average_price", "taker_fee_rate", "maker_fee_rate", "taker_coefficient", "maker_coefficient"))
+  assert_datetime(value[["time"]])
+  assert_no_missing_values(value[["time"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["buy"]])
+  assert_no_missing_values(value[["buy"]])
+  assert_character(value[["sell"]])
+  assert_no_missing_values(value[["sell"]])
+  assert_character(value[["change_rate"]])
+  assert_no_missing_values(value[["change_rate"]])
+  assert_character(value[["change_price"]])
+  assert_no_missing_values(value[["change_price"]])
+  assert_character(value[["high"]])
+  assert_no_missing_values(value[["high"]])
+  assert_character(value[["low"]])
+  assert_no_missing_values(value[["low"]])
+  assert_character(value[["vol"]])
+  assert_no_missing_values(value[["vol"]])
+  assert_character(value[["vol_value"]])
+  assert_no_missing_values(value[["vol_value"]])
+  assert_character(value[["last"]])
+  assert_no_missing_values(value[["last"]])
+  assert_character(value[["average_price"]])
+  assert_no_missing_values(value[["average_price"]])
+  assert_character(value[["taker_fee_rate"]])
+  assert_no_missing_values(value[["taker_fee_rate"]])
+  assert_character(value[["maker_fee_rate"]])
+  assert_no_missing_values(value[["maker_fee_rate"]])
+  assert_character(value[["taker_coefficient"]])
+  assert_no_missing_values(value[["taker_coefficient"]])
+  assert_character(value[["maker_coefficient"]])
+  assert_no_missing_values(value[["maker_coefficient"]])
   return(value)
 }
 
 assert_return_KucoinMarketData__get_market_list <- function(value) {
   assert_data_table(value)
-  assert_has_columns(value, c("market"))
+  assert_has_columns(value, c("market", "market"))
+  assert_character(value[["market"]])
+  assert_no_missing_values(value[["market"]])
   assert_character(value[["market"]])
   assert_no_missing_values(value[["market"]])
   return(value)
@@ -1344,7 +2050,11 @@ assert_return_KucoinMarketData__get_klines <- function(value) {
 
 assert_return_KucoinMarketData__get_server_time <- function(value) {
   assert_data_table(value)
-  assert_has_columns(value, c("server_time", "datetime"))
+  assert_has_columns(value, c("server_time", "datetime", "server_time", "datetime"))
+  assert_double(value[["server_time"]])
+  assert_no_missing_values(value[["server_time"]])
+  assert_datetime(value[["datetime"]])
+  assert_no_missing_values(value[["datetime"]])
   assert_double(value[["server_time"]])
   assert_no_missing_values(value[["server_time"]])
   assert_datetime(value[["datetime"]])
@@ -1354,6 +2064,11 @@ assert_return_KucoinMarketData__get_server_time <- function(value) {
 
 assert_return_KucoinMarketData__get_service_status <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("status", "msg"))
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
+  assert_character(value[["msg"]])
+  assert_no_missing_values(value[["msg"]])
   return(value)
 }
 
@@ -1423,6 +2138,10 @@ assert_args_KucoinOcoOrders__add_order <- function(symbol, side, price, size, st
 
 assert_return_KucoinOcoOrders__add_order <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["client_oid"]])
   return(value)
 }
 
@@ -1463,6 +2182,17 @@ assert_args_KucoinOcoOrders__get_order_by_id <- function(orderId) {
 
 assert_return_KucoinOcoOrders__get_order_by_id <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "symbol", "client_oid", "order_time", "status"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
+  assert_datetime(value[["order_time"]])
+  assert_no_missing_values(value[["order_time"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
   return(value)
 }
 
@@ -1473,6 +2203,17 @@ assert_args_KucoinOcoOrders__get_order_by_client_oid <- function(clientOid) {
 
 assert_return_KucoinOcoOrders__get_order_by_client_oid <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "symbol", "client_oid", "order_time", "status"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
+  assert_datetime(value[["order_time"]])
+  assert_no_missing_values(value[["order_time"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
   return(value)
 }
 
@@ -1483,6 +2224,30 @@ assert_args_KucoinOcoOrders__get_order_detail_by_id <- function(orderId) {
 
 assert_return_KucoinOcoOrders__get_order_detail_by_id <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "symbol", "client_oid", "order_time", "status", "sub_order_id", "sub_order_symbol", "sub_order_side", "sub_order_price", "sub_order_size", "sub_order_status", "sub_order_stop_price"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
+  assert_datetime(value[["order_time"]])
+  assert_no_missing_values(value[["order_time"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
+  assert_character(value[["sub_order_id"]])
+  assert_no_missing_values(value[["sub_order_id"]])
+  assert_character(value[["sub_order_symbol"]])
+  assert_no_missing_values(value[["sub_order_symbol"]])
+  assert_character(value[["sub_order_side"]])
+  assert_no_missing_values(value[["sub_order_side"]])
+  assert_character(value[["sub_order_price"]])
+  assert_no_missing_values(value[["sub_order_price"]])
+  assert_character(value[["sub_order_size"]])
+  assert_no_missing_values(value[["sub_order_size"]])
+  assert_character(value[["sub_order_status"]])
+  assert_no_missing_values(value[["sub_order_status"]])
+  assert_character(value[["sub_order_stop_price"]])
   return(value)
 }
 
@@ -1583,6 +2348,9 @@ assert_args_KucoinStopOrders__add_order <- function(type, symbol, side, stopPric
 
 assert_return_KucoinStopOrders__add_order <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
   return(value)
 }
 
@@ -1604,6 +2372,11 @@ assert_args_KucoinStopOrders__cancel_order_by_client_oid <- function(clientOid, 
 
 assert_return_KucoinStopOrders__cancel_order_by_client_oid <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("cancelled_order_id", "client_oid"))
+  assert_character(value[["cancelled_order_id"]])
+  assert_no_missing_values(value[["cancelled_order_id"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -1660,6 +2433,15 @@ assert_args_KucoinSubAccount__add_sub_account <- function(password, subName, acc
 
 assert_return_KucoinSubAccount__add_sub_account <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("uid", "sub_name", "remarks", "access"))
+  assert_integer(value[["uid"]])
+  assert_no_missing_values(value[["uid"]])
+  assert_character(value[["sub_name"]])
+  assert_no_missing_values(value[["sub_name"]])
+  assert_character(value[["remarks"]])
+  assert_no_missing_values(value[["remarks"]])
+  assert_character(value[["access"]])
+  assert_no_missing_values(value[["access"]])
   return(value)
 }
 
@@ -1780,6 +2562,10 @@ assert_args_KucoinTrading__add_order <- function(type, symbol, side, clientOid, 
 
 assert_return_KucoinTrading__add_order <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["client_oid"]])
   return(value)
 }
 
@@ -1863,6 +2649,11 @@ assert_args_KucoinTrading__add_order_test <- function(type, symbol, side, client
 
 assert_return_KucoinTrading__add_order_test <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -1873,6 +2664,12 @@ assert_args_KucoinTrading__add_order_batch <- function(order_list) {
 
 assert_return_KucoinTrading__add_order_batch <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid", "success", "fail_msg"))
+  assert_character(value[["order_id"]])
+  assert_character(value[["client_oid"]])
+  assert_logical(value[["success"]])
+  assert_no_missing_values(value[["success"]])
+  assert_character(value[["fail_msg"]])
   return(value)
 }
 
@@ -1884,6 +2681,9 @@ assert_args_KucoinTrading__cancel_order_by_id <- function(orderId, symbol) {
 
 assert_return_KucoinTrading__cancel_order_by_id <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
   return(value)
 }
 
@@ -1895,6 +2695,9 @@ assert_args_KucoinTrading__cancel_order_by_client_oid <- function(clientOid, sym
 
 assert_return_KucoinTrading__cancel_order_by_client_oid <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("client_oid"))
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -1915,6 +2718,11 @@ assert_args_KucoinTrading__cancel_partial_order <- function(orderId, symbol, can
 
 assert_return_KucoinTrading__cancel_partial_order <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "cancel_size"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["cancel_size"]])
+  assert_no_missing_values(value[["cancel_size"]])
   return(value)
 }
 
@@ -1925,7 +2733,9 @@ assert_args_KucoinTrading__cancel_all_by_symbol <- function(symbol) {
 
 assert_return_KucoinTrading__cancel_all_by_symbol <- function(value) {
   assert_data_table(value)
-  assert_has_columns(value, c("result"))
+  assert_has_columns(value, c("result", "result"))
+  assert_character(value[["result"]])
+  assert_no_missing_values(value[["result"]])
   assert_character(value[["result"]])
   assert_no_missing_values(value[["result"]])
   return(value)
@@ -1933,7 +2743,11 @@ assert_return_KucoinTrading__cancel_all_by_symbol <- function(value) {
 
 assert_return_KucoinTrading__cancel_all <- function(value) {
   assert_data_table(value)
-  assert_has_columns(value, c("symbol", "status"))
+  assert_has_columns(value, c("symbol", "status", "symbol", "status"))
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
   assert_character(value[["symbol"]])
   assert_no_missing_values(value[["symbol"]])
   assert_character(value[["status"]])
@@ -1951,6 +2765,23 @@ assert_args_KucoinTrading__get_order_by_id <- function(orderId, symbol) {
 
 assert_return_KucoinTrading__get_order_by_id <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "symbol", "side", "type", "price", "size", "created_at", "last_updated_at"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_character(value[["type"]])
+  assert_no_missing_values(value[["type"]])
+  assert_character(value[["price"]])
+  assert_no_missing_values(value[["price"]])
+  assert_character(value[["size"]])
+  assert_no_missing_values(value[["size"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
+  assert_datetime(value[["last_updated_at"]])
+  assert_no_missing_values(value[["last_updated_at"]])
   return(value)
 }
 
@@ -1962,6 +2793,15 @@ assert_args_KucoinTrading__get_order_by_client_oid <- function(clientOid, symbol
 
 assert_return_KucoinTrading__get_order_by_client_oid <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("client_oid", "symbol", "side", "created_at"))
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
   return(value)
 }
 
@@ -2000,7 +2840,9 @@ assert_return_KucoinTrading__get_fills <- function(value) {
 
 assert_return_KucoinTrading__get_symbols_with_open_orders <- function(value) {
   assert_data_table(value)
-  assert_has_columns(value, c("symbols"))
+  assert_has_columns(value, c("symbols", "symbols"))
+  assert_character(value[["symbols"]])
+  assert_no_missing_values(value[["symbols"]])
   assert_character(value[["symbols"]])
   assert_no_missing_values(value[["symbols"]])
   return(value)
@@ -2045,6 +2887,15 @@ assert_args_KucoinTrading__get_closed_orders <- function(symbol, side, type, sta
 
 assert_return_KucoinTrading__get_closed_orders <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "symbol", "side", "created_at"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["symbol"]])
+  assert_no_missing_values(value[["symbol"]])
+  assert_character(value[["side"]])
+  assert_no_missing_values(value[["side"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
   return(value)
 }
 
@@ -2138,6 +2989,16 @@ assert_args_KucoinTrading__add_order_batch_sync <- function(order_list) {
 
 assert_return_KucoinTrading__add_order_batch_sync <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "client_oid", "success", "status", "deal_size", "remain_size", "canceled_size", "fail_msg"))
+  assert_character(value[["order_id"]])
+  assert_character(value[["client_oid"]])
+  assert_logical(value[["success"]])
+  assert_no_missing_values(value[["success"]])
+  assert_character(value[["status"]])
+  assert_character(value[["deal_size"]])
+  assert_character(value[["remain_size"]])
+  assert_character(value[["canceled_size"]])
+  assert_character(value[["fail_msg"]])
   return(value)
 }
 
@@ -2149,6 +3010,19 @@ assert_args_KucoinTrading__cancel_order_by_id_sync <- function(orderId, symbol) 
 
 assert_return_KucoinTrading__cancel_order_by_id_sync <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id", "origin_size", "deal_size", "remain_size", "canceled_size", "status"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
+  assert_character(value[["origin_size"]])
+  assert_no_missing_values(value[["origin_size"]])
+  assert_character(value[["deal_size"]])
+  assert_no_missing_values(value[["deal_size"]])
+  assert_character(value[["remain_size"]])
+  assert_no_missing_values(value[["remain_size"]])
+  assert_character(value[["canceled_size"]])
+  assert_no_missing_values(value[["canceled_size"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
   return(value)
 }
 
@@ -2160,6 +3034,19 @@ assert_args_KucoinTrading__cancel_order_by_client_oid_sync <- function(clientOid
 
 assert_return_KucoinTrading__cancel_order_by_client_oid_sync <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("client_oid", "origin_size", "deal_size", "remain_size", "canceled_size", "status"))
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
+  assert_character(value[["origin_size"]])
+  assert_no_missing_values(value[["origin_size"]])
+  assert_character(value[["deal_size"]])
+  assert_no_missing_values(value[["deal_size"]])
+  assert_character(value[["remain_size"]])
+  assert_no_missing_values(value[["remain_size"]])
+  assert_character(value[["canceled_size"]])
+  assert_no_missing_values(value[["canceled_size"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
   return(value)
 }
 
@@ -2198,6 +3085,11 @@ assert_args_KucoinTrading__modify_order <- function(symbol, orderId, clientOid, 
 
 assert_return_KucoinTrading__modify_order <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("new_order_id", "client_oid"))
+  assert_character(value[["new_order_id"]])
+  assert_no_missing_values(value[["new_order_id"]])
+  assert_character(value[["client_oid"]])
+  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -2210,6 +3102,11 @@ assert_args_KucoinTrading__set_dcp <- function(symbols) {
 
 assert_return_KucoinTrading__set_dcp <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("current_time", "trigger_time"))
+  assert_integer(value[["current_time"]])
+  assert_no_missing_values(value[["current_time"]])
+  assert_integer(value[["trigger_time"]])
+  assert_no_missing_values(value[["trigger_time"]])
   return(value)
 }
 
@@ -2242,6 +3139,9 @@ assert_args_KucoinTransfer__add_transfer <- function(clientOid, currency, amount
 
 assert_return_KucoinTransfer__add_transfer <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("order_id"))
+  assert_character(value[["order_id"]])
+  assert_no_missing_values(value[["order_id"]])
   return(value)
 }
 
@@ -2256,6 +3156,17 @@ assert_args_KucoinTransfer__get_transferable <- function(currency, type, tag) {
 
 assert_return_KucoinTransfer__get_transferable <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("currency", "balance", "available", "holds", "transferable"))
+  assert_character(value[["currency"]])
+  assert_no_missing_values(value[["currency"]])
+  assert_character(value[["balance"]])
+  assert_no_missing_values(value[["balance"]])
+  assert_character(value[["available"]])
+  assert_no_missing_values(value[["available"]])
+  assert_character(value[["holds"]])
+  assert_no_missing_values(value[["holds"]])
+  assert_character(value[["transferable"]])
+  assert_no_missing_values(value[["transferable"]])
   return(value)
 }
 
@@ -2284,6 +3195,9 @@ assert_args_KucoinWithdrawal__add_withdrawal <- function(currency, toAddress, am
 
 assert_return_KucoinWithdrawal__add_withdrawal <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("withdrawal_id"))
+  assert_character(value[["withdrawal_id"]])
+  assert_no_missing_values(value[["withdrawal_id"]])
   return(value)
 }
 
@@ -2294,7 +3208,9 @@ assert_args_KucoinWithdrawal__cancel_withdrawal <- function(withdrawalId) {
 
 assert_return_KucoinWithdrawal__cancel_withdrawal <- function(value) {
   assert_data_table(value)
-  assert_has_columns(value, c("withdrawal_id"))
+  assert_has_columns(value, c("withdrawal_id", "withdrawal_id"))
+  assert_character(value[["withdrawal_id"]])
+  assert_no_missing_values(value[["withdrawal_id"]])
   assert_character(value[["withdrawal_id"]])
   assert_no_missing_values(value[["withdrawal_id"]])
   return(value)
@@ -2310,6 +3226,38 @@ assert_args_KucoinWithdrawal__get_withdrawal_quotas <- function(currency, chain)
 
 assert_return_KucoinWithdrawal__get_withdrawal_quotas <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("currency", "chain", "is_withdraw_enabled", "available_amount", "remain_amount", "withdraw_min_fee", "inner_withdraw_min_fee", "withdraw_min_size", "precision", "limit_btc_amount", "used_btc_amount", "locked_amount", "quota_currency", "limit_quota_currency_amount", "used_quota_currency_amount", "reason"))
+  assert_character(value[["currency"]])
+  assert_no_missing_values(value[["currency"]])
+  assert_character(value[["chain"]])
+  assert_no_missing_values(value[["chain"]])
+  assert_logical(value[["is_withdraw_enabled"]])
+  assert_no_missing_values(value[["is_withdraw_enabled"]])
+  assert_character(value[["available_amount"]])
+  assert_no_missing_values(value[["available_amount"]])
+  assert_character(value[["remain_amount"]])
+  assert_no_missing_values(value[["remain_amount"]])
+  assert_character(value[["withdraw_min_fee"]])
+  assert_no_missing_values(value[["withdraw_min_fee"]])
+  assert_character(value[["inner_withdraw_min_fee"]])
+  assert_no_missing_values(value[["inner_withdraw_min_fee"]])
+  assert_character(value[["withdraw_min_size"]])
+  assert_no_missing_values(value[["withdraw_min_size"]])
+  assert_integer(value[["precision"]])
+  assert_no_missing_values(value[["precision"]])
+  assert_character(value[["limit_btc_amount"]])
+  assert_no_missing_values(value[["limit_btc_amount"]])
+  assert_character(value[["used_btc_amount"]])
+  assert_no_missing_values(value[["used_btc_amount"]])
+  assert_character(value[["locked_amount"]])
+  assert_no_missing_values(value[["locked_amount"]])
+  assert_character(value[["quota_currency"]])
+  assert_no_missing_values(value[["quota_currency"]])
+  assert_character(value[["limit_quota_currency_amount"]])
+  assert_no_missing_values(value[["limit_quota_currency_amount"]])
+  assert_character(value[["used_quota_currency_amount"]])
+  assert_no_missing_values(value[["used_quota_currency_amount"]])
+  assert_logical(value[["reason"]])
   return(value)
 }
 
@@ -2345,6 +3293,51 @@ assert_args_KucoinWithdrawal__get_withdrawal_by_id <- function(withdrawalId) {
 
 assert_return_KucoinWithdrawal__get_withdrawal_by_id <- function(value) {
   assert_data_table(value)
+  assert_has_columns(value, c("id", "currency", "chain_id", "chain_name", "status", "address", "memo", "is_inner", "amount", "fee", "wallet_tx_id", "created_at", "cancel_type", "uid", "currency_name", "failure_reason", "failure_reason_msg", "address_remark", "remark", "taxes", "tax_description", "tx_id", "return_status", "return_amount", "return_currency"))
+  assert_character(value[["id"]])
+  assert_no_missing_values(value[["id"]])
+  assert_character(value[["currency"]])
+  assert_no_missing_values(value[["currency"]])
+  assert_character(value[["chain_id"]])
+  assert_no_missing_values(value[["chain_id"]])
+  assert_character(value[["chain_name"]])
+  assert_no_missing_values(value[["chain_name"]])
+  assert_character(value[["status"]])
+  assert_no_missing_values(value[["status"]])
+  assert_character(value[["address"]])
+  assert_no_missing_values(value[["address"]])
+  assert_character(value[["memo"]])
+  assert_no_missing_values(value[["memo"]])
+  assert_logical(value[["is_inner"]])
+  assert_no_missing_values(value[["is_inner"]])
+  assert_character(value[["amount"]])
+  assert_no_missing_values(value[["amount"]])
+  assert_character(value[["fee"]])
+  assert_no_missing_values(value[["fee"]])
+  assert_logical(value[["wallet_tx_id"]])
+  assert_datetime(value[["created_at"]])
+  assert_no_missing_values(value[["created_at"]])
+  assert_character(value[["cancel_type"]])
+  assert_no_missing_values(value[["cancel_type"]])
+  assert_integer(value[["uid"]])
+  assert_no_missing_values(value[["uid"]])
+  assert_character(value[["currency_name"]])
+  assert_no_missing_values(value[["currency_name"]])
+  assert_character(value[["failure_reason"]])
+  assert_no_missing_values(value[["failure_reason"]])
+  assert_logical(value[["failure_reason_msg"]])
+  assert_character(value[["address_remark"]])
+  assert_no_missing_values(value[["address_remark"]])
+  assert_character(value[["remark"]])
+  assert_no_missing_values(value[["remark"]])
+  assert_logical(value[["taxes"]])
+  assert_logical(value[["tax_description"]])
+  assert_logical(value[["tx_id"]])
+  assert_character(value[["return_status"]])
+  assert_no_missing_values(value[["return_status"]])
+  assert_logical(value[["return_amount"]])
+  assert_character(value[["return_currency"]])
+  assert_no_missing_values(value[["return_currency"]])
   return(value)
 }
 

--- a/man/KucoinAccount.Rd
+++ b/man/KucoinAccount.Rd
@@ -331,7 +331,21 @@ accordingly.
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the VIP tier
 level and the sub-account counts (total, spot, margin, futures, option)
-alongside their respective maxima.
+alongside their respective maxima:
+\itemize{
+\item level (integer) the tier level.
+\item sub_quantity (integer) the sub quantity.
+\item max_default_sub_quantity (integer) the max default sub quantity.
+\item max_sub_quantity (integer) the max sub quantity.
+\item spot_sub_quantity (integer) the spot sub quantity.
+\item margin_sub_quantity (integer) the margin sub quantity.
+\item futures_sub_quantity (integer) the futures sub quantity.
+\item option_sub_quantity (integer) the option sub quantity.
+\item max_spot_sub_quantity (integer) the max spot sub quantity.
+\item max_margin_sub_quantity (integer) the max margin sub quantity.
+\item max_futures_sub_quantity (integer) the max futures sub quantity.
+\item max_option_sub_quantity (integer) the max option sub quantity.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -420,7 +434,17 @@ failures.
 (data.table | promise<data.table>) one row describing the active
 API key: its label, key ID, version, comma-separated permissions and IP
 whitelist, creation datetime (POSIXct, coerced from epoch milliseconds),
-user ID, and whether it belongs to the master account.
+user ID, and whether it belongs to the master account:
+\itemize{
+\item remark (character) an optional remark.
+\item api_key (character) the api key.
+\item api_version (integer) the api version.
+\item permission (character) the permission.
+\item ip_whitelist (character) the ip whitelist.
+\item created_at (POSIXct) the created at (UTC).
+\item uid (integer) the user identifier.
+\item is_master (logical) the is master.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -709,7 +733,13 @@ lists.
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the currency
 code, total balance, the amount available for use, and the amount held
-in open orders for the requested account.
+in open orders for the requested account:
+\itemize{
+\item currency (character) the currency code.
+\item balance (character) the total balance.
+\item available (character) the amount available.
+\item holds (character) the amount on hold.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1339,7 +1369,11 @@ for fiat.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the base taker
-fee rate and the base maker fee rate.
+fee rate and the base maker fee rate:
+\itemize{
+\item taker_fee_rate (character) the taker fee rate.
+\item maker_fee_rate (character) the maker fee rate.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1428,7 +1462,12 @@ e.g. \code{"BTC-USDT,ETH-USDT"}.}
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per trading pair, each
 giving the pair symbol, the actual taker fee rate, and the actual maker
-fee rate.
+fee rate:
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item taker_fee_rate (character) the taker fee rate.
+\item maker_fee_rate (character) the maker fee rate.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinDeposit.Rd
+++ b/man/KucoinDeposit.Rd
@@ -246,7 +246,16 @@ invoice-based deposit addresses (e.g., Lightning Network).}
 created deposit address: the generated address, its memo/tag (empty
 string if not applicable), the blockchain network name, the chain
 identifier, the target account type, the currency code, and the token
-contract address (empty for native coins) -- all character.
+contract address (empty for native coins) -- all character:
+\itemize{
+\item address (character) the address.
+\item memo (character) the address memo/tag.
+\item chain (character) the chain code.
+\item chain_id (character) the chain identifier.
+\item to (character) the destination.
+\item currency (character) the currency code.
+\item contract_address (character) the token contract address.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinFuturesAccount.Rd
+++ b/man/KucoinFuturesAccount.Rd
@@ -181,7 +181,17 @@ Default \code{"USDT"}.}
 (data.table | promise<data.table>) one row giving the futures
 account overview: total account equity, unrealised profit and loss,
 margin balance, position and order margin, frozen funds, available
-balance, and the settlement currency code.
+balance, and the settlement currency code:
+\itemize{
+\item account_equity (numeric) the account equity.
+\item unrealised_pnl (numeric) the unrealised pnl.
+\item margin_balance (numeric) the margin balance.
+\item available_balance (numeric) the available balance.
+\item available_margin (numeric) the available margin.
+\item currency (character) the currency code.
+\item risk_ratio (numeric) the risk ratio.
+\item max_withdraw_amount (numeric) the max withdraw amount.
+}
 }
 }
 \if{html}{\out{<hr>}}
@@ -544,7 +554,11 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the contract
-symbol and its current margin mode (\code{"ISOLATED"} or \code{"CROSS"}).
+symbol and its current margin mode (\code{"ISOLATED"} or \code{"CROSS"}):
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item margin_mode (character) the margin mode.
+}
 }
 }
 \if{html}{\out{<hr>}}
@@ -622,7 +636,11 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the contract
-symbol and its updated margin mode.
+symbol and its updated margin mode:
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item margin_mode (character) the margin mode.
+}
 }
 }
 \if{html}{\out{<hr>}}
@@ -688,7 +706,11 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the contract
-symbol and its current cross-margin leverage multiplier.
+symbol and its current cross-margin leverage multiplier:
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item leverage (character) the leverage.
+}
 }
 }
 \if{html}{\out{<hr>}}
@@ -767,7 +789,11 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the contract
-symbol and its updated cross-margin leverage multiplier.
+symbol and its updated cross-margin leverage multiplier:
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item leverage (character) the leverage.
+}
 }
 }
 \if{html}{\out{<hr>}}
@@ -838,7 +864,12 @@ Verified: 2026-05-23
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the contract
 symbol and the maximum number of contracts that can be opened on the
-buy and sell sides.
+buy and sell sides:
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item max_buy_open_size (integer) the max buy open size.
+\item max_sell_open_size (integer) the max sell open size.
+}
 }
 }
 \if{html}{\out{<hr>}}
@@ -987,7 +1018,13 @@ Verified: 2026-05-23
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the margin
 operation ID, contract symbol, amount deposited, and operation type
-(e.g., \code{"ADD"}).
+(e.g., \code{"ADD"}):
+\itemize{
+\item id (character) the record identifier.
+\item symbol (character) the trading pair symbol.
+\item margin (character) the margin amount.
+\item margin_type (character) the margin type.
+}
 }
 }
 \if{html}{\out{<hr>}}
@@ -1068,7 +1105,13 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the margin
-operation ID, contract symbol, amount withdrawn, and operation type.
+operation ID, contract symbol, amount withdrawn, and operation type:
+\itemize{
+\item id (character) the record identifier.
+\item symbol (character) the trading pair symbol.
+\item margin (character) the margin amount.
+\item margin_type (character) the margin type.
+}
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/KucoinFuturesMarketData.Rd
+++ b/man/KucoinFuturesMarketData.Rd
@@ -600,7 +600,20 @@ generation.
 ticker snapshot: the sequence number, contract symbol, last trade side,
 size, trade identifier and price, the best bid and ask prices with their
 sizes, and the ticker datetime (POSIXct, coerced from the nanosecond
-timestamp).
+timestamp):
+\itemize{
+\item sequence (integer) the sequence.
+\item symbol (character) the trading pair symbol.
+\item side (character) the order side.
+\item size (integer) the size.
+\item price (character) the price.
+\item best_bid_size (integer) the best bid size.
+\item best_bid_price (character) the best bid price.
+\item best_ask_price (character) the best ask price.
+\item best_ask_size (integer) the best ask size.
+\item trade_id (character) the trade identifier.
+\item ts (POSIXct) the ts (UTC).
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -792,7 +805,16 @@ Default \code{20}.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) the level-2 order book in long
-format (ts, sequence, side, level, price, size, and symbol when present).
+format (ts, sequence, side, level, price, size, and symbol when present):
+\itemize{
+\item ts (POSIXct) the ts (UTC).
+\item sequence (character) the sequence.
+\item side (character) the order side.
+\item level (integer) the tier level.
+\item price (numeric) the price.
+\item size (numeric) the size.
+\item symbol (character) the trading pair symbol.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -890,7 +912,16 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) the level-2 order book in long
-format (ts, sequence, side, level, price, size, and symbol when present).
+format (ts, sequence, side, level, price, size, and symbol when present):
+\itemize{
+\item ts (POSIXct) the ts (UTC).
+\item sequence (character) the sequence.
+\item side (character) the order side.
+\item level (integer) the tier level.
+\item price (numeric) the price.
+\item size (numeric) the size.
+\item symbol (character) the trading pair symbol.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1206,7 +1237,14 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row giving the current mark
 price: the contract symbol, price granularity in milliseconds, the rate
 datetime (POSIXct, coerced from epoch milliseconds), the mark price, and
-the underlying index price.
+the underlying index price:
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item granularity (integer) the granularity.
+\item time_point (POSIXct) the time point (UTC).
+\item value (numeric) the order value.
+\item index_price (numeric) the index price.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1301,7 +1339,18 @@ funding rate: the contract symbol, funding interval in milliseconds, the
 rate datetime (POSIXct, coerced from epoch milliseconds), the current
 funding rate, the daily interest rate, the funding-rate cap and floor, the
 funding period, and the next funding settlement datetime (POSIXct, coerced
-from epoch milliseconds).
+from epoch milliseconds):
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item granularity (integer) the granularity.
+\item time_point (POSIXct) the time point (UTC).
+\item value (numeric) the order value.
+\item daily_interest_rate (numeric) the daily interest rate.
+\item funding_rate_cap (numeric) the funding rate cap.
+\item funding_rate_floor (numeric) the funding rate floor.
+\item period (integer) the period.
+\item funding_time (POSIXct) the funding time (UTC).
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1483,7 +1532,10 @@ Verified: 2026-05-23
 
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the server
-datetime (POSIXct, coerced from epoch milliseconds).
+datetime (POSIXct, coerced from epoch milliseconds):
+\itemize{
+\item server_time (POSIXct) the server time (UTC).
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1559,7 +1611,11 @@ windows.
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the operational
 status (\code{"open"}, \code{"close"}, or \code{"cancelonly"}) and an optional
-remark/message.
+remark/message:
+\itemize{
+\item status (character) the status.
+\item msg (character) the msg.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinFuturesTrading.Rd
+++ b/man/KucoinFuturesTrading.Rd
@@ -550,7 +550,11 @@ accidental position increases.
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the system-assigned order ID and the client-provided
-order ID.
+order ID:
+\itemize{
+\item order_id (character) the system order identifier.
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -726,7 +730,11 @@ permissions and symbols are correct.
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the simulated order ID and the client-provided order
-ID.
+ID:
+\itemize{
+\item order_id (character) the system order identifier.
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -884,7 +892,11 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per order result giving the system-assigned order ID, the
-client-provided order ID, the futures symbol, the per-order status code, and the per-order status message.
+client-provided order ID, the futures symbol, the per-order status code, and the per-order status message:
+\itemize{
+\item order_id (character) the system order identifier.
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1252,7 +1264,10 @@ cancels all untriggered stop orders across all symbols.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per cancelled order giving the cancelled order ID; an empty
-data.table if no orders matched.
+data.table if no orders matched:
+\itemize{
+\item cancelled_order_id (character) the cancelled order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1382,7 +1397,25 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row of full order details, including the creation and last-updated
-datetimes (POSIXct, coerced from epoch milliseconds).
+datetimes (POSIXct, coerced from epoch milliseconds):
+\itemize{
+\item id (character) the record identifier.
+\item symbol (character) the trading pair symbol.
+\item type (character) the type.
+\item side (character) the order side.
+\item price (character) the price.
+\item size (integer) the size.
+\item value (character) the order value.
+\item deal_value (character) the filled value.
+\item deal_size (integer) the filled size.
+\item leverage (integer) the leverage.
+\item margin_mode (character) the margin mode.
+\item position_side (character) the position side.
+\item status (character) the status.
+\item created_at (POSIXct) the created at (UTC).
+\item updated_at (POSIXct) the updated at (UTC).
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1510,7 +1543,25 @@ Verified: 2026-05-23
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-(data.table | promise<data.table>) one row of full order details; same columns as \code{get_order_by_id()}.
+(data.table | promise<data.table>) one row of full order details; same columns as \code{get_order_by_id()}:
+\itemize{
+\item id (character) the record identifier.
+\item symbol (character) the trading pair symbol.
+\item type (character) the type.
+\item side (character) the order side.
+\item price (character) the price.
+\item size (integer) the size.
+\item value (character) the order value.
+\item deal_value (character) the filled value.
+\item deal_size (integer) the filled size.
+\item leverage (integer) the leverage.
+\item margin_mode (character) the margin mode.
+\item position_side (character) the position side.
+\item status (character) the status.
+\item created_at (POSIXct) the created at (UTC).
+\item updated_at (POSIXct) the updated at (UTC).
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1644,7 +1695,25 @@ open orders, \code{status = "done"} for closed orders. Optional: \code{symbol},
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per order record (same columns as \code{get_order_by_id()}); an
-empty data.table if no orders match the filters.
+empty data.table if no orders match the filters:
+\itemize{
+\item id (character) the record identifier.
+\item symbol (character) the trading pair symbol.
+\item type (character) the type.
+\item side (character) the order side.
+\item price (character) the price.
+\item size (integer) the size.
+\item value (character) the order value.
+\item deal_value (character) the filled value.
+\item deal_size (integer) the filled size.
+\item leverage (integer) the leverage.
+\item margin_mode (character) the margin mode.
+\item position_side (character) the position side.
+\item status (character) the status.
+\item created_at (POSIXct) the created at (UTC).
+\item updated_at (POSIXct) the updated at (UTC).
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1782,7 +1851,25 @@ list.
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per order record (same columns as \code{get_order_by_id()}); an
-empty data.table if no recently closed orders exist.
+empty data.table if no recently closed orders exist:
+\itemize{
+\item id (character) the record identifier.
+\item symbol (character) the trading pair symbol.
+\item type (character) the type.
+\item side (character) the order side.
+\item price (character) the price.
+\item size (integer) the size.
+\item value (character) the order value.
+\item deal_value (character) the filled value.
+\item deal_size (integer) the filled size.
+\item leverage (integer) the leverage.
+\item margin_mode (character) the margin mode.
+\item position_side (character) the position side.
+\item status (character) the status.
+\item created_at (POSIXct) the created at (UTC).
+\item updated_at (POSIXct) the updated at (UTC).
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -2166,7 +2253,26 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per fill (same columns as \code{get_fills()}); an empty data.table
-if no recent fills exist.
+if no recent fills exist:
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item trade_id (character) the trade identifier.
+\item order_id (character) the system order identifier.
+\item side (character) the order side.
+\item liquidity (character) the liquidity role.
+\item force_taker (logical) the force taker.
+\item price (character) the price.
+\item size (integer) the size.
+\item value (character) the order value.
+\item fee_rate (character) the fee rate.
+\item fix_fee (character) the fix fee.
+\item fee_currency (character) the fee currency.
+\item fee (character) the fee.
+\item order_type (character) the order type.
+\item trade_type (character) the trade type.
+\item trade_time (POSIXct) the trade time (UTC).
+\item created_at (POSIXct) the created at (UTC).
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -2261,7 +2367,14 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the total buy order size, total sell order
-size, total buy order cost, total sell order cost, and the settlement currency.
+size, total buy order cost, total sell order cost, and the settlement currency:
+\itemize{
+\item open_order_buy_size (integer) the open order buy size.
+\item open_order_sell_size (integer) the open order sell size.
+\item open_order_buy_cost (character) the open order buy cost.
+\item open_order_sell_cost (character) the open order sell cost.
+\item settle_currency (character) the settle currency.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -2376,7 +2489,12 @@ When NULL, DCP applies to all symbols.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the configured timeout in seconds, the applicable
-symbols (empty for all), and the server time when DCP was set.
+symbols (empty for all), and the server time when DCP was set:
+\itemize{
+\item timeout (integer) the timeout.
+\item symbols (character) the symbols.
+\item current_time (numeric) the current time.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -2478,7 +2596,12 @@ When NULL, returns the global DCP configuration.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the configured timeout in seconds, the applicable
-symbols, and the server time of the query.
+symbols, and the server time of the query:
+\itemize{
+\item timeout (integer) the timeout.
+\item symbols (character) the symbols.
+\item current_time (numeric) the current time.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinLending.Rd
+++ b/man/KucoinLending.Rd
@@ -393,7 +393,10 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row with the lending order
-number.
+number:
+\itemize{
+\item order_no (character) the order number.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -480,7 +483,11 @@ Verified: 2026-05-23
 \item currency (character) the lending currency.
 \item purchase_order_no (character) the modified order number.
 \item interest_rate (numeric) the new interest rate.
-\item status (character) the local outcome marker, always \code{"success"}.
+\item status (character) the local outcome marker, always \code{"success"}:
+\item currency (character) the currency code.
+\item purchase_order_no (character) the purchase order no.
+\item interest_rate (numeric) the interest rate.
+\item status (character) the status.
 }
 }
 \subsection{Examples}{
@@ -658,7 +665,10 @@ from.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row with the redemption order
-number.
+number:
+\itemize{
+\item order_no (character) the order number.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinMarginData.Rd
+++ b/man/KucoinMarginData.Rd
@@ -362,7 +362,13 @@ Verified: 2026-05-23
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per supported currency, with the \code{currencyList} array exploded
 so each currency carries the replicated config-level fields for maximum leverage, warning debt ratio and
-liquidation debt ratio; an empty \code{currencyList} yields a zero-row data.table with this schema.
+liquidation debt ratio; an empty \code{currencyList} yields a zero-row data.table with this schema:
+\itemize{
+\item currency (character) the currency code.
+\item max_leverage (integer) the max leverage.
+\item warning_debt_ratio (character) the warning debt ratio.
+\item liq_debt_ratio (character) the liq debt ratio.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -445,7 +451,13 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row per (currency, tier) pair, with the nested \code{currencyList} and
 \code{items} arrays cross-joined into a flat long table carrying the currency code, lower and upper bounds of the
 collateral range, and the collateral ratio applied in that range; an empty response yields a zero-row
-data.table with this schema.
+data.table with this schema:
+\itemize{
+\item currency (character) the currency code.
+\item lower_limit (character) the lower limit.
+\item upper_limit (character) the upper limit.
+\item collateral_ratio (character) the collateral ratio.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinMarginTrading.Rd
+++ b/man/KucoinMarginTrading.Rd
@@ -577,7 +577,11 @@ Default \code{FALSE}.}
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the
 KuCoin-assigned order identifier and the client-provided order
-identifier (NA if not supplied).
+identifier (NA if not supplied):
+\itemize{
+\item order_id (character) the system order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -732,7 +736,11 @@ Default \code{FALSE}.}
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the
 KuCoin-assigned order identifier, the client-provided order identifier,
-the amount borrowed, and the loan application ID.
+the amount borrowed, and the loan application ID:
+\itemize{
+\item order_id (character) the system order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -888,7 +896,11 @@ Default \code{FALSE}.}
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the
 KuCoin-assigned order identifier and the client-provided order
-identifier (NA if not supplied).
+identifier (NA if not supplied):
+\itemize{
+\item order_id (character) the system order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1006,7 +1018,11 @@ Trading pair (e.g., \code{"BTC-USDT"}).}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the borrow order
-number and the amount actually borrowed.
+number and the amount actually borrowed:
+\itemize{
+\item order_no (character) the order number.
+\item actual_size (character) the actual filled size.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1530,7 +1546,9 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row:
 \itemize{
 \item leverage (numeric) the new leverage multiplier.
-\item status (character) the local outcome marker, always \code{"success"}.
+\item status (character) the local outcome marker, always \code{"success"}:
+\item leverage (numeric) the leverage.
+\item status (character) the status.
 }
 }
 \subsection{Examples}{

--- a/man/KucoinMarketData.Rd
+++ b/man/KucoinMarketData.Rd
@@ -415,7 +415,16 @@ fetch (default \code{Inf} for all).}
 (data.table | promise<data.table>) one row per announcement, each
 giving the announcement ID, title, \verb{;}-separated category tags, short
 description, creation datetime (POSIXct, coerced from epoch milliseconds),
-language code, and the full announcement URL.
+language code, and the full announcement URL:
+\itemize{
+\item ann_id (integer) the ann id.
+\item ann_title (character) the ann title.
+\item ann_type (character | NA) the ann type.
+\item ann_desc (character) the ann desc.
+\item c_time (POSIXct) the c time (UTC).
+\item language (character) the language.
+\item ann_url (character) the ann url.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -751,7 +760,37 @@ metadata: the pair identifier, base/quote/fee currencies, market segment,
 the base and quote minimum and maximum order sizes, the base and quote
 size increments, the price increment and price-limit rate, the minimum
 order value in quote currency, the margin- and trading-enabled flags, and
-the maker and taker fee coefficients.
+the maker and taker fee coefficients:
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item name (character) the name.
+\item base_currency (character) the base currency.
+\item quote_currency (character) the quote currency.
+\item fee_currency (character) the fee currency.
+\item market (character) the market.
+\item base_min_size (character) the base min size.
+\item quote_min_size (character) the quote min size.
+\item base_max_size (character) the base max size.
+\item quote_max_size (character) the quote max size.
+\item base_increment (character) the base increment.
+\item quote_increment (character) the quote increment.
+\item price_increment (character) the price increment.
+\item price_limit_rate (character) the price limit rate.
+\item min_funds (character) the min funds.
+\item is_margin_enabled (logical) the is margin enabled.
+\item enable_trading (logical) the enable trading.
+\item fee_category (integer) the fee category.
+\item maker_fee_coefficient (character) the maker fee coefficient.
+\item taker_fee_coefficient (character) the taker fee coefficient.
+\item st (logical) whether the symbol is in special treatment.
+\item callauction_is_enabled (logical) the callauction is enabled.
+\item callauction_price_floor (logical | NA) the callauction price floor.
+\item callauction_price_ceiling (logical | NA) the callauction price ceiling.
+\item callauction_first_stage_start_time (logical | NA) the callauction first stage start time.
+\item callauction_second_stage_start_time (logical | NA) the callauction second stage start time.
+\item callauction_third_stage_start_time (logical | NA) the callauction third stage start time.
+\item trading_start_time (logical | NA) the trading start time.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -928,7 +967,37 @@ available values.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per trading pair,
-carrying the same symbol metadata as \code{get_symbol()}.
+carrying the same symbol metadata as \code{get_symbol()}:
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item name (character) the name.
+\item base_currency (character) the base currency.
+\item quote_currency (character) the quote currency.
+\item fee_currency (character) the fee currency.
+\item market (character) the market.
+\item base_min_size (character) the base min size.
+\item quote_min_size (character) the quote min size.
+\item base_max_size (character) the base max size.
+\item quote_max_size (character) the quote max size.
+\item base_increment (character) the base increment.
+\item quote_increment (character) the quote increment.
+\item price_increment (character) the price increment.
+\item price_limit_rate (character) the price limit rate.
+\item min_funds (character) the min funds.
+\item is_margin_enabled (logical) the is margin enabled.
+\item enable_trading (logical) the enable trading.
+\item fee_category (integer) the fee category.
+\item maker_fee_coefficient (character) the maker fee coefficient.
+\item taker_fee_coefficient (character) the taker fee coefficient.
+\item st (logical) whether the symbol is in special treatment.
+\item callauction_is_enabled (logical) the callauction is enabled.
+\item callauction_price_floor (logical | NA) the callauction price floor.
+\item callauction_price_ceiling (logical | NA) the callauction price ceiling.
+\item callauction_first_stage_start_time (logical | NA) the callauction first stage start time.
+\item callauction_second_stage_start_time (logical | NA) the callauction second stage start time.
+\item callauction_third_stage_start_time (logical | NA) the callauction third stage start time.
+\item trading_start_time (logical | NA) the trading start time.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1020,7 +1089,17 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row giving the Level 1
 snapshot: server datetime (POSIXct, coerced from epoch milliseconds), the
 order book sequence number, the last trade price and size, and the best
-bid and ask prices with their sizes.
+bid and ask prices with their sizes:
+\itemize{
+\item time (POSIXct) the time (UTC).
+\item sequence (character) the sequence.
+\item price (character) the price.
+\item size (character) the size.
+\item best_bid (character) the best bid price.
+\item best_bid_size (character) the best bid size.
+\item best_ask (character) the best ask price.
+\item best_ask_size (character) the best ask size.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1120,7 +1199,24 @@ giving the pair symbol and display name, the best bid and ask prices with
 their sizes, the 24-hour change rate and amount, the 24-hour high, low,
 base-currency volume and quote-currency volume, the last trade and average
 prices, the taker and maker fee rates, and the snapshot datetime (POSIXct,
-coerced from epoch milliseconds).
+coerced from epoch milliseconds):
+\itemize{
+\item symbol (character) the trading pair symbol.
+\item symbol_name (character) the symbol name.
+\item buy (character) the best bid price.
+\item sell (character) the best ask price.
+\item change_rate (character) the 24h change rate.
+\item change_price (character) the 24h change in price.
+\item high (character) the 24h high price.
+\item low (character) the 24h low price.
+\item vol (character) the 24h traded volume.
+\item vol_value (character) the 24h traded turnover.
+\item last (character) the last traded price.
+\item average_price (character) the average price.
+\item taker_fee_rate (character) the taker fee rate.
+\item maker_fee_rate (character) the maker fee rate.
+\item time (POSIXct) the time (UTC).
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1212,7 +1308,15 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row per recent trade, each
 giving the trade sequence number, price, quantity, direction (\code{"buy"} or
 \code{"sell"}), and the trade datetime (POSIXct, coerced from the nanosecond
-timestamp).
+timestamp):
+\itemize{
+\item sequence (character) the sequence.
+\item side (character) the order side.
+\item price (character) the price.
+\item size (character) the size.
+\item time (POSIXct) the time (UTC).
+\item trade_id (character) the trade identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1494,7 +1598,25 @@ Verified: 2026-05-23
 milliseconds), the trading pair, the best bid and ask prices, the 24-hour
 change rate and amount, the 24-hour high, low, base-currency volume and
 quote-currency volume, the last trade and average prices, and the taker
-and maker fee rates.
+and maker fee rates:
+\itemize{
+\item time (POSIXct) the time (UTC).
+\item symbol (character) the trading pair symbol.
+\item buy (character) the best bid price.
+\item sell (character) the best ask price.
+\item change_rate (character) the 24h change rate.
+\item change_price (character) the 24h change in price.
+\item high (character) the 24h high price.
+\item low (character) the 24h low price.
+\item vol (character) the 24h traded volume.
+\item vol_value (character) the 24h traded turnover.
+\item last (character) the last traded price.
+\item average_price (character) the average price.
+\item taker_fee_rate (character) the taker fee rate.
+\item maker_fee_rate (character) the maker fee rate.
+\item taker_coefficient (character) the taker fee coefficient.
+\item maker_coefficient (character) the maker fee coefficient.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1567,7 +1689,8 @@ Verified: 2026-05-23
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per market segment:
 \itemize{
-\item market (character) the segment identifier, e.g. \code{"USDS"}, \code{"DeFi"}.
+\item market (character) the segment identifier, e.g. \code{"USDS"}, \code{"DeFi"}:
+\item market (character) the market.
 }
 }
 \subsection{Examples}{
@@ -1749,7 +1872,9 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row:
 \itemize{
 \item server_time (numeric) the server clock in epoch milliseconds.
-\item datetime (POSIXct) the same instant as a POSIXct (UTC).
+\item datetime (POSIXct) the same instant as a POSIXct (UTC):
+\item server_time (numeric) the server time.
+\item datetime (POSIXct) the datetime (UTC).
 }
 }
 \subsection{Examples}{
@@ -1819,7 +1944,11 @@ Verified: 2026-05-23
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the operational
 status (\code{"open"}, \code{"close"}, or \code{"cancelonly"}) and an optional
-remark/message.
+remark/message:
+\itemize{
+\item status (character) the status.
+\item msg (character) the msg.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinOcoOrders.Rd
+++ b/man/KucoinOcoOrders.Rd
@@ -349,7 +349,11 @@ spot trading.}
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the
 KuCoin-assigned OCO order identifier and the client-provided order
-identifier (NA if not supplied).
+identifier (NA if not supplied):
+\itemize{
+\item order_id (character) the system order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -752,7 +756,14 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row giving the OCO order
 identifier, trading pair, client-assigned order identifier, order
 creation datetime (POSIXct, coerced from epoch milliseconds), and order
-status (e.g., \code{"NEW"}, \code{"DONE"}, \code{"TRIGGERED"}).
+status (e.g., \code{"NEW"}, \code{"DONE"}, \code{"TRIGGERED"}):
+\itemize{
+\item order_id (character) the system order identifier.
+\item symbol (character) the trading pair symbol.
+\item client_oid (character) the client-supplied order identifier.
+\item order_time (POSIXct) the order time (UTC).
+\item status (character) the status.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -850,7 +861,14 @@ placing the OCO order (e.g., \code{"my-bot-oco-001"}).}
 (data.table | promise<data.table>) one row giving the
 KuCoin-assigned OCO order identifier, trading pair, client-assigned order
 identifier, order creation datetime (POSIXct, coerced from epoch
-milliseconds), and order status (e.g., \code{"NEW"}, \code{"DONE"}, \code{"TRIGGERED"}).
+milliseconds), and order status (e.g., \code{"NEW"}, \code{"DONE"}, \code{"TRIGGERED"}):
+\itemize{
+\item order_id (character) the system order identifier.
+\item symbol (character) the trading pair symbol.
+\item client_oid (character) the client-supplied order identifier.
+\item order_time (POSIXct) the order time (UTC).
+\item status (character) the status.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -970,7 +988,21 @@ milliseconds), and overall OCO order status, with the nested \code{orders}
 array (typically the limit leg plus the stop-limit leg) exploded to long
 format by replicating the parent OCO row once per sub-order and adding
 each sub-order's id, symbol, side, price, size, status, and stop price
-(present only on the stop leg) as \code{sub_order_}-prefixed columns.
+(present only on the stop leg) as \code{sub_order_}-prefixed columns:
+\itemize{
+\item order_id (character) the system order identifier.
+\item symbol (character) the trading pair symbol.
+\item client_oid (character) the client-supplied order identifier.
+\item order_time (POSIXct) the order time (UTC).
+\item status (character) the status.
+\item sub_order_id (character) the sub order id.
+\item sub_order_symbol (character) the sub order symbol.
+\item sub_order_side (character) the sub order side.
+\item sub_order_price (character) the sub order price.
+\item sub_order_size (character) the sub order size.
+\item sub_order_status (character) the sub order status.
+\item sub_order_stop_price (character | NA) the sub order stop price.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinStopOrders.Rd
+++ b/man/KucoinStopOrders.Rd
@@ -424,7 +424,10 @@ spot trading.}
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the
 KuCoin-assigned stop order identifier and the client-provided order
-identifier (NA if not supplied).
+identifier (NA if not supplied):
+\itemize{
+\item order_id (character) the system order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -620,7 +623,11 @@ Required to disambiguate client OIDs across different trading pairs.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the KuCoin order
-ID and the client-assigned order ID of the cancelled stop order.
+ID and the client-assigned order ID of the cancelled stop order:
+\itemize{
+\item cancelled_order_id (character) the cancelled order identifier.
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinSubAccount.Rd
+++ b/man/KucoinSubAccount.Rd
@@ -269,7 +269,13 @@ the sub-account (1-24 chars).}
 \subsection{Returns}{
 (data.table | promise<data.table>) one row with the newly created
 sub-account details: the unique user ID \code{uid}, the login name \code{sub_name},
-the \code{remarks} string, and the granted permission \code{access}.
+the \code{remarks} string, and the granted permission \code{access}:
+\itemize{
+\item uid (integer) the user identifier.
+\item sub_name (character) the sub name.
+\item remarks (character) an optional remark.
+\item access (character) the access.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinTrading.Rd
+++ b/man/KucoinTrading.Rd
@@ -539,7 +539,11 @@ Mutually exclusive with \code{size}. Not applicable for limit orders.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the KuCoin-assigned order identifier and the
-client-provided order identifier.
+client-provided order identifier:
+\itemize{
+\item order_id (character) the system order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -696,7 +700,11 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the simulated order identifier and the client-provided
-order identifier.
+order identifier:
+\itemize{
+\item order_id (character) the system order identifier.
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -822,7 +830,13 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per order giving the KuCoin order ID, client order ID, the
-success flag, and any failure message.
+success flag, and any failure message:
+\itemize{
+\item order_id (character | NA) the system order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
+\item success (logical) whether the order succeeded.
+\item fail_msg (character | NA) the failure message.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -899,7 +913,10 @@ Verified: 2026-05-23
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-(data.table | promise<data.table>) one row giving the cancelled order ID.
+(data.table | promise<data.table>) one row giving the cancelled order ID:
+\itemize{
+\item order_id (character) the system order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -970,7 +987,10 @@ Verified: 2026-05-23
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-(data.table | promise<data.table>) one row giving the cancelled client order ID.
+(data.table | promise<data.table>) one row giving the cancelled client order ID:
+\itemize{
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1050,7 +1070,11 @@ Verified: 2026-05-23
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-(data.table | promise<data.table>) one row giving the cancellation result.
+(data.table | promise<data.table>) one row giving the cancellation result:
+\itemize{
+\item order_id (character) the system order identifier.
+\item cancel_size (character) the cancelled size.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1128,7 +1152,8 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row giving the cancellation
 response:
 \itemize{
-\item result (character) the KuCoin response string, e.g. \code{"success"}.
+\item result (character) the KuCoin response string, e.g. \code{"success"}:
+\item result (character) the result.
 }
 }
 \subsection{Examples}{
@@ -1201,7 +1226,9 @@ Verified: 2026-05-23
 an empty (but typed) data.table if no orders were open:
 \itemize{
 \item symbol (character) the trading pair, e.g. \code{"BTC-USDT"}.
-\item status (character) per-symbol outcome, \code{"succeed"} or \code{"failed"}.
+\item status (character) per-symbol outcome, \code{"succeed"} or \code{"failed"}:
+\item symbol (character) the trading pair symbol.
+\item status (character) the status.
 }
 }
 \subsection{Examples}{
@@ -1306,7 +1333,17 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row of full order details, including the creation and last-updated
-datetimes (POSIXct) when timestamps are present.
+datetimes (POSIXct) when timestamps are present:
+\itemize{
+\item order_id (character) the system order identifier.
+\item symbol (character) the trading pair symbol.
+\item side (character) the order side.
+\item type (character) the type.
+\item price (character) the price.
+\item size (character) the size.
+\item created_at (POSIXct) the created at (UTC).
+\item last_updated_at (POSIXct) the last updated at (UTC).
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1410,7 +1447,13 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row of full order details, including the creation and last-updated
-datetimes (POSIXct).
+datetimes (POSIXct):
+\itemize{
+\item client_oid (character) the client-supplied order identifier.
+\item symbol (character) the trading pair symbol.
+\item side (character) the order side.
+\item created_at (POSIXct) the created at (UTC).
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1619,7 +1662,8 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row per trading pair that
 has at least one open order:
 \itemize{
-\item symbols (character) the trading pair, e.g. \code{"BTC-USDT"}.
+\item symbols (character) the trading pair, e.g. \code{"BTC-USDT"}:
+\item symbols (character) the symbols.
 }
 }
 \subsection{Examples}{
@@ -1866,7 +1910,13 @@ If NULL, returns closed orders across all symbols.}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-(data.table | promise<data.table>) one row per closed order, including the creation datetime (POSIXct).
+(data.table | promise<data.table>) one row per closed order, including the creation datetime (POSIXct):
+\itemize{
+\item order_id (character) the system order identifier.
+\item symbol (character) the trading pair symbol.
+\item side (character) the order side.
+\item created_at (POSIXct) the created at (UTC).
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -2143,7 +2193,17 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row per order giving the order and client identifiers, the success
-flag, the fill status, and the filled, remaining, and cancelled quantities.
+flag, the fill status, and the filled, remaining, and cancelled quantities:
+\itemize{
+\item order_id (character | NA) the system order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
+\item success (logical) whether the order succeeded.
+\item status (character | NA) the status.
+\item deal_size (character | NA) the filled size.
+\item remain_size (character | NA) the unfilled size.
+\item canceled_size (character | NA) the cancelled size.
+\item fail_msg (character | NA) the failure message.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -2233,7 +2293,15 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the order ID, the original, filled, remaining, and
-cancelled sizes, and the fill status.
+cancelled sizes, and the fill status:
+\itemize{
+\item order_id (character) the system order identifier.
+\item origin_size (character) the original size.
+\item deal_size (character) the filled size.
+\item remain_size (character) the unfilled size.
+\item canceled_size (character) the cancelled size.
+\item status (character) the status.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -2311,7 +2379,15 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the client order ID, the original, filled, remaining,
-and cancelled sizes, and the fill status.
+and cancelled sizes, and the fill status:
+\itemize{
+\item client_oid (character) the client-supplied order identifier.
+\item origin_size (character) the original size.
+\item deal_size (character) the filled size.
+\item remain_size (character) the unfilled size.
+\item canceled_size (character) the cancelled size.
+\item status (character) the status.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -2419,7 +2495,11 @@ Verified: 2026-05-23
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the replacement order's ID and the original client
-order ID.
+order ID:
+\itemize{
+\item new_order_id (character) the new order identifier.
+\item client_oid (character) the client-supplied order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -2516,7 +2596,11 @@ Empty or NULL applies to all pairs.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the current server time and the time at which
-cancellation will trigger, both in seconds.
+cancellation will trigger, both in seconds:
+\itemize{
+\item current_time (integer) the current server time, in epoch seconds.
+\item trigger_time (integer) the time at which cancellation triggers, in epoch seconds.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinTransfer.Rd
+++ b/man/KucoinTransfer.Rd
@@ -272,7 +272,10 @@ ISOLATED/ISOLATED_V2 destination accounts (e.g., \code{"BTC-USDT"}).}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row with column \code{order_id}
-(character): the transfer order identifier.
+(character): the transfer order identifier:
+\itemize{
+\item order_id (character) the system order identifier.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -392,7 +395,14 @@ Verified: 2026-05-23
 breakdown: \code{currency} (currency code), \code{balance} (total funds),
 \code{available} (funds available to withdraw or trade), \code{holds} (funds
 locked in open orders), and \code{transferable} (funds available for
-transfer) -- all character.
+transfer) -- all character:
+\itemize{
+\item currency (character) the currency code.
+\item balance (character) the total balance.
+\item available (character) the amount available.
+\item holds (character) the amount on hold.
+\item transferable (character) the transferable amount.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/man/KucoinWithdrawal.Rd
+++ b/man/KucoinWithdrawal.Rd
@@ -304,7 +304,10 @@ withdrawal.}
 }
 \subsection{Returns}{
 (data.table | promise<data.table>) one row with column
-\code{withdrawal_id} (character): the unique withdrawal identifier.
+\code{withdrawal_id} (character): the unique withdrawal identifier:
+\itemize{
+\item withdrawal_id (character) the withdrawal id.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -409,7 +412,8 @@ cancel.}
 withdrawal ID echoed from the input (KuCoin returns \code{null} data on a
 successful cancel):
 \itemize{
-\item withdrawal_id (character) the cancelled withdrawal ID.
+\item withdrawal_id (character) the cancelled withdrawal ID:
+\item withdrawal_id (character) the withdrawal id.
 }
 }
 \subsection{Examples}{
@@ -524,7 +528,25 @@ quota details (currency, limit_btc_amount, used_btc_amount,
 quota_currency, limit_quota_currency_amount, used_quota_currency_amount,
 remain_amount, available_amount, withdraw_min_fee, inner_withdraw_min_fee,
 withdraw_min_size, is_withdraw_enabled, precision, chain, reason,
-locked_amount, ...).
+locked_amount, ...):
+\itemize{
+\item currency (character) the currency code.
+\item chain (character) the chain code.
+\item is_withdraw_enabled (logical) the is withdraw enabled.
+\item available_amount (character) the available amount.
+\item remain_amount (character) the remain amount.
+\item withdraw_min_fee (character) the withdraw min fee.
+\item inner_withdraw_min_fee (character) the inner withdraw min fee.
+\item withdraw_min_size (character) the withdraw min size.
+\item precision (integer) the decimal precision.
+\item limit_btc_amount (character) the limit btc amount.
+\item used_btc_amount (character) the used btc amount.
+\item locked_amount (character) the locked amount.
+\item quota_currency (character) the quota currency.
+\item limit_quota_currency_amount (character) the limit quota currency amount.
+\item used_quota_currency_amount (character) the used quota currency amount.
+\item reason (logical | NA) the reason, when present.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -783,7 +805,34 @@ withdrawal can still be cancelled.
 withdrawal detail (id, currency, chain_id, chain_name, status, address,
 memo, is_inner, amount, fee, wallet_tx_id, cancel_type, failure_reason,
 failure_reason_msg, created_at, ...), with \code{created_at} coerced to
-POSIXct.
+POSIXct:
+\itemize{
+\item id (character) the record identifier.
+\item currency (character) the currency code.
+\item chain_id (character) the chain identifier.
+\item chain_name (character) the chain name.
+\item status (character) the status.
+\item address (character) the address.
+\item memo (character) the address memo/tag.
+\item is_inner (logical) the is inner.
+\item amount (character) the amount.
+\item fee (character) the fee.
+\item wallet_tx_id (logical | NA) the wallet tx id.
+\item created_at (POSIXct) the created at (UTC).
+\item cancel_type (character) the cancel type.
+\item uid (integer) the user identifier.
+\item currency_name (character) the currency name.
+\item failure_reason (character) the failure reason.
+\item failure_reason_msg (logical | NA) the failure reason msg.
+\item address_remark (character) the address remark.
+\item remark (character) an optional remark.
+\item taxes (logical | NA) the taxes.
+\item tax_description (logical | NA) the tax description.
+\item tx_id (logical | NA) the tx id.
+\item return_status (character) the return status.
+\item return_amount (logical | NA) the return amount.
+\item return_currency (character) the return currency.
+}
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}


### PR DESCRIPTION
Plain-English: this change makes the docs say exactly which columns each table-returning method gives back and what type each column is (text, number, whole number, true/false, timestamp). Before, the docs just said "a data.table" with no detail. As a bonus, writing the columns down automatically switches on a runtime check that the real response matches the documented shape, so a future KuCoin API change that drops or retypes a column is caught at the boundary instead of flowing silently downstream.

## What changed
- 83 public methods that always return a fixed-shape `data.table` now document each column as a typed nested bullet (roxyassert grammar: bare element types — `character`, `integer`, `numeric`, `logical`, `POSIXct` — with ` | NA` where a column can legitimately be missing).
- Documenting the columns regenerates `assert_has_columns` plus the per-column type asserts in `contracts-generated.R`; the loose `assert_data_table` check becomes a real shape contract enforced at the public boundary, for the synchronous value and the resolved value of a promise alike.
- Types are ground-truth, not guessed: every method was driven against its committed test fixtures and the actual column classes recorded, so each documented type matches what the parser emits (KuCoin string-numbers stay `character`, coerced millisecond/nanosecond timestamps are `POSIXct`, counts are `integer`).

## Left generic on purpose (variable-shape, matching the existing flattener convention)
- Methods that can return a zero-column empty `data.table` on an empty response (list/paginated histories, cancel endpoints): `assert_has_columns` cannot hold on an empty table without a typed-empty constructor, which is out of scope for a docs change.
- The futures position tables (`get_position` / `get_positions`), whose numeric fields arrive sometimes as numbers and sometimes as strings.
- The wide futures-contract metadata tables (`get_contract` / `get_all_contracts`).

## Validation
- `devtools::test()`: FAIL 0 (PASS 1353; 2 live-only skips).
- `lintr`: 0 warnings; `air` formatted; docs regenerated.
- Patch bump to 4.2.3 with a NEWS entry.