### PR TITLE
feat(conditions): typed input-validation conditions (kucoin_error domain root)

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -8,7 +8,7 @@ linters: linters_with_defaults(
     object_name_linter = object_name_linter(styles = c("snake_case", "SNAKE_CASE", "CamelCase")),
     # Functions accepted as a valid exit under return_style = "explicit".
     # Add project-specific aborters here (e.g. abort_assertion).
-    return_linter = return_linter(return_style = "explicit", return_functions = c("abort", "cli_abort")),
+    return_linter = return_linter(return_style = "explicit", return_functions = c("abort", "cli_abort", "abort_kucoin_validation_error")),
     # Disabled: long fixture / API-field names are intentional (an API wrapper
     # mirroring upstream field names; the template sanctions NULL here).
     object_length_linter = NULL,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kucoin
 Type: Package
 Title: API Wrapper to KuCoin Cryptocurrency Exchange
-Version: 4.4.0
+Version: 4.5.0
 URL: https://dereckscompany.github.io/kucoin/
 BugReports: https://github.com/dereckscompany/kucoin/issues
 Authors@R: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# kucoin 4.5.0
+
+## Typed input-validation conditions (the non-transport half of the taxonomy)
+
+* The connector's 101 non-transport `rlang::abort()` sites — a method's argument or parameter is malformed or violates a rule *before* any request is made (a missing required parameter, a bad ticker, a non-positive size, a mutually-exclusive pair supplied together, a value out of range) — now signal a **classed condition** through a new `abort_kucoin_validation_error()` raiser, so a caller branches on error *type* instead of grepping the message text. This completes the taxonomy alongside the request funnel's typed transport conditions.
+* The class vector is `c("kucoin_validation_error", "kucoin_error")`. `kucoin_error` is the connector's DOMAIN root, parallel to the transport `connectcore_error` root: a validation failure is not a transport failure, so the two roots never meet — exactly the `core_error` / `connectcore_error` split the fleet already uses. Catch `kucoin_validation_error` for input bugs specifically, or `kucoin_error` for any non-transport KuCoin failure.
+* The message strings are **byte-identical** to the bare `rlang::abort()` calls they replaced (a reverse-substitution proves all 101 reproduce master exactly; golden tests pin two representative sites), so existing tests and downstream message greps keep matching. The classes are purely additive; `conditionMessage()` and `inherits(e, "error")` are unchanged. No behaviour changes.
+* Follows the org convention (dereckscompany/tradebot-core#30; discussion "throw typed errors, not bare strings"). The transport/API funnel (`abort_kucoin_error`, rooted at `connectcore_error`) is untouched.
+
 # kucoin 4.4.0
 
 ## Typed API-error conditions

--- a/R/KucoinAccount.R
+++ b/R/KucoinAccount.R
@@ -1420,7 +1420,7 @@ KucoinAccount <- R6::R6Class(
     get_fee_rate = function(symbols) {
       assert_args_KucoinAccount__get_fee_rate(symbols)
       if (!is.character(symbols) || !nzchar(symbols)) {
-        rlang::abort("Parameter 'symbols' must be a non-empty string of comma-separated pairs.")
+        abort_kucoin_validation_error("Parameter 'symbols' must be a non-empty string of comma-separated pairs.")
       }
 
       res <- private$.request(

--- a/R/KucoinBase.R
+++ b/R/KucoinBase.R
@@ -85,7 +85,7 @@ KucoinBase <- R6::R6Class(
     ) {
       assert_args_KucoinBase__initialize(keys, base_url, async)
       if (isTRUE(async) && !requireNamespace("promises", quietly = TRUE)) {
-        rlang::abort(
+        abort_kucoin_validation_error(
           "Package 'promises' is required for async mode. Install with: install.packages('promises')"
         )
       }

--- a/R/KucoinDeposit.R
+++ b/R/KucoinDeposit.R
@@ -151,10 +151,10 @@ KucoinDeposit <- R6::R6Class(
       assert_args_KucoinDeposit__add_deposit_address(currency, chain, to, amount)
       assert::assert_nonempty_strings(currency)
       if (is.null(chain)) {
-        rlang::abort("Parameter 'chain' is required by the KuCoin API.")
+        abort_kucoin_validation_error("Parameter 'chain' is required by the KuCoin API.")
       }
       if (is.null(to)) {
-        rlang::abort("Parameter 'to' is required by the KuCoin API.")
+        abort_kucoin_validation_error("Parameter 'to' is required by the KuCoin API.")
       }
       body <- list(currency = currency)
       if (!is.null(chain)) {

--- a/R/KucoinFuturesMarketData.R
+++ b/R/KucoinFuturesMarketData.R
@@ -883,7 +883,7 @@ KucoinFuturesMarketData <- R6::R6Class(
       # fetch_all mode: segment the time range into multiple API calls
       if (isTRUE(fetch_all)) {
         if (is.null(from) || is.null(to)) {
-          rlang::abort("Both `from` and `to` are required when `fetch_all = TRUE`.")
+          abort_kucoin_validation_error("Both `from` and `to` are required when `fetch_all = TRUE`.")
         }
         # Keep as POSIXct for the fetch function. Declare with the
         # already-POSIXct branch as the default; reassign when the

--- a/R/KucoinLending.R
+++ b/R/KucoinLending.R
@@ -189,7 +189,7 @@ KucoinLending <- R6::R6Class(
     get_loan_market_rate = function(currency) {
       assert_args_KucoinLending__get_loan_market_rate(currency)
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
 
       res <- private$.request(
@@ -274,13 +274,13 @@ KucoinLending <- R6::R6Class(
     purchase = function(currency, size, interest_rate) {
       assert_args_KucoinLending__purchase(currency, size, interest_rate)
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
       if (!is.numeric(size) || size <= 0) {
-        rlang::abort("Parameter 'size' must be a positive number.")
+        abort_kucoin_validation_error("Parameter 'size' must be a positive number.")
       }
       if (!is.numeric(interest_rate) || interest_rate <= 0) {
-        rlang::abort("Parameter 'interestRate' must be a positive number.")
+        abort_kucoin_validation_error("Parameter 'interestRate' must be a positive number.")
       }
 
       body <- list(
@@ -371,13 +371,13 @@ KucoinLending <- R6::R6Class(
     modify_purchase = function(currency, purchase_order_no, interest_rate) {
       assert_args_KucoinLending__modify_purchase(currency, purchase_order_no, interest_rate)
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
       if (!is.character(purchase_order_no) || !nzchar(purchase_order_no)) {
-        rlang::abort("Parameter 'purchaseOrderNo' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'purchaseOrderNo' must be a non-empty string.")
       }
       if (!is.numeric(interest_rate) || interest_rate <= 0) {
-        rlang::abort("Parameter 'interestRate' must be a positive number.")
+        abort_kucoin_validation_error("Parameter 'interestRate' must be a positive number.")
       }
 
       body <- list(
@@ -576,13 +576,13 @@ KucoinLending <- R6::R6Class(
     redeem = function(currency, size, purchase_order_no) {
       assert_args_KucoinLending__redeem(currency, size, purchase_order_no)
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
       if (!is.numeric(size) || size <= 0) {
-        rlang::abort("Parameter 'size' must be a positive number.")
+        abort_kucoin_validation_error("Parameter 'size' must be a positive number.")
       }
       if (!is.character(purchase_order_no) || !nzchar(purchase_order_no)) {
-        rlang::abort("Parameter 'purchaseOrderNo' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'purchaseOrderNo' must be a non-empty string.")
       }
 
       body <- list(

--- a/R/KucoinMarginData.R
+++ b/R/KucoinMarginData.R
@@ -481,7 +481,7 @@ KucoinMarginData <- R6::R6Class(
     get_risk_limit = function(is_isolated, query = list()) {
       assert_args_KucoinMarginData__get_risk_limit(is_isolated, query)
       if (!is.logical(is_isolated)) {
-        rlang::abort("Parameter 'is_isolated' must be logical (TRUE or FALSE).")
+        abort_kucoin_validation_error("Parameter 'is_isolated' must be logical (TRUE or FALSE).")
       }
 
       query$isIsolated <- is_isolated

--- a/R/KucoinMarginTrading.R
+++ b/R/KucoinMarginTrading.R
@@ -863,13 +863,15 @@ KucoinMarginTrading <- R6::R6Class(
         is_hf
       )
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
       if (!is.numeric(size) || size <= 0) {
-        rlang::abort("Parameter 'size' must be a positive number.")
+        abort_kucoin_validation_error("Parameter 'size' must be a positive number.")
       }
       if (isTRUE(is_isolated) && (is.null(symbol) || !verify_symbol(symbol))) {
-        rlang::abort("Parameter 'symbol' is required and must be a valid ticker when 'is_isolated' is TRUE.")
+        abort_kucoin_validation_error(
+          "Parameter 'symbol' is required and must be a valid ticker when 'is_isolated' is TRUE."
+        )
       }
 
       body <- list(
@@ -964,10 +966,10 @@ KucoinMarginTrading <- R6::R6Class(
     repay = function(currency, size) {
       assert_args_KucoinMarginTrading__repay(currency, size)
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
       if (!is.numeric(size) || size <= 0) {
-        rlang::abort("Parameter 'size' must be a positive number.")
+        abort_kucoin_validation_error("Parameter 'size' must be a positive number.")
       }
 
       body <- list(
@@ -1403,7 +1405,7 @@ KucoinMarginTrading <- R6::R6Class(
     #' }
     modify_leverage = function(leverage) {
       if (!is.numeric(leverage) || leverage <= 0) {
-        rlang::abort("Parameter 'leverage' must be a positive number.")
+        abort_kucoin_validation_error("Parameter 'leverage' must be a positive number.")
       }
 
       body <- list(leverage = as.character(leverage))

--- a/R/KucoinMarketData.R
+++ b/R/KucoinMarketData.R
@@ -1141,7 +1141,7 @@ KucoinMarketData <- R6::R6Class(
       assert_args_KucoinMarketData__get_part_orderbook(symbol)
       assert::assert_nonempty_strings(symbol)
       if (!size %in% c(20, 100)) {
-        rlang::abort("Parameter 'size' must be 20 or 100.")
+        abort_kucoin_validation_error("Parameter 'size' must be 20 or 100.")
       }
 
       res <- private$.request(

--- a/R/KucoinOcoOrders.R
+++ b/R/KucoinOcoOrders.R
@@ -193,7 +193,7 @@ KucoinOcoOrders <- R6::R6Class(
         trade_type
       )
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
       side <- rlang::arg_match0(side, c("buy", "sell"))
 

--- a/R/KucoinStopOrders.R
+++ b/R/KucoinStopOrders.R
@@ -271,27 +271,27 @@ KucoinStopOrders <- R6::R6Class(
       type <- rlang::arg_match0(type, c("limit", "market"))
       side <- rlang::arg_match0(side, c("buy", "sell"))
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       # Type-specific validation
       if (type == "limit") {
         if (is.null(price)) {
-          rlang::abort("'price' is required for limit stop orders.")
+          abort_kucoin_validation_error("'price' is required for limit stop orders.")
         }
         if (is.null(size)) {
-          rlang::abort("'size' is required for limit stop orders.")
+          abort_kucoin_validation_error("'size' is required for limit stop orders.")
         }
-        if (!is.null(funds)) rlang::abort("'funds' is not applicable for limit orders.")
+        if (!is.null(funds)) abort_kucoin_validation_error("'funds' is not applicable for limit orders.")
       } else {
         if (!is.null(price)) {
-          rlang::abort("'price' is not applicable for market orders.")
+          abort_kucoin_validation_error("'price' is not applicable for market orders.")
         }
         if (is.null(size) && is.null(funds)) {
-          rlang::abort("Either 'size' or 'funds' must be specified for market orders.")
+          abort_kucoin_validation_error("Either 'size' or 'funds' must be specified for market orders.")
         }
         if (!is.null(size) && !is.null(funds)) {
-          rlang::abort("'size' and 'funds' are mutually exclusive for market orders.")
+          abort_kucoin_validation_error("'size' and 'funds' are mutually exclusive for market orders.")
         }
       }
 

--- a/R/KucoinTrading.R
+++ b/R/KucoinTrading.R
@@ -550,7 +550,7 @@ KucoinTrading <- R6::R6Class(
     add_order_batch = function(order_list) {
       assert_args_KucoinTrading__add_order_batch(order_list)
       if (!is.list(order_list) || length(order_list) == 0 || length(order_list) > 20) {
-        rlang::abort("Parameter 'order_list' must contain 1 to 20 orders.")
+        abort_kucoin_validation_error("Parameter 'order_list' must contain 1 to 20 orders.")
       }
 
       validated <- lapply(order_list, validate_batch_order)
@@ -638,10 +638,10 @@ KucoinTrading <- R6::R6Class(
     cancel_order_by_id = function(order_id, symbol) {
       assert_args_KucoinTrading__cancel_order_by_id(order_id, symbol)
       if (!is.character(order_id) || !nzchar(order_id)) {
-        rlang::abort("Parameter 'order_id' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'order_id' must be a non-empty string.")
       }
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker (e.g., 'BTC-USDT').")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker (e.g., 'BTC-USDT').")
       }
 
       res <- private$.request(
@@ -710,10 +710,10 @@ KucoinTrading <- R6::R6Class(
     cancel_order_by_client_oid = function(client_order_id, symbol) {
       assert_args_KucoinTrading__cancel_order_by_client_oid(client_order_id, symbol)
       if (!is.character(client_order_id) || !nzchar(client_order_id)) {
-        rlang::abort("Parameter 'client_order_id' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'client_order_id' must be a non-empty string.")
       }
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       res <- private$.request(
@@ -789,10 +789,10 @@ KucoinTrading <- R6::R6Class(
     cancel_partial_order = function(order_id, symbol, cancel_size) {
       assert_args_KucoinTrading__cancel_partial_order(order_id, symbol, cancel_size)
       if (!is.character(order_id) || !nzchar(order_id)) {
-        rlang::abort("Parameter 'order_id' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'order_id' must be a non-empty string.")
       }
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       res <- private$.request(
@@ -863,7 +863,7 @@ KucoinTrading <- R6::R6Class(
     cancel_all_by_symbol = function(symbol) {
       assert_args_KucoinTrading__cancel_all_by_symbol(symbol)
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       res <- private$.request(
@@ -1059,10 +1059,10 @@ KucoinTrading <- R6::R6Class(
     get_order_by_id = function(order_id, symbol = NULL) {
       assert_args_KucoinTrading__get_order_by_id(order_id, symbol)
       if (!is.character(order_id) || !nzchar(order_id)) {
-        rlang::abort("Parameter 'order_id' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'order_id' must be a non-empty string.")
       }
       if (!is.null(symbol) && !verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       res <- private$.request(
@@ -1184,10 +1184,10 @@ KucoinTrading <- R6::R6Class(
     get_order_by_client_oid = function(client_order_id, symbol) {
       assert_args_KucoinTrading__get_order_by_client_oid(client_order_id, symbol)
       if (!is.character(client_order_id) || !nzchar(client_order_id)) {
-        rlang::abort("Parameter 'client_order_id' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'client_order_id' must be a non-empty string.")
       }
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       res <- private$.request(
@@ -1330,7 +1330,7 @@ KucoinTrading <- R6::R6Class(
         end_at
       )
       if (!is.null(symbol) && !verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       res <- private$.request(
@@ -1549,7 +1549,7 @@ KucoinTrading <- R6::R6Class(
     get_open_orders = function(symbol = NULL) {
       assert_args_KucoinTrading__get_open_orders(symbol)
       if (!is.null(symbol) && !verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       res <- private$.request(
@@ -1697,7 +1697,7 @@ KucoinTrading <- R6::R6Class(
         last_id
       )
       if (!is.null(symbol) && !verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       res <- private$.request(
@@ -2044,7 +2044,7 @@ KucoinTrading <- R6::R6Class(
     add_order_batch_sync = function(order_list) {
       assert_args_KucoinTrading__add_order_batch_sync(order_list)
       if (!is.list(order_list) || length(order_list) == 0 || length(order_list) > 20) {
-        rlang::abort("Parameter 'order_list' must contain 1 to 20 orders.")
+        abort_kucoin_validation_error("Parameter 'order_list' must contain 1 to 20 orders.")
       }
 
       validated <- lapply(order_list, validate_batch_order)
@@ -2156,10 +2156,10 @@ KucoinTrading <- R6::R6Class(
     cancel_order_by_id_sync = function(order_id, symbol) {
       assert_args_KucoinTrading__cancel_order_by_id_sync(order_id, symbol)
       if (!is.character(order_id) || !nzchar(order_id)) {
-        rlang::abort("Parameter 'order_id' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'order_id' must be a non-empty string.")
       }
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker (e.g., 'BTC-USDT').")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker (e.g., 'BTC-USDT').")
       }
 
       res <- private$.request(
@@ -2248,10 +2248,10 @@ KucoinTrading <- R6::R6Class(
     cancel_order_by_client_oid_sync = function(client_order_id, symbol) {
       assert_args_KucoinTrading__cancel_order_by_client_oid_sync(client_order_id, symbol)
       if (!is.character(client_order_id) || !nzchar(client_order_id)) {
-        rlang::abort("Parameter 'client_order_id' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'client_order_id' must be a non-empty string.")
       }
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker.")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker.")
       }
 
       res <- private$.request(
@@ -2361,13 +2361,13 @@ KucoinTrading <- R6::R6Class(
     modify_order = function(symbol, order_id = NULL, client_order_id = NULL, new_price = NULL, new_size = NULL) {
       assert_args_KucoinTrading__modify_order(symbol, order_id, client_order_id, new_price, new_size)
       if (!verify_symbol(symbol)) {
-        rlang::abort("Parameter 'symbol' must be a valid ticker (e.g., 'BTC-USDT').")
+        abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker (e.g., 'BTC-USDT').")
       }
       if (is.null(order_id) && is.null(client_order_id)) {
-        rlang::abort("At least one of 'order_id' or 'client_order_id' must be specified.")
+        abort_kucoin_validation_error("At least one of 'order_id' or 'client_order_id' must be specified.")
       }
       if (is.null(new_price) && is.null(new_size)) {
-        rlang::abort("At least one of 'new_price' or 'new_size' must be specified.")
+        abort_kucoin_validation_error("At least one of 'new_price' or 'new_size' must be specified.")
       }
 
       body <- list(symbol = symbol)
@@ -2477,10 +2477,10 @@ KucoinTrading <- R6::R6Class(
     set_dcp = function(timeout, symbols = NULL) {
       assert_args_KucoinTrading__set_dcp(symbols)
       if (!is.numeric(timeout) || length(timeout) != 1) {
-        rlang::abort("Parameter 'timeout' must be a single integer.")
+        abort_kucoin_validation_error("Parameter 'timeout' must be a single integer.")
       }
       if (timeout != -1 && (timeout < 5 || timeout > 86400)) {
-        rlang::abort("Parameter 'timeout' must be -1 (disable) or between 5 and 86400.")
+        abort_kucoin_validation_error("Parameter 'timeout' must be -1 (disable) or between 5 and 86400.")
       }
 
       body <- list(timeout = as.integer(timeout))

--- a/R/KucoinTransfer.R
+++ b/R/KucoinTransfer.R
@@ -202,17 +202,17 @@ KucoinTransfer <- R6::R6Class(
         to_account_tag
       )
       if (!is.character(client_order_id) || !nzchar(client_order_id)) {
-        rlang::abort("Parameter 'client_order_id' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'client_order_id' must be a non-empty string.")
       }
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
       if (!is.character(amount) || !nzchar(amount)) {
-        rlang::abort("Parameter 'amount' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'amount' must be a non-empty string.")
       }
       valid_types <- c("INTERNAL", "PARENT_TO_SUB", "SUB_TO_PARENT")
       if (!is.character(type) || !(type %in% valid_types)) {
-        rlang::abort(paste0(
+        abort_kucoin_validation_error(paste0(
           "Parameter 'type' must be one of: ",
           paste(valid_types, collapse = ", "),
           "."
@@ -220,14 +220,14 @@ KucoinTransfer <- R6::R6Class(
       }
       valid_accounts <- c("MAIN", "TRADE", "CONTRACT", "MARGIN", "ISOLATED", "MARGIN_V2", "ISOLATED_V2")
       if (!is.character(from_account_type) || !(from_account_type %in% valid_accounts)) {
-        rlang::abort(paste0(
+        abort_kucoin_validation_error(paste0(
           "Parameter 'fromAccountType' must be one of: ",
           paste(valid_accounts, collapse = ", "),
           "."
         ))
       }
       if (!is.character(to_account_type) || !(to_account_type %in% valid_accounts)) {
-        rlang::abort(paste0(
+        abort_kucoin_validation_error(paste0(
           "Parameter 'toAccountType' must be one of: ",
           paste(valid_accounts, collapse = ", "),
           "."
@@ -354,11 +354,11 @@ KucoinTransfer <- R6::R6Class(
     get_transferable = function(currency, type, tag = NULL) {
       assert_args_KucoinTransfer__get_transferable(currency, type, tag)
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
       valid_types <- c("MAIN", "TRADE", "MARGIN", "ISOLATED", "MARGIN_V2", "ISOLATED_V2")
       if (!is.character(type) || !(type %in% valid_types)) {
-        rlang::abort(paste0(
+        abort_kucoin_validation_error(paste0(
           "Parameter 'type' must be one of: ",
           paste(valid_types, collapse = ", "),
           "."

--- a/R/KucoinWithdrawal.R
+++ b/R/KucoinWithdrawal.R
@@ -187,17 +187,17 @@ KucoinWithdrawal <- R6::R6Class(
         fee_deduct_type
       )
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
       if (!is.character(to_address) || !nzchar(to_address)) {
-        rlang::abort("Parameter 'toAddress' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'toAddress' must be a non-empty string.")
       }
       if (!is.character(amount) || !nzchar(amount)) {
-        rlang::abort("Parameter 'amount' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'amount' must be a non-empty string.")
       }
       valid_types <- c("ADDRESS", "UID", "MAIL", "PHONE")
       if (!is.character(withdraw_type) || !(withdraw_type %in% valid_types)) {
-        rlang::abort(paste0(
+        abort_kucoin_validation_error(paste0(
           "Parameter 'withdrawType' must be one of: ",
           paste(valid_types, collapse = ", "),
           "."
@@ -205,7 +205,7 @@ KucoinWithdrawal <- R6::R6Class(
       }
 
       if (is.null(chain)) {
-        rlang::abort("Parameter 'chain' is required by the KuCoin API.")
+        abort_kucoin_validation_error("Parameter 'chain' is required by the KuCoin API.")
       }
 
       body <- list(
@@ -309,7 +309,7 @@ KucoinWithdrawal <- R6::R6Class(
     cancel_withdrawal = function(withdrawal_id) {
       assert_args_KucoinWithdrawal__cancel_withdrawal(withdrawal_id)
       if (!is.character(withdrawal_id) || !nzchar(withdrawal_id)) {
-        rlang::abort("Parameter 'withdrawalId' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'withdrawalId' must be a non-empty string.")
       }
 
       res <- private$.request(
@@ -431,7 +431,7 @@ KucoinWithdrawal <- R6::R6Class(
     get_withdrawal_quotas = function(currency, chain = NULL) {
       assert_args_KucoinWithdrawal__get_withdrawal_quotas(currency, chain)
       if (!is.character(currency) || !nzchar(currency)) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
 
       res <- private$.request(
@@ -611,7 +611,7 @@ KucoinWithdrawal <- R6::R6Class(
         max_pages
       )
       if (!is.null(currency) && (!is.character(currency) || !nzchar(currency))) {
-        rlang::abort("Parameter 'currency' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'currency' must be a non-empty string.")
       }
 
       res <- private$.paginate(
@@ -770,7 +770,7 @@ KucoinWithdrawal <- R6::R6Class(
     get_withdrawal_by_id = function(withdrawal_id) {
       assert_args_KucoinWithdrawal__get_withdrawal_by_id(withdrawal_id)
       if (!is.character(withdrawal_id) || !nzchar(withdrawal_id)) {
-        rlang::abort("Parameter 'withdrawalId' must be a non-empty string.")
+        abort_kucoin_validation_error("Parameter 'withdrawalId' must be a non-empty string.")
       }
 
       res <- private$.request(

--- a/R/backfill.R
+++ b/R/backfill.R
@@ -68,7 +68,7 @@ kucoin_backfill_klines <- function(
   assert_args_kucoin_backfill_klines(timeframes, file, base_url, sleep, verbose)
   # --- Input validation ---
   if (is.null(symbols) || length(symbols) == 0L) {
-    rlang::abort("`symbols` must be a non-empty character vector of trading pairs.")
+    abort_kucoin_validation_error("`symbols` must be a non-empty character vector of trading pairs.")
   }
 
   # Clamp from / to

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -84,3 +84,38 @@ abort_kucoin_error <- function(status, code = NULL, msg = NULL, url = NULL, body
     call = rlang::caller_env()
   ))
 }
+
+#' Raise a typed KuCoin input-validation error
+#'
+#' Signals a condition classed `c("kucoin_validation_error", "kucoin_error")` (on
+#' top of rlang's error classes) for a NON-transport failure: a method's argument
+#' or parameter is malformed or violates a rule before any request is made (a
+#' missing required parameter, a bad ticker, a non-positive size, a
+#' mutually-exclusive pair supplied together, a value out of range). `kucoin_error`
+#' is the connector's DOMAIN root, parallel to the transport `connectcore_error`
+#' root: a validation failure is not a transport failure, so the two roots never
+#' meet -- exactly the `core_error` / `connectcore_error` split. The `message` is
+#' passed through verbatim, so the string stays byte-identical to the bare
+#' `rlang::abort()` this replaced. See [connectcore::connectcore_conditions] for
+#' the transport taxonomy.
+#'
+#' @param message (scalar<character>) the condition message, passed through
+#'   verbatim to [rlang::abort()].
+#' @param ... structured fields stored on the condition, read with `e[["field"]]`.
+#'   Forwarded to [rlang::abort()].
+#' @param call (environment) the environment blamed in the traceback; defaults to
+#'   the caller via [rlang::caller_env()].
+#' @return (class<kucoin_error>) never returns normally; signals the classed
+#'   condition described above.
+#' @importFrom rlang abort caller_env
+#' @keywords internal
+#' @noassert
+#' @noRd
+abort_kucoin_validation_error <- function(message, ..., call = rlang::caller_env()) {
+  return(rlang::abort(
+    message = message,
+    class = c("kucoin_validation_error", "kucoin_error"),
+    ...,
+    call = call
+  ))
+}

--- a/R/helpers_validate.R
+++ b/R/helpers_validate.R
@@ -104,7 +104,7 @@ validate_order_params <- function(
   side <- rlang::arg_match0(side, c("buy", "sell"))
 
   if (!verify_symbol(symbol)) {
-    rlang::abort("Parameter 'symbol' must be a valid ticker (e.g., 'BTC-USDT').")
+    abort_kucoin_validation_error("Parameter 'symbol' must be a valid ticker (e.g., 'BTC-USDT').")
   }
 
   # Convert numerics to character for the API
@@ -124,28 +124,28 @@ validate_order_params <- function(
   # Type-specific validation
   if (type == "limit") {
     if (is.null(price)) {
-      rlang::abort("Parameter 'price' is required for limit orders.")
+      abort_kucoin_validation_error("Parameter 'price' is required for limit orders.")
     }
     if (is.null(size)) {
-      rlang::abort("Parameter 'size' is required for limit orders.")
+      abort_kucoin_validation_error("Parameter 'size' is required for limit orders.")
     }
-    if (!is.null(funds)) rlang::abort("Parameter 'funds' is not applicable for limit orders.")
+    if (!is.null(funds)) abort_kucoin_validation_error("Parameter 'funds' is not applicable for limit orders.")
   } else if (type == "market") {
     if (!is.null(price)) {
-      rlang::abort("Parameter 'price' is not applicable for market orders.")
+      abort_kucoin_validation_error("Parameter 'price' is not applicable for market orders.")
     }
     if (is.null(size) && is.null(funds)) {
-      rlang::abort("Either 'size' or 'funds' must be specified for market orders.")
+      abort_kucoin_validation_error("Either 'size' or 'funds' must be specified for market orders.")
     }
     if (!is.null(size) && !is.null(funds)) {
-      rlang::abort("Parameters 'size' and 'funds' are mutually exclusive for market orders.")
+      abort_kucoin_validation_error("Parameters 'size' and 'funds' are mutually exclusive for market orders.")
     }
   }
 
   # Optional parameter validation
   if (!is.null(client_order_id)) {
     if (!is.character(client_order_id) || nchar(client_order_id) > 40 || !grepl("^[a-zA-Z0-9_-]+$", client_order_id)) {
-      rlang::abort("Parameter 'client_order_id' must be <= 40 chars, alphanumeric/underscore/hyphen.")
+      abort_kucoin_validation_error("Parameter 'client_order_id' must be <= 40 chars, alphanumeric/underscore/hyphen.")
     }
   }
 
@@ -155,13 +155,13 @@ validate_order_params <- function(
 
   if (!is.null(tags)) {
     if (!is.character(tags) || nchar(tags) > 20 || !all(charToRaw(tags) <= 127)) {
-      rlang::abort("Parameter 'tags' must be ASCII and max 20 characters.")
+      abort_kucoin_validation_error("Parameter 'tags' must be ASCII and max 20 characters.")
     }
   }
 
   if (!is.null(remark)) {
     if (!is.character(remark) || nchar(remark) > 20 || !all(charToRaw(remark) <= 127)) {
-      rlang::abort("Parameter 'remark' must be ASCII and max 20 characters.")
+      abort_kucoin_validation_error("Parameter 'remark' must be ASCII and max 20 characters.")
     }
   }
 
@@ -171,34 +171,34 @@ validate_order_params <- function(
 
   if (!is.null(cancel_after)) {
     if (!is.numeric(cancel_after) || cancel_after <= 0) {
-      rlang::abort("Parameter 'cancel_after' must be a positive number.")
+      abort_kucoin_validation_error("Parameter 'cancel_after' must be a positive number.")
     }
     cancel_after <- as.integer(cancel_after)
   }
 
   if (!is.null(post_only) && !is.logical(post_only)) {
-    rlang::abort("Parameter 'post_only' must be logical.")
+    abort_kucoin_validation_error("Parameter 'post_only' must be logical.")
   }
   if (!is.null(hidden) && !is.logical(hidden)) {
-    rlang::abort("Parameter 'hidden' must be logical.")
+    abort_kucoin_validation_error("Parameter 'hidden' must be logical.")
   }
   if (!is.null(iceberg) && !is.logical(iceberg)) {
-    rlang::abort("Parameter 'iceberg' must be logical.")
+    abort_kucoin_validation_error("Parameter 'iceberg' must be logical.")
   }
 
   if (!is.null(visible_size) && !isTRUE(iceberg)) {
-    rlang::abort("Parameter 'visible_size' is only applicable when 'iceberg' is TRUE.")
+    abort_kucoin_validation_error("Parameter 'visible_size' is only applicable when 'iceberg' is TRUE.")
   }
 
   # Cross-field validation
   if (identical(time_in_force, "GTT") && is.null(cancel_after)) {
-    rlang::abort("Parameter 'cancel_after' is required when 'time_in_force' is 'GTT'.")
+    abort_kucoin_validation_error("Parameter 'cancel_after' is required when 'time_in_force' is 'GTT'.")
   }
   if (isTRUE(post_only) && time_in_force %in% c("IOC", "FOK")) {
-    rlang::abort("Parameter 'post_only' cannot be TRUE when 'time_in_force' is 'IOC' or 'FOK'.")
+    abort_kucoin_validation_error("Parameter 'post_only' cannot be TRUE when 'time_in_force' is 'IOC' or 'FOK'.")
   }
   if (isTRUE(iceberg) && isTRUE(hidden)) {
-    rlang::abort("Parameters 'iceberg' and 'hidden' cannot both be TRUE.")
+    abort_kucoin_validation_error("Parameters 'iceberg' and 'hidden' cannot both be TRUE.")
   }
 
   # Build the result list, dropping NULLs
@@ -297,13 +297,13 @@ validate_margin_order_params <- function(
 
   # Margin-specific validation
   if (!is.null(is_isolated) && !is.logical(is_isolated)) {
-    rlang::abort("Parameter 'is_isolated' must be logical.")
+    abort_kucoin_validation_error("Parameter 'is_isolated' must be logical.")
   }
   if (!is.null(auto_borrow) && !is.logical(auto_borrow)) {
-    rlang::abort("Parameter 'autoBorrow' must be logical.")
+    abort_kucoin_validation_error("Parameter 'autoBorrow' must be logical.")
   }
   if (!is.null(auto_repay) && !is.logical(auto_repay)) {
-    rlang::abort("Parameter 'autoRepay' must be logical.")
+    abort_kucoin_validation_error("Parameter 'autoRepay' must be logical.")
   }
 
   # Append margin-specific fields
@@ -331,13 +331,13 @@ validate_margin_order_params <- function(
 validate_batch_order <- function(order) {
   assert_args_validate_batch_order(order)
   if (!is.list(order)) {
-    rlang::abort("Each order in a batch must be a list.")
+    abort_kucoin_validation_error("Each order in a batch must be a list.")
   }
 
   required <- c("symbol", "type", "side")
   missing <- setdiff(required, names(order))
   if (length(missing) > 0) {
-    rlang::abort(paste0("Missing required field(s) in batch order: ", paste(missing, collapse = ", ")))
+    abort_kucoin_validation_error(paste0("Missing required field(s) in batch order: ", paste(missing, collapse = ", ")))
   }
 
   return(assert_return_validate_batch_order(validate_order_params(

--- a/R/impl_klines.R
+++ b/R/impl_klines.R
@@ -42,7 +42,7 @@ kucoin_fetch_klines <- function(
   is_async = FALSE
 ) {
   if (!timeframe %in% names(kucoin_timeframe_map)) {
-    rlang::abort(paste0(
+    abort_kucoin_validation_error(paste0(
       "Invalid timeframe '",
       timeframe,
       "'. Valid: ",
@@ -202,7 +202,7 @@ kucoin_fetch_futures_klines <- function(
 ) {
   gran_key <- as.character(granularity)
   if (!gran_key %in% names(kucoin_futures_granularity_map)) {
-    rlang::abort(paste0(
+    abort_kucoin_validation_error(paste0(
       "Invalid granularity '",
       granularity,
       "'. Valid: ",

--- a/R/utils_time.R
+++ b/R/utils_time.R
@@ -24,7 +24,7 @@
 time_convert_from_kucoin <- function(time_value, unit = c("ms", "ns", "s")) {
   unit <- match.arg(unit)
   if (!is.numeric(time_value)) {
-    rlang::abort("Input must be a numeric value.")
+    abort_kucoin_validation_error("Input must be a numeric value.")
   }
 
   seconds <- switch(
@@ -60,7 +60,7 @@ time_convert_from_kucoin <- function(time_value, unit = c("ms", "ns", "s")) {
 time_convert_to_kucoin <- function(datetime, unit = c("ms", "ns", "s")) {
   unit <- match.arg(unit)
   if (!inherits(datetime, "POSIXct")) {
-    rlang::abort("Input must be a POSIXct object.")
+    abort_kucoin_validation_error("Input must be a POSIXct object.")
   }
 
   seconds <- as.numeric(datetime)

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -1,0 +1,41 @@
+# Typed KuCoin input-validation conditions. Every non-transport abort is raised
+# through abort_kucoin_validation_error(), classed c("kucoin_validation_error",
+# "kucoin_error") -- kucoin_error is the connector's DOMAIN root, parallel to the
+# transport connectcore_error root. The message strings stay byte-identical to
+# the bare rlang::abort() calls each site replaced (the goldens below pin that).
+# If a golden fails, the backward-compatibility contract broke.
+
+test_that("abort_kucoin_validation_error layers kucoin_validation_error then kucoin_error", {
+  err <- tryCatch(kucoin:::abort_kucoin_validation_error("boom"), error = function(e) e)
+  expect_identical(
+    class(err),
+    c("kucoin_validation_error", "kucoin_error", "rlang_error", "error", "condition")
+  )
+  expect_identical(conditionMessage(err), "boom")
+})
+
+test_that("kucoin_validation_error is caught by the kucoin_error root but is NOT a transport error", {
+  caught <- tryCatch(kucoin:::abort_kucoin_validation_error("x"), kucoin_error = function(e) "root")
+  expect_identical(caught, "root")
+  err <- tryCatch(kucoin:::abort_kucoin_validation_error("x"), error = function(e) e)
+  expect_false(inherits(err, "connectcore_error"))
+})
+
+# ---- Real sites: class, and byte-identical message (golden) ----
+
+test_that("time_convert_from_kucoin rejects a non-numeric with kucoin_validation_error (golden)", {
+  err <- tryCatch(time_convert_from_kucoin("not-a-number"), error = function(e) e)
+  expect_s3_class(err, "kucoin_validation_error")
+  expect_s3_class(err, "kucoin_error")
+  expect_identical(conditionMessage(err), "Input must be a numeric value.")
+})
+
+test_that("validate_order_params rejects a limit order without price with kucoin_validation_error (golden)", {
+  err <- tryCatch(
+    validate_order_params(type = "limit", symbol = "BTC-USDT", side = "buy", size = 0.001),
+    error = function(e) e
+  )
+  expect_s3_class(err, "kucoin_validation_error")
+  expect_s3_class(err, "kucoin_error")
+  expect_identical(conditionMessage(err), "Parameter 'price' is required for limit orders.")
+})


### PR DESCRIPTION
When a KuCoin method rejected a bad argument — a missing required parameter, a malformed ticker, a non-positive size, a mutually-exclusive pair supplied together — it raised a bare text string, so any code that wanted to react could only pattern-match the English message, which breaks the moment the wording changes. This PR gives every one of those input-validation errors a machine-readable TYPE so callers branch on the kind of failure, not its wording. The messages themselves do not change.

This is the input-validation half of the connector's error taxonomy, completing the picture alongside the request funnel's typed transport conditions, following the org convention (dereckscompany/tradebot-core#30; discussion "throw typed errors, not bare strings").

What changed:

- The 101 non-transport `rlang::abort()` sites — a method's argument or parameter is malformed or violates a rule before any request is made — now raise through a new internal `abort_kucoin_validation_error()` raiser. Every one classifies as input validation; there is no other non-transport surface in this connector.
- The class vector is `c("kucoin_validation_error", "kucoin_error")`. `kucoin_error` is the connector's DOMAIN root, parallel to the transport `connectcore_error` root: a validation failure is not a transport failure, so the two roots never meet — exactly the `core_error` / `connectcore_error` split the fleet already uses. Catch `kucoin_validation_error` for input bugs specifically, or `kucoin_error` for any non-transport KuCoin failure.
- The API / transport funnel is untouched (`abort_kucoin_error`, rooted at `connectcore_error`).

Backward compatibility:

- Every converted site signals the SAME message string it signalled before. A reverse-substitution proves all 101 sites reproduce `origin/master` byte-for-byte; new golden tests in `test-conditions.R` pin two representative sites byte-for-byte.
- `conditionMessage()` and `inherits(e, "error")` are unchanged; the classes are purely additive. No behaviour changes.

Verification (local; org CI off):

- Full suite: FAIL 0 | WARN 0 | SKIP 0 | PASS 1449.
- `R CMD check`: 0 errors, 0 warnings, 2 NOTEs (the MIT-license template; a pre-existing "Lost braces" doc issue in `KucoinMarketData.Rd`) — both pre-existing and identical on master. `rlang` is NOT flagged as an unused import (still used by the raisers).
- `scripts/FORMAT.sh` and `scripts/LINT.sh` clean (0 warnings; the new raiser added to the `return_linter` allowlist).
