### PR TITLE
fix(paginate): walk pages iteratively in sync mode (closes #15)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kucoin
 Type: Package
 Title: API Wrapper to KuCoin Cryptocurrency Exchange
-Version: 4.3.0
+Version: 4.3.1
 URL: https://dereckscompany.github.io/kucoin/
 BugReports: https://github.com/dereckscompany/kucoin/issues
 Authors@R: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# kucoin 4.3.1
+
+## `kucoin_paginate()` walks pages iteratively in sync mode (closes #15)
+
+`kucoin_paginate()` expressed its page walk as self-recursion: each page's synchronous continuation called the fetch closure for the next page, so on a deep walk (thousands of pages, e.g. a long account history) the nested `fetch_page -> then_or_now -> continuation -> fetch_page` frames grew the call stack and eventually aborted with a node-stack overflow (R has no tail-call optimisation). The sync path is now an iterative `while`-loop that accumulates pages in constant stack depth, so a several-thousand-page walk completes. Results are bit-identical: the same page ordering, the same `page < total && page < max_pages` stop condition, and the same `max_pages` / `page_size` closed-interval contracts. The async path keeps its promise-based recursion, which is safe because `promises::then()` schedules each continuation as a fresh event-loop task, so the call stack unwinds between pages. A regression test walks 3000 pages through the mock router and confirms the sync path survives where the recursive code overflowed.
+
 # kucoin 4.3.0
 
 ## snake_case argument convergence (clean break) + connectcore alignment

--- a/R/helpers_request.R
+++ b/R/helpers_request.R
@@ -301,12 +301,15 @@ kucoin_paginate <- function(
 
   accumulator <- list()
 
-  fetch_page <- function(page) {
+  # Issue one page request. Returns the parsed page data in sync mode, or a
+  # promise resolving to it in async mode. Both walk paths below build the
+  # request identically through this seam, so the two modes stay bit-identical.
+  request_page <- function(page) {
     q <- query
     q$currentPage <- page
     q$pageSize <- page_size
 
-    result <- connectcore::build_request(
+    return(connectcore::build_request(
       base_url = base_url,
       endpoint = endpoint,
       method = method,
@@ -320,30 +323,66 @@ kucoin_paginate <- function(
       is_async = is_async,
       timeout = timeout,
       ctx = list(get_timestamp_ms = .get_timestamp_ms)
-    )
-
-    return(connectcore::then_or_now(
-      result,
-      function(data) {
-        page_items <- data[[items_field]]
-        if (!is.null(page_items)) {
-          accumulator[[length(accumulator) + 1L]] <<- page_items
-        }
-
-        total <- 1L
-        if (!is.null(data$totalPage)) {
-          total <- data$totalPage
-        }
-
-        if (page < total && page < max_pages) {
-          return(fetch_page(page + 1L))
-        }
-
-        return(.parser(accumulator))
-      },
-      is_async = is_async
     ))
   }
 
-  return(assert_return_kucoin_paginate(fetch_page(1L)))
+  # Fold one page's items into the accumulator and report its `totalPage`
+  # (defaulting to 1 when the field is absent, exactly as before). Shared by
+  # both walk paths so ordering and stop conditions are identical.
+  absorb_page <- function(data) {
+    page_items <- data[[items_field]]
+    if (!is.null(page_items)) {
+      accumulator[[length(accumulator) + 1L]] <<- page_items
+    }
+
+    total <- 1L
+    if (!is.null(data$totalPage)) {
+      total <- data$totalPage
+    }
+
+    return(total)
+  }
+
+  # Sync and async walk the same pages with the same stop condition; only the
+  # control structure differs, because each mode has a different stack model.
+  result <- NULL
+  if (is_async) {
+    # Async: promise-based recursion. `promises::then()` schedules each
+    # continuation as a fresh event-loop task, so the call stack unwinds between
+    # pages (the recursion is trampolined by the event loop and does not grow
+    # the stack with page count). Left as recursion deliberately.
+    fetch_page <- function(page) {
+      return(connectcore::then_or_now(
+        request_page(page),
+        function(data) {
+          total <- absorb_page(data)
+          if (page < total && page < max_pages) {
+            return(fetch_page(page + 1L))
+          }
+          return(.parser(accumulator))
+        },
+        is_async = TRUE
+      ))
+    }
+    result <- fetch_page(1L)
+  } else {
+    # Sync: iterative while-loop. R has no tail-call optimisation and runs the
+    # continuation inline, so expressing the walk as self-recursion nested
+    # `fetch_page -> then_or_now -> continuation -> fetch_page` and overflowed
+    # the stack on a deep walk (thousands of pages). The loop runs in constant
+    # stack depth while preserving the exact page ordering.
+    page <- 1L
+    walking <- TRUE
+    while (walking) {
+      total <- absorb_page(request_page(page))
+      if (page < total && page < max_pages) {
+        page <- page + 1L
+      } else {
+        walking <- FALSE
+      }
+    }
+    result <- .parser(accumulator)
+  }
+
+  return(assert_return_kucoin_paginate(result))
 }

--- a/tests/testthat/test-helpers_request.R
+++ b/tests/testthat/test-helpers_request.R
@@ -394,3 +394,43 @@ test_that("kucoin_paginate respects max_pages", {
 
   expect_equal(call_count, 2L)
 })
+
+test_that("kucoin_paginate walks thousands of pages in sync mode without overflowing the stack", {
+  # Regression for #15: the sync walk used to self-recurse once per page, nesting
+  # `fetch_page -> then_or_now -> continuation -> fetch_page` on the call stack
+  # (R has no tail-call optimisation), and overflowed the node stack on a deep
+  # walk. Verified: the old recursive code aborts this exact test with
+  # "node stack overflow"; the iterative sync loop runs in constant stack depth
+  # and completes. Every page reports the same large totalPage and carries no
+  # items, so the walk runs `deep_total` iterations cheaply (the empty
+  # accumulator is fed to flatten_pages, which yields an empty data.table). The
+  # multi-page ordering/accumulation contract is covered by the tests above.
+  deep_total <- 3000L
+  call_count <- 0L
+
+  # The walk's stop condition reads only totalPage, never the response's
+  # currentPage, so one constant response drives every page (fast: no per-page
+  # JSON re-encoding).
+  resp <- mock_kucoin_response(
+    data = list(
+      totalNum = deep_total,
+      totalPage = deep_total,
+      pageSize = 1L
+    )
+  )
+  httr2::local_mocked_responses(function(req) {
+    call_count <<- call_count + 1L
+    return(resp)
+  })
+
+  result <- kucoin_paginate(
+    base_url = "https://api.kucoin.com",
+    endpoint = "/api/v3/announcements",
+    .parser = flatten_pages,
+    page_size = 1
+  )
+
+  expect_equal(call_count, deep_total)
+  expect_s3_class(result, "data.table")
+  expect_equal(nrow(result), 0L)
+})


### PR DESCRIPTION
In plain terms: when the code fetched a very long paginated list (say an account history thousands of pages deep) in the normal, synchronous mode, it fetched each page by calling itself again for the next page. R does not optimise that kind of self-call, so the calls piled up on the stack and eventually the whole thing fell over with a stack-overflow crash. This rewrites the synchronous walk as a plain loop, which uses a fixed, tiny amount of stack no matter how many pages there are. The output is exactly the same as before.

## What changed

* `kucoin_paginate()` sync path is now an iterative `while`-loop that accumulates pages in constant stack depth, replacing the per-page self-recursion inside the synchronous continuation.
* The async path is deliberately left as promise-based recursion: `promises::then()` schedules each continuation as a fresh event-loop task, so the call stack unwinds between pages (the recursion is trampolined by the event loop and does not grow with page count). Verified against `connectcore::then_or_now()`, whose async branch is `promises::then(x, fn)` while its sync branch runs `fn(x)` inline.
* Per-page request-building and page-folding are factored into two small closures (`request_page`, `absorb_page`) shared by both paths, so the two modes stay bit-identical: same page ordering, same `page < total && page < max_pages` stop condition, same `max_pages` / `page_size` closed-interval contracts. No public signature or roxygen contract changed.

## Evidence

* New regression test walks 3000 pages through the mock router. Old recursive code aborts this exact test with `node stack overflow`; the iterative loop passes. An isolated mechanism repro (recursive vs iterative walk, no HTTP) shows the recursive form aborts with `evaluation nested too deeply: infinite recursion / options(expressions=)?` at depth 3000 while the loop survives.
* Full suite: `FAIL 0  WARN 0  PASS 1422` (2 live-integration files skipped by design).
* `R CMD check` (`_R_CHECK_FORCE_SUGGESTS_=false`): `checking tests ... OK`, `checking R files for syntax errors ... OK`. Remaining 2 WARNINGs / 2 NOTEs are pre-existing and unrelated (MIT-license template NOTE, "Lost braces" in `KucoinMarketData.Rd`, and vignette-directory WARNINGs from a `--no-vignettes` build).
* `scripts/FORMAT.sh` and `scripts/LINT.sh` clean (lintr: 0 warnings).

Version bumped 4.3.0 -> 4.3.1; NEWS entry added.