### PR TITLE
fix(klines): keep segment epoch math in double to avoid int32 overflow (closes #40)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kucoin
 Type: Package
 Title: API Wrapper to KuCoin Cryptocurrency Exchange
-Version: 4.5.0
+Version: 4.5.1
 URL: https://dereckscompany.github.io/kucoin/
 BugReports: https://github.com/dereckscompany/kucoin/issues
 Authors@R: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# kucoin 4.5.1
+
+## Weekly and monthly candle fetches no longer overflow (closes #40)
+
+In plain English: asking for 1week or 1month candles over any long history used to crash the fetch loop, because the arithmetic that splits the request into 1,500-candle segments was done in 32-bit integers — and fifteen hundred months of seconds is a bigger number than a 32-bit integer can hold. The segment maths now stays in double precision end to end (mirroring the futures path, which always did), so week- and month-scale backfills work across the full history. Regression tests pin 1week and 1month segment boundaries at 2020-era epochs and prove the hourly/daily paths are byte-for-byte unchanged.
+
 # kucoin 4.5.0
 
 ## Typed input-validation conditions (the non-transport half of the taxonomy)

--- a/R/impl_klines.R
+++ b/R/impl_klines.R
@@ -85,9 +85,16 @@ kucoin_fetch_klines <- function(
     from <- lubridate::now("UTC") - lubridate::dhours(24)
   }
 
+  # Epoch-second math stays in double, never int32. For week/month intervals the
+  # window width `max_candles * timeframe_seconds` alone exceeds
+  # .Machine$integer.max (1500 * 2592000 = 3.888e9), and adding a 2020-era epoch
+  # second compounds it, so int32 arithmetic yielded NA and broke the loop
+  # condition (issue #40). The futures path already works in double for this
+  # reason. `as.numeric(timeframe_seconds)` forces the product into double even
+  # though `from_s`/`to_s` are already double.
   timeframe_seconds <- kucoin_timeframe_map[[timeframe]]
-  from_s <- as.integer(as.numeric(from))
-  to_s <- as.integer(as.numeric(to))
+  from_s <- as.numeric(from)
+  to_s <- as.numeric(to)
   max_candles <- 1500L
 
   # Split into segments of up to 1500 candles each, with 1-candle overlap
@@ -95,7 +102,7 @@ kucoin_fetch_klines <- function(
   segments <- list()
   seg_start <- from_s
   while (seg_start < to_s) {
-    seg_end <- min(seg_start + max_candles * timeframe_seconds, to_s)
+    seg_end <- min(seg_start + max_candles * as.numeric(timeframe_seconds), to_s)
     segments[[length(segments) + 1L]] <- list(
       startAt = seg_start,
       endAt = seg_end

--- a/tests/testthat/test-impl_klines.R
+++ b/tests/testthat/test-impl_klines.R
@@ -266,3 +266,148 @@ test_that("kucoin_fetch_klines segments overlap by 1 candle", {
   seg2_start <- captured_queries[[2]]$startAt
   expect_equal(seg2_start, seg1_end - 900)
 })
+
+# -- int32 overflow regression (issue #40) --
+
+# For week/month intervals the segment-window width alone
+# (max_candles * timeframe_seconds) exceeds .Machine$integer.max, so the old
+# int32 arithmetic produced `NA` on the first loop iteration and threw
+# "missing value where TRUE/FALSE needed". These tests drive the exact 2020-era
+# epochs from the bug report and assert the segmentation is overflow-free with
+# finite, correct boundaries.
+
+test_that("kucoin_fetch_klines: 1week segment math is overflow-free at 2020+ epochs (issue #40)", {
+  from_dt <- lubridate::as_datetime("2020-01-01", tz = "UTC")
+  to_dt <- lubridate::as_datetime("2021-01-01", tz = "UTC")
+  from_s <- as.numeric(from_dt)
+  to_s <- as.numeric(to_dt)
+
+  captured_queries <- list()
+  call_count <- 0L
+  fake_req_fn <- function(endpoint, method, query, auth, .parser, ...) {
+    call_count <<- call_count + 1L
+    captured_queries[[call_count]] <<- query
+    return(.parser(list()))
+  }
+
+  expect_no_warning(
+    kucoin_fetch_klines(
+      symbol = "BTC-USDT",
+      timeframe = "1week",
+      from = from_dt,
+      to = to_dt,
+      .req_fn = fake_req_fn
+    )
+  )
+
+  # A full year of weekly candles fits inside one 1500-week segment
+  expect_equal(call_count, 1L)
+  q <- captured_queries[[1]]
+  expect_false(is.na(q$startAt))
+  expect_false(is.na(q$endAt))
+  expect_equal(q$startAt, from_s)
+  expect_equal(q$endAt, to_s)
+})
+
+test_that("kucoin_fetch_klines: 1month segment math is overflow-free at 2020+ epochs (issue #40)", {
+  from_dt <- lubridate::as_datetime("2020-01-01", tz = "UTC")
+  to_dt <- lubridate::as_datetime("2022-01-01", tz = "UTC")
+  from_s <- as.numeric(from_dt)
+  to_s <- as.numeric(to_dt)
+
+  captured_queries <- list()
+  call_count <- 0L
+  fake_req_fn <- function(endpoint, method, query, auth, .parser, ...) {
+    call_count <<- call_count + 1L
+    captured_queries[[call_count]] <<- query
+    return(.parser(list()))
+  }
+
+  # 1month's width alone (1500 * 2592000 = 3.888e9) overflows int32 even before
+  # adding the epoch second, so this is the strictest regression of the two.
+  expect_no_warning(
+    kucoin_fetch_klines(
+      symbol = "BTC-USDT",
+      timeframe = "1month",
+      from = from_dt,
+      to = to_dt,
+      .req_fn = fake_req_fn
+    )
+  )
+
+  expect_equal(call_count, 1L)
+  q <- captured_queries[[1]]
+  expect_false(is.na(q$startAt))
+  expect_false(is.na(q$endAt))
+  expect_equal(q$startAt, from_s)
+  expect_equal(q$endAt, to_s)
+})
+
+test_that("kucoin_fetch_klines: 1week multi-segment boundaries are correct past int32 (issue #40)", {
+  tf_s <- 604800 # 1week in seconds
+  from_dt <- lubridate::as_datetime("2020-01-01", tz = "UTC")
+  from_s <- as.numeric(from_dt)
+  # Window just over one 1500-week segment to force a second segment. The first
+  # segment's endAt (from_s + 1500 * 604800 = 2.485e9) lands past
+  # .Machine$integer.max, which is exactly where the old code overflowed.
+  to_s <- from_s + 1500 * tf_s + tf_s
+  to_dt <- lubridate::as_datetime(to_s, tz = "UTC")
+
+  captured_queries <- list()
+  call_count <- 0L
+  fake_req_fn <- function(endpoint, method, query, auth, .parser, ...) {
+    call_count <<- call_count + 1L
+    captured_queries[[call_count]] <<- query
+    return(.parser(list()))
+  }
+
+  expect_no_warning(
+    kucoin_fetch_klines(
+      symbol = "BTC-USDT",
+      timeframe = "1week",
+      from = from_dt,
+      to = to_dt,
+      .req_fn = fake_req_fn
+    )
+  )
+
+  expect_equal(call_count, 2L)
+  seg1_end <- captured_queries[[1]]$endAt
+  seg2_start <- captured_queries[[2]]$startAt
+  expect_false(is.na(seg1_end))
+  expect_gt(seg1_end, .Machine$integer.max)
+  expect_equal(seg1_end, from_s + 1500 * tf_s)
+  expect_equal(seg2_start, seg1_end - tf_s) # 1-candle overlap
+})
+
+test_that("kucoin_fetch_klines: sub-week intervals (1hour/4hour/1day) unchanged at 2020+ epochs (issue #40)", {
+  from_dt <- lubridate::as_datetime("2020-01-01", tz = "UTC")
+  from_s <- as.numeric(from_dt)
+  to_dt <- from_dt + lubridate::ddays(50) # small window: single segment for all
+  to_s <- as.numeric(to_dt)
+
+  for (tf in c("1hour", "4hour", "1day")) {
+    captured_queries <- list()
+    call_count <- 0L
+    fake_req_fn <- function(endpoint, method, query, auth, .parser, ...) {
+      call_count <<- call_count + 1L
+      captured_queries[[call_count]] <<- query
+      return(.parser(list()))
+    }
+
+    expect_no_warning(
+      kucoin_fetch_klines(
+        symbol = "BTC-USDT",
+        timeframe = tf,
+        from = from_dt,
+        to = to_dt,
+        .req_fn = fake_req_fn
+      )
+    )
+
+    expect_equal(call_count, 1L, info = tf)
+    q <- captured_queries[[1]]
+    expect_equal(q$startAt, from_s, info = tf)
+    expect_equal(q$endAt, to_s, info = tf)
+  }
+})


### PR DESCRIPTION
## In plain terms

Backfilling KuCoin `1week` and `1month` candles never returned any data: every request died with `NAs produced by integer overflow` followed by `missing value where TRUE/FALSE needed`. The shorter intervals (`1min` … `1day`) were fine. The cause was that the code did its epoch-second arithmetic in 32-bit integers, and for week/month intervals one intermediate value grew past the largest number a 32-bit integer can hold, turning into `NA` and breaking the loop that walks the time range. This makes the weekly/monthly math run in ordinary (64-bit) floating point instead, so it no longer overflows.

## Root cause

`kucoin_fetch_klines()` (`R/impl_klines.R`) coerced the range bounds to int32 and added an integer window width:

```r
from_s <- as.integer(as.numeric(from))
to_s   <- as.integer(as.numeric(to))
max_candles <- 1500L
seg_end <- min(seg_start + max_candles * timeframe_seconds, to_s)
```

For `1week`, `max_candles * timeframe_seconds = 1500 * 604800 = 907,200,000`; adding a 2020-era epoch second (`1,577,836,800`) gives `2,485,036,800 > .Machine$integer.max (2,147,483,647)` → `NA`, and the subsequent `if (seg_end >= to_s)` throws. For `1month` the window width alone (`1500 * 2592000 = 3,888,000,000`) already overflows int32 regardless of the epoch, so dropping the `as.integer()` coercion is necessary but not sufficient on its own — the product must also be forced to double.

## The fix

Keep the segmentation math in double, mirroring `kucoin_fetch_futures_klines()` which already uses `as.numeric(...)`:

- drop the `as.integer()` coercion on `from_s` / `to_s` (epoch seconds are exact in a double well past 2100);
- force the window width to double via `max_candles * as.numeric(timeframe_seconds)` so `1month` cannot overflow either.

Query parameters are still whole numbers; `httr2::req_url_query()` serialises the resulting doubles without scientific notation (`2480036800` → `2480036800`), and the futures path already passes doubles through the same funnel.

## Tests

Adds four regression tests to `test-impl_klines.R`: `1week` and `1month` segment math at 2020+ epochs (overflow-free, finite boundaries, correct `startAt`/`endAt`), a multi-segment `1week` case whose first segment boundary lands past `.Machine$integer.max` with correct 1-candle overlap, and a proof that `1hour`/`4hour`/`1day` boundaries are unchanged.

Full suite against the installed package: `FAIL 0 | WARN 0 | SKIP 0 | PASS 1479` (2 live-integration files skipped, no credentials). `impl_klines` file: `FAIL 0 | WARN 0 | SKIP 0 | PASS 56`.

R CMD check: `1 error | 0 warnings | 3 notes` — identical to the `origin/master` baseline (`1 error | 0 warnings | 4 notes`); every finding on this branch is a subset of master's (the vignette-rebuild error from `box::use("../tests/testthat/mock_router")` and the licence/timestamp/Rd notes are all pre-existing). No new findings introduced.

closes #40
