### PR TITLE
chore(desc): drop stale RoxygenNote (keep Config/roxygen2/version 8.0.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,4 +50,3 @@ Remotes:
     dereckscompany/roxyassert
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0
-RoxygenNote: 7.3.3


### PR DESCRIPTION
The package metadata recorded two different roxygen2 versions at once: the modern `Config/roxygen2/version: 8.0.0` field and a leftover `RoxygenNote: 7.3.3` from an older toolchain. This drops the stale one so kucoin matches the rest of the fleet -- sibling connectors like `binance` and `aisstream` record only `Config/roxygen2/version: 8.0.0` and no `RoxygenNote`.

This is a metadata-only edit. `RoxygenNote` records which roxygen2 last ran and does not affect the generated documentation, so `man/` was not regenerated (no content-loss risk).

## Verification

`R CMD check` on the built tarball -> **2 NOTEs, 0 ERRORs, 0 WARNINGs**:

- `checking tests ... OK`, `checking re-building of vignette outputs ... OK`.
- The two NOTEs are pre-existing and unrelated to this change: (1) `License components which are templates and need '+ file LICENSE': MIT`, and (2) `Lost braces` in the generated `KucoinMarketData.Rd` (man/ untouched here). Both appear on master as well.