### PR TITLE
feat(retry): constructor max_tries, a hard GET-only carve-out

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kucoin
 Type: Package
 Title: API Wrapper to KuCoin Cryptocurrency Exchange
-Version: 4.5.1
+Version: 4.6.0
 URL: https://dereckscompany.github.io/kucoin/
 BugReports: https://github.com/dereckscompany/kucoin/issues
 Authors@R: 
@@ -28,7 +28,7 @@ Imports:
     lubridate,
     uuid,
     assert,
-    connectcore (>= 0.4.0)
+    connectcore (>= 0.5.0)
 Suggests:
     promises,
     coro,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# kucoin 4.6.0
+
+## Opt-in request retry at construction (`max_tries`), a hard GET-only carve-out
+
+Every client class constructor (via `KucoinBase`) gains a `max_tries` argument (`scalar<integer in [1, 10]>`, default `1` = no retry) threaded to `connectcore`'s retry machinery. Setting it above `1` opts every GET the client makes — single requests and paginated reads alike — into automatic retry on a transient failure (HTTP 408/429/5xx or a dropped connection) with jittered backoff. Retry is a hard **GET-only** carve-out: a non-idempotent verb (an order `POST`, a cancel `DELETE`) is never auto-retried, so a resend can never double-submit an order. The default `1` leaves live-trading behaviour unchanged — the trader layer stays the single retry authority there; raise `max_tries` only for research and backfill reads. Implements the fleet retry-convergence ruling (2026-07-14), closes #14. Requires `connectcore (>= 0.5.0)`, where the GET-only guard is enforced in the one shared request funnel. `kucoin_paginate()` also gains a `max_tries` argument so the constructor policy reaches paginated reads.
+
 # kucoin 4.5.1
 
 ## Weekly and monthly candle fetches no longer overflow (closes #40)

--- a/R/KucoinBase.R
+++ b/R/KucoinBase.R
@@ -41,6 +41,17 @@
 #'   before each authenticated request. This is slower (one extra HTTP round
 #'   trip) but ensures signing works even when the local clock is out of sync.
 #'
+#' ### Retries
+#' `max_tries > 1` opts every GET this client makes — single requests and
+#' paginated reads alike — into automatic retry on a transient failure (HTTP
+#' 408/429/5xx or a dropped connection) with jittered backoff, delegated to
+#' [connectcore::build_request()]. Retry is a hard **GET-only** carve-out: a
+#' non-idempotent verb (an order `POST`, a cancel `DELETE`) is never
+#' auto-retried, so a resend can never double-submit an order. Leave it at the
+#' default `1` for live trading — there the trader layer is the single retry
+#' authority (it routes by typed error class and manages cooldowns); raise it
+#' only for research and backfill reads.
+#'
 #' ### Design
 #' This class is not meant to be instantiated directly. Subclasses (e.g.,
 #' [KucoinMarketData], [KucoinTrading]) inherit from it and define their
@@ -75,15 +86,20 @@ KucoinBase <- R6::R6Class(
     #'   signing. `"local"` (default) uses the local UTC clock. `"server"` fetches
     #'   the KuCoin server time before each authenticated request, which adds
     #'   latency but avoids clock-drift issues.
+    #' @param max_tries (scalar<integer in [1, 10]>) for idempotent GET requests
+    #'   only, retry up to this many times on a transient failure. Default `1`
+    #'   (no retry). See the class **Retries** section for the write-safety
+    #'   carve-out and why live trading should leave this at `1`.
     #' @return (class<KucoinBase>) invisibly, the new instance.
     #' @noassert time_source
     initialize = function(
       keys = get_api_keys(),
       base_url = get_base_url(),
       async = FALSE,
-      time_source = c("local", "server")
+      time_source = c("local", "server"),
+      max_tries = 1L
     ) {
-      assert_args_KucoinBase__initialize(keys, base_url, async)
+      assert_args_KucoinBase__initialize(keys, base_url, async, max_tries)
       if (isTRUE(async) && !requireNamespace("promises", quietly = TRUE)) {
         abort_kucoin_validation_error(
           "Package 'promises' is required for async mode. Install with: install.packages('promises')"
@@ -96,7 +112,8 @@ KucoinBase <- R6::R6Class(
         time_source = match.arg(time_source),
         time_endpoint = "/api/v1/timestamp",
         time_field = "data",
-        body_format = "none"
+        body_format = "none",
+        max_tries = max_tries
       )
       return(invisible(self))
     }
@@ -188,6 +205,9 @@ KucoinBase <- R6::R6Class(
         sign = private$.sign,
         parse_envelope = private$.parse_envelope,
         .perform = private$.perform,
+        # Paginated reads are GETs; honour the instance retry policy (connectcore
+        # applies it to GET only, so this can never resend a write).
+        max_tries = private$.max_tries,
         # Coerce number-as-string quantity columns to numeric on the accumulated
         # paginated result (see coerce_numeric_quantities()).
         .parser = function(parsed) coerce_numeric_quantities(.parser(parsed)),

--- a/R/contracts-generated.R
+++ b/R/contracts-generated.R
@@ -209,10 +209,12 @@ assert_return_KucoinAccount__get_fee_rate <- function(value) {
   return(value)
 }
 
-assert_args_KucoinBase__initialize <- function(keys, base_url, async) {
+assert_args_KucoinBase__initialize <- function(keys, base_url, async, max_tries) {
   assert_list(keys)
   assert_scalar_character(base_url)
   assert_scalar_logical(async)
+  assert_scalar_integer(max_tries)
+  assert_between(max_tries, lower = 1, upper = 10)
   return(invisible(NULL))
 }
 
@@ -3292,7 +3294,7 @@ assert_return_parse_kucoin_response <- function(value) {
   return(value)
 }
 
-assert_args_kucoin_paginate <- function(base_url, endpoint, method, query, body, keys, sign, parse_envelope, .perform, .parser, is_async, page_size, max_pages, items_field, timeout, .get_timestamp_ms) {
+assert_args_kucoin_paginate <- function(base_url, endpoint, method, query, body, keys, sign, parse_envelope, .perform, .parser, is_async, page_size, max_pages, items_field, timeout, .get_timestamp_ms, max_tries) {
   assert_scalar_character(base_url)
   assert_scalar_character(endpoint)
   assert_scalar_character(method)
@@ -3329,6 +3331,8 @@ assert_args_kucoin_paginate <- function(base_url, endpoint, method, query, body,
   if (!is.null(.get_timestamp_ms)) {
     assert_function(.get_timestamp_ms)
   }
+  assert_scalar_integer(max_tries)
+  assert_between(max_tries, lower = 1, upper = 10)
   return(invisible(NULL))
 }
 

--- a/R/helpers_request.R
+++ b/R/helpers_request.R
@@ -263,6 +263,10 @@ parse_kucoin_response <- function(resp) {
 #'   Default `30`.
 #' @param .get_timestamp_ms (function | NULL) custom timestamp provider for
 #'   request signing. If `NULL`, uses the default internal timestamp function.
+#' @param max_tries (scalar<integer in [1, 10]>) retry each page request up to
+#'   this many times on a transient failure. Paginated endpoints are GETs, so
+#'   [connectcore::build_request()] applies the retry to every page. Default `1`
+#'   (no retry).
 #' @return (any | promise<any>) parsed and post-processed result, or a promise
 #'   thereof.
 #'
@@ -284,7 +288,8 @@ kucoin_paginate <- function(
   max_pages = Inf,
   items_field = "items",
   timeout = 30,
-  .get_timestamp_ms = NULL
+  .get_timestamp_ms = NULL,
+  max_tries = 1L
 ) {
   assert_args_kucoin_paginate(
     base_url,
@@ -302,7 +307,8 @@ kucoin_paginate <- function(
     max_pages,
     items_field,
     timeout,
-    .get_timestamp_ms
+    .get_timestamp_ms,
+    max_tries
   )
   # KuCoin owns no funnel: every page flows through connectcore::build_request.
   # The body (rare for paginated endpoints) is pre-serialised to compact JSON and
@@ -337,6 +343,7 @@ kucoin_paginate <- function(
       .perform = .perform,
       is_async = is_async,
       timeout = timeout,
+      max_tries = max_tries,
       ctx = list(get_timestamp_ms = .get_timestamp_ms)
     ))
   }

--- a/man/KucoinBase.Rd
+++ b/man/KucoinBase.Rd
@@ -4,11 +4,6 @@
 \alias{KucoinBase}
 \title{KucoinBase: Abstract Base Class for KuCoin API Clients}
 \description{
-KucoinBase: Abstract Base Class for KuCoin API Clients
-
-KucoinBase: Abstract Base Class for KuCoin API Clients
-}
-\details{
 Provides shared infrastructure for all KuCoin R6 classes, including API
 credential management, sync/async execution mode, timestamp source
 configuration, and a standardised method for calling implementation
@@ -56,6 +51,19 @@ trip) but ensures signing works even when the local clock is out of sync.
 }
 }
 
+\subsection{Retries}{
+
+\code{max_tries > 1} opts every GET this client makes — single requests and
+paginated reads alike — into automatic retry on a transient failure (HTTP
+408/429/5xx or a dropped connection) with jittered backoff, delegated to
+\code{\link[connectcore:build_request]{connectcore::build_request()}}. Retry is a hard \strong{GET-only} carve-out: a
+non-idempotent verb (an order \code{POST}, a cancel \code{DELETE}) is never
+auto-retried, so a resend can never double-submit an order. Leave it at the
+default \code{1} for live trading — there the trader layer is the single retry
+authority (it routes by typed error class and manages cooldowns); raise it
+only for research and backfill reads.
+}
+
 \subsection{Design}{
 
 This class is not meant to be instantiated directly. Subclasses (e.g.,
@@ -79,63 +87,69 @@ trading <- KucoinTrading$new(time_source = "server")
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-KucoinBase-new}{\code{KucoinBase$new()}}
-\item \href{#method-KucoinBase-clone}{\code{KucoinBase$clone()}}
-}
+  \itemize{
+    \item \href{#method-KucoinBase-initialize}{\code{KucoinBase$new()}}
+    \item \href{#method-KucoinBase-clone}{\code{KucoinBase$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-KucoinBase-new"></a>}}
-\if{latex}{\out{\hypertarget{method-KucoinBase-new}{}}}
-\subsection{Method \code{new()}}{
-Initialise a KucoinBase Object
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{KucoinBase$new(
+\if{html}{\out{<a id="method-KucoinBase-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-KucoinBase-initialize}{}}}
+\subsection{\code{KucoinBase$new()}}{
+  Initialise a KucoinBase Object
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{KucoinBase$new(
   keys = get_api_keys(),
   base_url = get_base_url(),
   async = FALSE,
-  time_source = c("local", "server")
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{keys}}{(list) API credentials from \code{\link[=get_api_keys]{get_api_keys()}}. Defaults to
+  time_source = c("local", "server"),
+  max_tries = 1L
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{keys}}{(list) API credentials from \code{\link[=get_api_keys]{get_api_keys()}}. Defaults to
 \code{get_api_keys()}.}
-
-\item{\code{base_url}}{(scalar<character>) API base URL. Defaults to
+      \item{\code{base_url}}{(scalar<character>) API base URL. Defaults to
 \code{get_base_url()}.}
-
-\item{\code{async}}{(scalar<logical>) if \code{TRUE}, methods return promises. Default
+      \item{\code{async}}{(scalar<logical>) if \code{TRUE}, methods return promises. Default
 \code{FALSE}.}
-
-\item{\code{time_source}}{(scalar<character>) clock source for HMAC request
+      \item{\code{time_source}}{(scalar<character>) clock source for HMAC request
 signing. \code{"local"} (default) uses the local UTC clock. \code{"server"} fetches
 the KuCoin server time before each authenticated request, which adds
 latency but avoids clock-drift issues.}
+      \item{\code{max_tries}}{(scalar<integer in [1, 10]>) for idempotent GET requests
+only, retry up to this many times on a transient failure. Default \code{1}
+(no retry). See the class \strong{Retries} section for the write-safety
+carve-out and why live trading should leave this at \code{1}.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    (class<KucoinBase>) invisibly, the new instance.
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-(class<KucoinBase>) invisibly, the new instance.
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-KucoinBase-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-KucoinBase-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{KucoinBase$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{KucoinBase$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{KucoinBase$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/kucoin_paginate.Rd
+++ b/man/kucoin_paginate.Rd
@@ -20,7 +20,8 @@ kucoin_paginate(
   max_pages = Inf,
   items_field = "items",
   timeout = 30,
-  .get_timestamp_ms = NULL
+  .get_timestamp_ms = NULL,
+  max_tries = 1L
 )
 }
 \arguments{
@@ -69,6 +70,11 @@ Default \code{30}.}
 
 \item{.get_timestamp_ms}{(function | NULL) custom timestamp provider for
 request signing. If \code{NULL}, uses the default internal timestamp function.}
+
+\item{max_tries}{(scalar<integer in [1, 10]>) retry each page request up to
+this many times on a transient failure. Paginated endpoints are GETs, so
+\code{\link[connectcore:build_request]{connectcore::build_request()}} applies the retry to every page. Default \code{1}
+(no retry).}
 }
 \value{
 (any | promise<any>) parsed and post-processed result, or a promise

--- a/renv.lock
+++ b/renv.lock
@@ -497,14 +497,14 @@
     },
     "connectcore": {
       "Package": "connectcore",
-      "Version": "0.4.0",
+      "Version": "0.5.0",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "dereckscompany",
       "RemoteRepo": "connectcore",
-      "RemoteRef": "v0.4.0",
-      "RemoteSha": "30a5be7b5e6ee08bb38b52d98b0e3aeb963c6850"
+      "RemoteRef": "v0.5.0",
+      "RemoteSha": "de677f7c864c12df3e975519529e0eb3f16da7d6"
     },
     "coro": {
       "Package": "coro",

--- a/tests/testthat/test-KucoinBase.R
+++ b/tests/testthat/test-KucoinBase.R
@@ -61,3 +61,55 @@ test_that("KucoinBase time_source is read-only", {
 
   expect_error(base$time_source <- "server")
 })
+
+test_that("KucoinBase rejects max_tries outside [1, 10]", {
+  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
+  expect_error(KucoinBase$new(keys = keys, base_url = "https://api.kucoin.com", max_tries = 0L))
+  expect_error(KucoinBase$new(keys = keys, base_url = "https://api.kucoin.com", max_tries = 11L))
+})
+
+# -- max_tries: the hard GET-only retry carve-out --
+#
+# `httr2::req_perform()` short-circuits its retry loop whenever the `httr2_mock`
+# option is set, so `local_mocked_responses()` cannot exercise retry. We mock the
+# per-attempt fetch (`httr2:::req_perform1`) instead, letting `req_perform()`
+# re-drive it against the policy the constructor's `max_tries` threaded into
+# `connectcore::build_request()`; `sys_sleep` is stubbed so backoff is instant.
+
+test_that("a non-idempotent POST is performed exactly once even with max_tries = 5", {
+  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
+  base <- KucoinBase$new(keys = keys, base_url = "https://api.kucoin.com", max_tries = 5L)
+  n <- 0L
+  testthat::local_mocked_bindings(
+    sys_sleep = function(seconds, ...) invisible(),
+    req_perform1 = function(req, req_prep, path, handle, resend_count) {
+      n <<- n + 1L
+      return(mock_http_error(status_code = 500L, body_text = "Internal Server Error"))
+    },
+    .package = "httr2"
+  )
+  priv <- base$.__enclos_env__$private
+  expect_error(priv$.request(endpoint = "/api/v1/orders", method = "POST", auth = FALSE))
+  expect_identical(n, 1L) # never a silent resend of an order
+})
+
+test_that("a transient 500 on a GET is retried and then succeeds (max_tries = 3)", {
+  keys <- get_api_keys(api_key = "k", api_secret = "s", api_passphrase = "p")
+  base <- KucoinBase$new(keys = keys, base_url = "https://api.kucoin.com", max_tries = 3L)
+  n <- 0L
+  testthat::local_mocked_bindings(
+    sys_sleep = function(seconds, ...) invisible(),
+    req_perform1 = function(req, req_prep, path, handle, resend_count) {
+      n <<- n + 1L
+      if (n == 1L) {
+        return(mock_http_error(status_code = 500L, body_text = "Internal Server Error"))
+      }
+      return(mock_kucoin_response(data = list(ok = TRUE)))
+    },
+    .package = "httr2"
+  )
+  priv <- base$.__enclos_env__$private
+  out <- priv$.request(endpoint = "/api/v1/status", method = "GET", auth = FALSE)
+  expect_true(out$ok)
+  expect_identical(n, 2L) # retried once on the 500, then succeeded
+})


### PR DESCRIPTION
## In plain terms

You can now tell a KuCoin client to automatically retry failed requests by passing `max_tries` when you create it — but **only read-only `GET` requests are ever retried** (single calls and paginated reads alike). Anything that places or cancels an order is sent exactly once, no matter what, so a hiccup can never accidentally submit an order twice. By default nothing retries (`max_tries = 1`), so live trading is unchanged — the trader layer stays in charge of retries there. Turn it up only for research and backfill reads.

## What changed

- Every client class constructor (via `KucoinBase`) gains `max_tries` (`scalar<integer in [1, 10]>`, default `1` = no retry), threaded to `connectcore`'s retry machinery.
- `max_tries > 1` retries a GET on a transient failure (HTTP 408/429/5xx or a dropped connection) with jittered backoff, honouring `Retry-After`.
- The **GET-only carve-out** is enforced centrally in `connectcore` (see dereckscompany/connectcore#12), so a non-idempotent verb is never auto-retried here.
- `kucoin_paginate()` gains a `max_tries` argument, and `KucoinBase$.paginate()` forwards the instance policy, so paginated reads (which flow through `build_request()` directly rather than the `.request()` funnel) also honour `max_tries`.
- Two-level docs: the `max_tries` `@param` plus a class **Retries** section covering the write-safety carve-out and the trader-is-retry-authority note.

## Tests

- A non-idempotent `POST` with `max_tries = 5` performs exactly **one** request then raises — no silent resend of an order.
- A `GET` returning `500`-then-`200` with `max_tries = 3` retries once and succeeds.

Note on test mechanics: httr2's `req_perform()` short-circuits its retry loop whenever the `httr2_mock` option is set, so `local_mocked_responses()` cannot exercise retry. The behavioural tests mock the per-attempt fetch (`httr2:::req_perform1`) to drive the real retry loop against the constructor's threaded policy.

Suite: FAIL=0 WARN=0 SKIP=0 PASS=1485. `R CMD check`: 0 errors, 1 warning, 3 notes — all pre-existing/structural (New-submission/Remotes/connectcore/roxyassert; the "checking Rd files" note is pre-existing "Lost braces" in sibling man pages, unchanged here — verified against `git HEAD`). None introduced by this change.

Requires `connectcore (>= 0.5.0)` (the GET-only guard). Implements the fleet retry-convergence ruling (2026-07-14).

closes #14
