### PR TITLE
fix: ground column contracts + fixtures in live KuCoin reality

### DIFF
--- a/R/KucoinAccount.R
+++ b/R/KucoinAccount.R
@@ -188,8 +188,8 @@ KucoinAccount <- R6::R6Class(
     #' ### Automated Trading Usage
     #' - **Permission Verification**: Confirm the key has `Trade` permission before placing orders in a bot startup
     #'   routine.
-    #' - **IP Whitelist Check**: Validate that the bot's server IP is in `is_master`/`ip_whitelist` to avoid auth
-    #'   failures.
+    #' - **IP Whitelist Check**: Confirm the key's IP-whitelist settings on KuCoin allow the bot's server IP to
+    #'   avoid auth failures.
     #' - **Key Rotation Monitoring**: Use `created_at` to track key age and schedule rotation for security.
     #'
     #' ### curl
@@ -220,24 +220,27 @@ KucoinAccount <- R6::R6Class(
     #' ```
     #'
     #' @return (data.table | promise<data.table>) one row describing the active
-    #'   API key: its label, key ID, version, comma-separated permissions and IP
-    #'   whitelist, creation datetime (POSIXct, coerced from epoch milliseconds),
-    #'   user ID, and whether it belongs to the master account:
+    #'   API key: its label, key ID, version, comma-separated permissions,
+    #'   creation datetime (POSIXct, coerced from epoch milliseconds), user ID,
+    #'   whether it belongs to the master account, and the account's region, KYC
+    #'   status and site type:
     #' - remark (character | NA) an optional remark.
     #' - api_key (character | NA) the api key.
     #' - api_version (integer | NA) the api version.
     #' - permission (character) the permission.
-    #' - ip_whitelist (character | NA) the ip whitelist.
     #' - created_at (POSIXct) the created at (UTC).
     #' - uid (integer) the user identifier.
     #' - is_master (logical) the is master.
+    #' - region (character | NA) the account region.
+    #' - kyc_status (character | NA) the KYC verification status.
+    #' - site_type (character | NA) the site type.
     #'
     #' @examples
     #' \dontrun{
     #' account <- KucoinAccount$new()
     #' key_info <- account$get_apikey_info()
     #' cat("Permissions:", key_info$permission, "\\n")
-    #' cat("IP Whitelist:", key_info$ip_whitelist, "\\n")
+    #' cat("Region:", key_info$region, "\\n")
     #' cat("Is Master:", key_info$is_master, "\\n")
     #' }
     get_apikey_info = function() {
@@ -246,6 +249,9 @@ KucoinAccount <- R6::R6Class(
         .parser = function(data) {
           dt <- as_dt_row(data)
           coerce_cols(dt, "created_at", ms_to_datetime)
+          # region/kyc_status/site_type are null for some accounts; coerce so
+          # each column lands as character rather than an all-logical NA vector.
+          coerce_cols(dt, c("region", "kyc_status", "site_type"), as.character)
           return(dt[])
         }
       )

--- a/R/KucoinFuturesMarketData.R
+++ b/R/KucoinFuturesMarketData.R
@@ -367,7 +367,7 @@ KucoinFuturesMarketData <- R6::R6Class(
     #'   size, trade identifier and price, the best bid and ask prices with their
     #'   sizes, and the ticker datetime (POSIXct, coerced from the nanosecond
     #'   timestamp):
-    #' - sequence (integer) the sequence.
+    #' - sequence (numeric) the sequence.
     #' - symbol (character) the trading pair symbol.
     #' - side (character) the order side.
     #' - size (integer | NA) the size.

--- a/R/KucoinFuturesTrading.R
+++ b/R/KucoinFuturesTrading.R
@@ -193,7 +193,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the system-assigned order ID and the client-provided
     #'   order ID:
     #' - order_id (character) the system order identifier.
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -375,7 +375,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the simulated order ID and the client-provided order
     #'   ID:
     #' - order_id (character) the system order identifier.
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -565,7 +565,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row per order result giving the system-assigned order ID, the
     #'   client-provided order ID, the futures symbol, the per-order status code, and the per-order status message:
     #' - order_id (character) the system order identifier.
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1054,7 +1054,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #' - status (character) the status.
     #' - created_at (POSIXct) the created at (UTC).
     #' - updated_at (POSIXct | NA) the updated at (UTC).
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1189,7 +1189,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #' - status (character) the status.
     #' - created_at (POSIXct) the created at (UTC).
     #' - updated_at (POSIXct | NA) the updated at (UTC).
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1331,7 +1331,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #' - status (character) the status.
     #' - created_at (POSIXct) the created at (UTC).
     #' - updated_at (POSIXct | NA) the updated at (UTC).
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1476,7 +1476,7 @@ KucoinFuturesTrading <- R6::R6Class(
     #' - status (character) the status.
     #' - created_at (POSIXct) the created at (UTC).
     #' - updated_at (POSIXct | NA) the updated at (UTC).
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinMarketData.R
+++ b/R/KucoinMarketData.R
@@ -523,12 +523,12 @@ KucoinMarketData <- R6::R6Class(
     #' - taker_fee_coefficient (character | NA) the taker fee coefficient.
     #' - st (logical) whether the symbol is in special treatment.
     #' - callauction_is_enabled (logical) the callauction is enabled.
-    #' - callauction_price_floor (logical | NA) the callauction price floor.
-    #' - callauction_price_ceiling (logical | NA) the callauction price ceiling.
-    #' - callauction_first_stage_start_time (logical | NA) the callauction first stage start time.
-    #' - callauction_second_stage_start_time (logical | NA) the callauction second stage start time.
-    #' - callauction_third_stage_start_time (logical | NA) the callauction third stage start time.
-    #' - trading_start_time (logical | NA) the trading start time.
+    #' - callauction_price_floor (character | NA) the callauction price floor.
+    #' - callauction_price_ceiling (character | NA) the callauction price ceiling.
+    #' - callauction_first_stage_start_time (numeric | NA) the callauction first stage start time (epoch ms).
+    #' - callauction_second_stage_start_time (numeric | NA) the callauction second stage start time (epoch ms).
+    #' - callauction_third_stage_start_time (numeric | NA) the callauction third stage start time (epoch ms).
+    #' - trading_start_time (numeric | NA) the trading start time (epoch ms).
     #'
     #' @examples
     #' \dontrun{
@@ -542,7 +542,24 @@ KucoinMarketData <- R6::R6Class(
       res <- private$.request(
         endpoint = paste0("/api/v2/symbols/", symbol),
         auth = FALSE,
-        .parser = as_dt_row
+        .parser = function(data) {
+          dt <- as_dt_row(data)
+          # KuCoin returns the call-auction fields as null for non-auction
+          # symbols; coerce so each column lands as its documented type (price
+          # strings / epoch-ms numerics) rather than an all-logical NA vector.
+          coerce_cols(dt, c("callauction_price_floor", "callauction_price_ceiling"), as.character)
+          coerce_cols(
+            dt,
+            c(
+              "callauction_first_stage_start_time",
+              "callauction_second_stage_start_time",
+              "callauction_third_stage_start_time",
+              "trading_start_time"
+            ),
+            as.numeric
+          )
+          return(dt[])
+        }
       )
       return(connectcore::then_or_now(
         res,
@@ -663,12 +680,12 @@ KucoinMarketData <- R6::R6Class(
     #' - taker_fee_coefficient (character | NA) the taker fee coefficient.
     #' - st (logical) whether the symbol is in special treatment.
     #' - callauction_is_enabled (logical) the callauction is enabled.
-    #' - callauction_price_floor (logical | NA) the callauction price floor.
-    #' - callauction_price_ceiling (logical | NA) the callauction price ceiling.
-    #' - callauction_first_stage_start_time (logical | NA) the callauction first stage start time.
-    #' - callauction_second_stage_start_time (logical | NA) the callauction second stage start time.
-    #' - callauction_third_stage_start_time (logical | NA) the callauction third stage start time.
-    #' - trading_start_time (logical | NA) the trading start time.
+    #' - callauction_price_floor (character | NA) the callauction price floor.
+    #' - callauction_price_ceiling (character | NA) the callauction price ceiling.
+    #' - callauction_first_stage_start_time (numeric | NA) the callauction first stage start time (epoch ms).
+    #' - callauction_second_stage_start_time (numeric | NA) the callauction second stage start time (epoch ms).
+    #' - callauction_third_stage_start_time (numeric | NA) the callauction third stage start time (epoch ms).
+    #' - trading_start_time (numeric | NA) the trading start time (epoch ms).
     #'
     #' @examples
     #' \dontrun{
@@ -688,10 +705,21 @@ KucoinMarketData <- R6::R6Class(
           if (is.null(data) || length(data) == 0) {
             return(data.table::data.table()[])
           }
-          return(data.table::rbindlist(
-            lapply(data, as_dt_row),
-            fill = TRUE
-          )[])
+          dt <- data.table::rbindlist(lapply(data, as_dt_row), fill = TRUE)
+          # As in get_symbol: coerce the call-auction fields (null for
+          # non-auction symbols) to their documented types.
+          coerce_cols(dt, c("callauction_price_floor", "callauction_price_ceiling"), as.character)
+          coerce_cols(
+            dt,
+            c(
+              "callauction_first_stage_start_time",
+              "callauction_second_stage_start_time",
+              "callauction_third_stage_start_time",
+              "trading_start_time"
+            ),
+            as.numeric
+          )
+          return(dt[])
         }
       )
       return(connectcore::then_or_now(

--- a/R/KucoinOcoOrders.R
+++ b/R/KucoinOcoOrders.R
@@ -592,7 +592,7 @@ KucoinOcoOrders <- R6::R6Class(
     #'   status (e.g., `"NEW"`, `"DONE"`, `"TRIGGERED"`):
     #' - order_id (character) the system order identifier.
     #' - symbol (character) the trading pair symbol.
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #' - order_time (POSIXct) the order time (UTC).
     #' - status (character) the status.
     #'
@@ -686,7 +686,7 @@ KucoinOcoOrders <- R6::R6Class(
     #'   milliseconds), and order status (e.g., `"NEW"`, `"DONE"`, `"TRIGGERED"`):
     #' - order_id (character) the system order identifier.
     #' - symbol (character) the trading pair symbol.
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #' - order_time (POSIXct) the order time (UTC).
     #' - status (character) the status.
     #'
@@ -802,7 +802,7 @@ KucoinOcoOrders <- R6::R6Class(
     #'   (present only on the stop leg) as `sub_order_`-prefixed columns:
     #' - order_id (character) the system order identifier.
     #' - symbol (character) the trading pair symbol.
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #' - order_time (POSIXct) the order time (UTC).
     #' - status (character) the status.
     #' - sub_order_id (character) the sub order id.

--- a/R/KucoinStopOrders.R
+++ b/R/KucoinStopOrders.R
@@ -503,7 +503,7 @@ KucoinStopOrders <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the KuCoin order
     #'   ID and the client-assigned order ID of the cancelled stop order:
     #' - cancelled_order_id (character) the cancelled order identifier.
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{

--- a/R/KucoinTrading.R
+++ b/R/KucoinTrading.R
@@ -352,7 +352,7 @@ KucoinTrading <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the simulated order identifier and the client-provided
     #'   order identifier:
     #' - order_id (character) the system order identifier.
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -686,7 +686,7 @@ KucoinTrading <- R6::R6Class(
     #' @param clientOid (scalar<character>) client order ID.
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
     #' @return (data.table | promise<data.table>) one row giving the cancelled client order ID:
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{
@@ -1142,7 +1142,7 @@ KucoinTrading <- R6::R6Class(
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
     #' @return (data.table | promise<data.table>) one row of full order details, including the creation and last-updated
     #'   datetimes (POSIXct):
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #' - symbol (character) the trading pair symbol.
     #' - side (character) the order side.
     #' - created_at (POSIXct) the created at (UTC).
@@ -2170,7 +2170,7 @@ KucoinTrading <- R6::R6Class(
     #' @param symbol (scalar<character>) trading pair (e.g., `"BTC-USDT"`).
     #' @return (data.table | promise<data.table>) one row giving the client order ID, the original, filled, remaining,
     #'   and cancelled sizes, and the fill status:
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #' - origin_size (character | NA) the original size.
     #' - deal_size (character | NA) the filled size.
     #' - remain_size (character | NA) the unfilled size.
@@ -2270,7 +2270,7 @@ KucoinTrading <- R6::R6Class(
     #' @return (data.table | promise<data.table>) one row giving the replacement order's ID and the original client
     #'   order ID:
     #' - new_order_id (character) the new order identifier.
-    #' - client_oid (character) the client-supplied order identifier.
+    #' - client_oid (character | NA) the client-supplied order identifier.
     #'
     #' @examples
     #' \dontrun{

--- a/R/contracts-generated.R
+++ b/R/contracts-generated.R
@@ -21,19 +21,21 @@ assert_return_KucoinAccount__get_summary <- function(value) {
 
 assert_return_KucoinAccount__get_apikey_info <- function(value) {
   assert_data_table(value)
-  assert_has_columns(value, c("remark", "api_key", "api_version", "permission", "ip_whitelist", "created_at", "uid", "is_master"))
+  assert_has_columns(value, c("remark", "api_key", "api_version", "permission", "created_at", "uid", "is_master", "region", "kyc_status", "site_type"))
   assert_character(value[["remark"]])
   assert_character(value[["api_key"]])
   assert_integer(value[["api_version"]])
   assert_character(value[["permission"]])
   assert_no_missing_values(value[["permission"]])
-  assert_character(value[["ip_whitelist"]])
   assert_datetime(value[["created_at"]])
   assert_no_missing_values(value[["created_at"]])
   assert_integer(value[["uid"]])
   assert_no_missing_values(value[["uid"]])
   assert_logical(value[["is_master"]])
   assert_no_missing_values(value[["is_master"]])
+  assert_character(value[["region"]])
+  assert_character(value[["kyc_status"]])
+  assert_character(value[["site_type"]])
   return(value)
 }
 
@@ -496,7 +498,7 @@ assert_args_KucoinFuturesMarketData__get_ticker <- function(symbol) {
 assert_return_KucoinFuturesMarketData__get_ticker <- function(value) {
   assert_data_table(value)
   assert_has_columns(value, c("sequence", "symbol", "side", "size", "price", "best_bid_size", "best_bid_price", "best_ask_price", "best_ask_size", "trade_id", "ts"))
-  assert_integer(value[["sequence"]])
+  assert_double(value[["sequence"]])
   assert_no_missing_values(value[["sequence"]])
   assert_character(value[["symbol"]])
   assert_no_missing_values(value[["symbol"]])
@@ -742,7 +744,6 @@ assert_return_KucoinFuturesTrading__add_order <- function(value) {
   assert_character(value[["order_id"]])
   assert_no_missing_values(value[["order_id"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -778,7 +779,6 @@ assert_return_KucoinFuturesTrading__add_order_test <- function(value) {
   assert_character(value[["order_id"]])
   assert_no_missing_values(value[["order_id"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -793,7 +793,6 @@ assert_return_KucoinFuturesTrading__add_order_batch <- function(value) {
   assert_character(value[["order_id"]])
   assert_no_missing_values(value[["order_id"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -877,7 +876,6 @@ assert_return_KucoinFuturesTrading__get_order_by_id <- function(value) {
   assert_no_missing_values(value[["created_at"]])
   assert_datetime(value[["updated_at"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -913,7 +911,6 @@ assert_return_KucoinFuturesTrading__get_order_by_client_oid <- function(value) {
   assert_no_missing_values(value[["created_at"]])
   assert_datetime(value[["updated_at"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -949,7 +946,6 @@ assert_return_KucoinFuturesTrading__get_order_list <- function(value) {
   assert_no_missing_values(value[["created_at"]])
   assert_datetime(value[["updated_at"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -987,7 +983,6 @@ assert_return_KucoinFuturesTrading__get_recent_closed_orders <- function(value) 
   assert_no_missing_values(value[["created_at"]])
   assert_datetime(value[["updated_at"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -1631,12 +1626,12 @@ assert_return_KucoinMarketData__get_symbol <- function(value) {
   assert_no_missing_values(value[["st"]])
   assert_logical(value[["callauction_is_enabled"]])
   assert_no_missing_values(value[["callauction_is_enabled"]])
-  assert_logical(value[["callauction_price_floor"]])
-  assert_logical(value[["callauction_price_ceiling"]])
-  assert_logical(value[["callauction_first_stage_start_time"]])
-  assert_logical(value[["callauction_second_stage_start_time"]])
-  assert_logical(value[["callauction_third_stage_start_time"]])
-  assert_logical(value[["trading_start_time"]])
+  assert_character(value[["callauction_price_floor"]])
+  assert_character(value[["callauction_price_ceiling"]])
+  assert_double(value[["callauction_first_stage_start_time"]])
+  assert_double(value[["callauction_second_stage_start_time"]])
+  assert_double(value[["callauction_third_stage_start_time"]])
+  assert_double(value[["trading_start_time"]])
   return(value)
 }
 
@@ -1683,12 +1678,12 @@ assert_return_KucoinMarketData__get_all_symbols <- function(value) {
   assert_no_missing_values(value[["st"]])
   assert_logical(value[["callauction_is_enabled"]])
   assert_no_missing_values(value[["callauction_is_enabled"]])
-  assert_logical(value[["callauction_price_floor"]])
-  assert_logical(value[["callauction_price_ceiling"]])
-  assert_logical(value[["callauction_first_stage_start_time"]])
-  assert_logical(value[["callauction_second_stage_start_time"]])
-  assert_logical(value[["callauction_third_stage_start_time"]])
-  assert_logical(value[["trading_start_time"]])
+  assert_character(value[["callauction_price_floor"]])
+  assert_character(value[["callauction_price_ceiling"]])
+  assert_double(value[["callauction_first_stage_start_time"]])
+  assert_double(value[["callauction_second_stage_start_time"]])
+  assert_double(value[["callauction_third_stage_start_time"]])
+  assert_double(value[["trading_start_time"]])
   return(value)
 }
 
@@ -1997,7 +1992,6 @@ assert_return_KucoinOcoOrders__get_order_by_id <- function(value) {
   assert_character(value[["symbol"]])
   assert_no_missing_values(value[["symbol"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   assert_datetime(value[["order_time"]])
   assert_no_missing_values(value[["order_time"]])
   assert_character(value[["status"]])
@@ -2018,7 +2012,6 @@ assert_return_KucoinOcoOrders__get_order_by_client_oid <- function(value) {
   assert_character(value[["symbol"]])
   assert_no_missing_values(value[["symbol"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   assert_datetime(value[["order_time"]])
   assert_no_missing_values(value[["order_time"]])
   assert_character(value[["status"]])
@@ -2039,7 +2032,6 @@ assert_return_KucoinOcoOrders__get_order_detail_by_id <- function(value) {
   assert_character(value[["symbol"]])
   assert_no_missing_values(value[["symbol"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   assert_datetime(value[["order_time"]])
   assert_no_missing_values(value[["order_time"]])
   assert_character(value[["status"]])
@@ -2183,7 +2175,6 @@ assert_return_KucoinStopOrders__cancel_order_by_client_oid <- function(value) {
   assert_character(value[["cancelled_order_id"]])
   assert_no_missing_values(value[["cancelled_order_id"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -2459,7 +2450,6 @@ assert_return_KucoinTrading__add_order_test <- function(value) {
   assert_character(value[["order_id"]])
   assert_no_missing_values(value[["order_id"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -2503,7 +2493,6 @@ assert_return_KucoinTrading__cancel_order_by_client_oid <- function(value) {
   assert_data_table(value)
   assert_has_columns(value, c("client_oid"))
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 
@@ -2598,7 +2587,6 @@ assert_return_KucoinTrading__get_order_by_client_oid <- function(value) {
   assert_data_table(value)
   assert_has_columns(value, c("client_oid", "symbol", "side", "created_at"))
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   assert_character(value[["symbol"]])
   assert_no_missing_values(value[["symbol"]])
   assert_character(value[["side"]])
@@ -2835,7 +2823,6 @@ assert_return_KucoinTrading__cancel_order_by_client_oid_sync <- function(value) 
   assert_data_table(value)
   assert_has_columns(value, c("client_oid", "origin_size", "deal_size", "remain_size", "canceled_size", "status"))
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   assert_character(value[["origin_size"]])
   assert_character(value[["deal_size"]])
   assert_character(value[["remain_size"]])
@@ -2884,7 +2871,6 @@ assert_return_KucoinTrading__modify_order <- function(value) {
   assert_character(value[["new_order_id"]])
   assert_no_missing_values(value[["new_order_id"]])
   assert_character(value[["client_oid"]])
-  assert_no_missing_values(value[["client_oid"]])
   return(value)
 }
 

--- a/man/KucoinAccount.Rd
+++ b/man/KucoinAccount.Rd
@@ -103,7 +103,7 @@ cat("Sub-accounts:", summary$sub_quantity, "/", summary$max_sub_quantity, "\\\\n
 account <- KucoinAccount$new()
 key_info <- account$get_apikey_info()
 cat("Permissions:", key_info$permission, "\\\\n")
-cat("IP Whitelist:", key_info$ip_whitelist, "\\\\n")
+cat("Region:", key_info$region, "\\\\n")
 cat("Is Master:", key_info$is_master, "\\\\n")
 }
 
@@ -392,8 +392,8 @@ Verified: 2026-05-23
 \itemize{
 \item \strong{Permission Verification}: Confirm the key has \code{Trade} permission before placing orders in a bot startup
 routine.
-\item \strong{IP Whitelist Check}: Validate that the bot's server IP is in \code{is_master}/\code{ip_whitelist} to avoid auth
-failures.
+\item \strong{IP Whitelist Check}: Confirm the key's IP-whitelist settings on KuCoin allow the bot's server IP to
+avoid auth failures.
 \item \strong{Key Rotation Monitoring}: Use \code{created_at} to track key age and schedule rotation for security.
 }
 }
@@ -432,18 +432,21 @@ failures.
 
 \subsection{Returns}{
 (data.table | promise<data.table>) one row describing the active
-API key: its label, key ID, version, comma-separated permissions and IP
-whitelist, creation datetime (POSIXct, coerced from epoch milliseconds),
-user ID, and whether it belongs to the master account:
+API key: its label, key ID, version, comma-separated permissions,
+creation datetime (POSIXct, coerced from epoch milliseconds), user ID,
+whether it belongs to the master account, and the account's region, KYC
+status and site type:
 \itemize{
 \item remark (character | NA) an optional remark.
 \item api_key (character | NA) the api key.
 \item api_version (integer | NA) the api version.
 \item permission (character) the permission.
-\item ip_whitelist (character | NA) the ip whitelist.
 \item created_at (POSIXct) the created at (UTC).
 \item uid (integer) the user identifier.
 \item is_master (logical) the is master.
+\item region (character | NA) the account region.
+\item kyc_status (character | NA) the KYC verification status.
+\item site_type (character | NA) the site type.
 }
 }
 \subsection{Examples}{
@@ -452,7 +455,7 @@ user ID, and whether it belongs to the master account:
 account <- KucoinAccount$new()
 key_info <- account$get_apikey_info()
 cat("Permissions:", key_info$permission, "\\\\n")
-cat("IP Whitelist:", key_info$ip_whitelist, "\\\\n")
+cat("Region:", key_info$region, "\\\\n")
 cat("Is Master:", key_info$is_master, "\\\\n")
 }
 }

--- a/man/KucoinFuturesMarketData.Rd
+++ b/man/KucoinFuturesMarketData.Rd
@@ -602,7 +602,7 @@ size, trade identifier and price, the best bid and ask prices with their
 sizes, and the ticker datetime (POSIXct, coerced from the nanosecond
 timestamp):
 \itemize{
-\item sequence (integer) the sequence.
+\item sequence (numeric) the sequence.
 \item symbol (character) the trading pair symbol.
 \item side (character) the order side.
 \item size (integer | NA) the size.

--- a/man/KucoinFuturesTrading.Rd
+++ b/man/KucoinFuturesTrading.Rd
@@ -553,7 +553,7 @@ accidental position increases.
 order ID:
 \itemize{
 \item order_id (character) the system order identifier.
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{
@@ -733,7 +733,7 @@ permissions and symbols are correct.
 ID:
 \itemize{
 \item order_id (character) the system order identifier.
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{
@@ -895,7 +895,7 @@ Verified: 2026-05-23
 client-provided order ID, the futures symbol, the per-order status code, and the per-order status message:
 \itemize{
 \item order_id (character) the system order identifier.
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{
@@ -1414,7 +1414,7 @@ datetimes (POSIXct, coerced from epoch milliseconds):
 \item status (character) the status.
 \item created_at (POSIXct) the created at (UTC).
 \item updated_at (POSIXct | NA) the updated at (UTC).
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{
@@ -1560,7 +1560,7 @@ Verified: 2026-05-23
 \item status (character) the status.
 \item created_at (POSIXct) the created at (UTC).
 \item updated_at (POSIXct | NA) the updated at (UTC).
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{
@@ -1712,7 +1712,7 @@ empty data.table if no orders match the filters:
 \item status (character) the status.
 \item created_at (POSIXct) the created at (UTC).
 \item updated_at (POSIXct | NA) the updated at (UTC).
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{
@@ -1868,7 +1868,7 @@ empty data.table if no recently closed orders exist:
 \item status (character) the status.
 \item created_at (POSIXct) the created at (UTC).
 \item updated_at (POSIXct | NA) the updated at (UTC).
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{

--- a/man/KucoinMarketData.Rd
+++ b/man/KucoinMarketData.Rd
@@ -784,12 +784,12 @@ the maker and taker fee coefficients:
 \item taker_fee_coefficient (character | NA) the taker fee coefficient.
 \item st (logical) whether the symbol is in special treatment.
 \item callauction_is_enabled (logical) the callauction is enabled.
-\item callauction_price_floor (logical | NA) the callauction price floor.
-\item callauction_price_ceiling (logical | NA) the callauction price ceiling.
-\item callauction_first_stage_start_time (logical | NA) the callauction first stage start time.
-\item callauction_second_stage_start_time (logical | NA) the callauction second stage start time.
-\item callauction_third_stage_start_time (logical | NA) the callauction third stage start time.
-\item trading_start_time (logical | NA) the trading start time.
+\item callauction_price_floor (character | NA) the callauction price floor.
+\item callauction_price_ceiling (character | NA) the callauction price ceiling.
+\item callauction_first_stage_start_time (numeric | NA) the callauction first stage start time (epoch ms).
+\item callauction_second_stage_start_time (numeric | NA) the callauction second stage start time (epoch ms).
+\item callauction_third_stage_start_time (numeric | NA) the callauction third stage start time (epoch ms).
+\item trading_start_time (numeric | NA) the trading start time (epoch ms).
 }
 }
 \subsection{Examples}{
@@ -991,12 +991,12 @@ carrying the same symbol metadata as \code{get_symbol()}:
 \item taker_fee_coefficient (character | NA) the taker fee coefficient.
 \item st (logical) whether the symbol is in special treatment.
 \item callauction_is_enabled (logical) the callauction is enabled.
-\item callauction_price_floor (logical | NA) the callauction price floor.
-\item callauction_price_ceiling (logical | NA) the callauction price ceiling.
-\item callauction_first_stage_start_time (logical | NA) the callauction first stage start time.
-\item callauction_second_stage_start_time (logical | NA) the callauction second stage start time.
-\item callauction_third_stage_start_time (logical | NA) the callauction third stage start time.
-\item trading_start_time (logical | NA) the trading start time.
+\item callauction_price_floor (character | NA) the callauction price floor.
+\item callauction_price_ceiling (character | NA) the callauction price ceiling.
+\item callauction_first_stage_start_time (numeric | NA) the callauction first stage start time (epoch ms).
+\item callauction_second_stage_start_time (numeric | NA) the callauction second stage start time (epoch ms).
+\item callauction_third_stage_start_time (numeric | NA) the callauction third stage start time (epoch ms).
+\item trading_start_time (numeric | NA) the trading start time (epoch ms).
 }
 }
 \subsection{Examples}{

--- a/man/KucoinOcoOrders.Rd
+++ b/man/KucoinOcoOrders.Rd
@@ -760,7 +760,7 @@ status (e.g., \code{"NEW"}, \code{"DONE"}, \code{"TRIGGERED"}):
 \itemize{
 \item order_id (character) the system order identifier.
 \item symbol (character) the trading pair symbol.
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 \item order_time (POSIXct) the order time (UTC).
 \item status (character) the status.
 }
@@ -865,7 +865,7 @@ milliseconds), and order status (e.g., \code{"NEW"}, \code{"DONE"}, \code{"TRIGG
 \itemize{
 \item order_id (character) the system order identifier.
 \item symbol (character) the trading pair symbol.
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 \item order_time (POSIXct) the order time (UTC).
 \item status (character) the status.
 }
@@ -992,7 +992,7 @@ each sub-order's id, symbol, side, price, size, status, and stop price
 \itemize{
 \item order_id (character) the system order identifier.
 \item symbol (character) the trading pair symbol.
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 \item order_time (POSIXct) the order time (UTC).
 \item status (character) the status.
 \item sub_order_id (character) the sub order id.

--- a/man/KucoinStopOrders.Rd
+++ b/man/KucoinStopOrders.Rd
@@ -626,7 +626,7 @@ Required to disambiguate client OIDs across different trading pairs.}
 ID and the client-assigned order ID of the cancelled stop order:
 \itemize{
 \item cancelled_order_id (character) the cancelled order identifier.
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{

--- a/man/KucoinTrading.Rd
+++ b/man/KucoinTrading.Rd
@@ -703,7 +703,7 @@ Verified: 2026-05-23
 order identifier:
 \itemize{
 \item order_id (character) the system order identifier.
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{
@@ -989,7 +989,7 @@ Verified: 2026-05-23
 \subsection{Returns}{
 (data.table | promise<data.table>) one row giving the cancelled client order ID:
 \itemize{
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{
@@ -1449,7 +1449,7 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row of full order details, including the creation and last-updated
 datetimes (POSIXct):
 \itemize{
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 \item symbol (character) the trading pair symbol.
 \item side (character) the order side.
 \item created_at (POSIXct) the created at (UTC).
@@ -2381,7 +2381,7 @@ Verified: 2026-05-23
 (data.table | promise<data.table>) one row giving the client order ID, the original, filled, remaining,
 and cancelled sizes, and the fill status:
 \itemize{
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 \item origin_size (character | NA) the original size.
 \item deal_size (character | NA) the filled size.
 \item remain_size (character | NA) the unfilled size.
@@ -2498,7 +2498,7 @@ Verified: 2026-05-23
 order ID:
 \itemize{
 \item new_order_id (character) the new order identifier.
-\item client_oid (character) the client-supplied order identifier.
+\item client_oid (character | NA) the client-supplied order identifier.
 }
 }
 \subsection{Examples}{

--- a/tests/testthat/fixtures/futures_ticker.json
+++ b/tests/testthat/fixtures/futures_ticker.json
@@ -1,7 +1,7 @@
 {
   "code": "200000",
   "data": {
-    "sequence": 1729159460,
+    "sequence": 1744931221320,
     "symbol": "XBTUSDTM",
     "side": "sell",
     "size": 1,

--- a/tests/testthat/test-KucoinAccount.R
+++ b/tests/testthat/test-KucoinAccount.R
@@ -50,10 +50,12 @@ test_that("get_apikey_info returns data.table with key details", {
       apiKey = "670c42f1a24b1b0001a5c7e0",
       apiVersion = 3,
       permission = "General,Spot",
-      ipWhitelist = "198.51.100.42",
       createdAt = 1728905969000,
       uid = 123456789,
-      isMaster = TRUE
+      isMaster = TRUE,
+      region = "US",
+      kycStatus = "KYC2",
+      siteType = "MAIN"
     )
   )
   httr2::local_mocked_responses(function(req) resp)


### PR DESCRIPTION
**In plain terms:** Running the package against the real KuCoin API revealed several columns that were typed from test fixtures which happened to be empty — so a "trading start time" was typed as a true/false flag, a call-auction price as a flag, and a futures sequence number as a small integer that overflows on real data. It also revealed that KuCoin dropped the API key's IP-whitelist field and now returns region / KYC status / site type instead. This fixes those contracts to match what the live API actually returns, and updates the mock fixtures to the real shapes.

## Change

- `callauction_price_floor`/`ceiling`: logical → `character | NA` (real prices); `callauction_*_stage_start_time` and `trading_start_time`: logical → `numeric | NA` (epoch ms). The symbol parsers coerce these (null for non-auction symbols) so the column lands as its documented type rather than an all-logical NA vector.
- futures `get_ticker` `sequence`: integer → numeric (real sequences exceed 32-bit); fixture updated to a realistic value.
- `get_apikey_info`: dropped `ip_whitelist`, added `region`/`kyc_status`/`site_type`; coerce those (null for some accounts) to character; inline mock updated to the real shape.
- `client_oid`: loosened to `| NA` across all order methods (live `add_order_test` returns it null).

Mock suite green (1353); every type / NA / column live-integration check now passes.

## Known follow-up (separate, pre-existing)

Five live tests still fail on a distinct, pre-existing gap unrelated to typing: empty results (no closed orders, no matching futures order, no recent fills, unset DCP) do not carry their typed columns, so `assert_has_columns` aborts. The fix is typed zero-row empties in those parsers (as the sibling `coinbase` package does with its `empty_dt_*` helpers). Recommend a follow-up PR.

## Stacking

Stacked on the lean-permissive PR.
