### PR TITLE
docs(readme): add plain-English lead

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,6 +21,10 @@ knitr::opts_chunk$set(
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
+**In plain terms:** KuCoin is a large cryptocurrency exchange, and this package is the R doorway to it. Instead of hand-building web requests, signing them with your secret keys, and untangling the raw replies, you call plain R functions to read live prices, place and cancel orders, manage margin and futures positions, and move money in and out of your account. Every answer comes back as a tidy table with consistent column names, so the same code shape works whether you are checking a price or reviewing a filled order. It can run one request at a time or fire off many at once and collect the results as they arrive. You bring the account and the API keys; the package handles the plumbing.
+
+## Technical overview
+
 An R API wrapper for the [KuCoin](https://www.kucoin.com/) cryptocurrency exchange. Provides `R6` classes for spot market data, trading, stop orders, OCO orders, account management, deposits, transfers, withdrawals, sub-accounts, margin trading, margin lending, and futures trading. Supports both synchronous and asynchronous (promise based) operation via `httr2`.
 
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
+**In plain terms:** KuCoin is a large cryptocurrency exchange, and this
+package is the R doorway to it. Instead of hand-building web requests,
+signing them with your secret keys, and untangling the raw replies, you
+call plain R functions to read live prices, place and cancel orders,
+manage margin and futures positions, and move money in and out of your
+account. Every answer comes back as a tidy table with consistent column
+names, so the same code shape works whether you are checking a price or
+reviewing a filled order. It can run one request at a time or fire off
+many at once and collect the results as they arrive. You bring the
+account and the API keys; the package handles the plumbing.
+
+## Technical overview
+
 An R API wrapper for the [KuCoin](https://www.kucoin.com/)
 cryptocurrency exchange. Provides `R6` classes for spot market data,
 trading, stop orders, OCO orders, account management, deposits,


### PR DESCRIPTION
This adds a short, jargon-free opening paragraph to the top of the README so a first-time reader immediately understands what the package is and why it exists, before any technical detail. It is documentation only: no code, tests, versions, or NEWS change.

## Technical overview

Per the house two-level documentation convention (plain-English explanation first, technical depth after, same document), the README now opens — right after the badges block — with an `**In plain terms:**` paragraph, followed by a `## Technical overview` heading that introduces the pre-existing wrapper description. Nothing else in the README changed.

- Edited `README.Rmd` (the source) only; `README.md` was regenerated with `scripts/BUILD.sh readme`, whose chunks execute against the `tests/testthat` mock fixtures (no live keys). All 53 chunks rendered cleanly.
- The `README.md` diff is purely additive (the new lead plus the heading); the pandoc re-wrap of the inserted paragraph is the only render noise.